### PR TITLE
fix: add nginx redirects from marketing site to app subdomain

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -12,13 +12,18 @@
 
 ```
 Internet → nginx (443/80) → PM2 processes
-                          ├── groomgrid-prod  (port 3000) → getgroomgrid.com
-                          └── groomgrid-staging (port 3001) → staging.getgroomgrid.com
+                          ├── groomgrid-landing (port 3002) → getgroomgrid.com
+                          ├── groomgrid-prod     (port 3000) → app.getgroomgrid.com
+                          └── groomgrid-staging  (port 3001) → staging.getgroomgrid.com
 
 Both apps share:
   - PostgreSQL (local, groomgrid_prod / groomgrid_staging)
   - SSL certs via Certbot (wildcard: *.getgroomgrid.com)
   - Node.js 22 / PM2
+
+Redirects (from getgroomgrid.com → app.getgroomgrid.com):
+  - /signup → /signup
+  - /plans  → /plans
 ```
 
 ---
@@ -88,6 +93,13 @@ pm2 save
 pm2 status
 curl -o /dev/null -sw "%{http_code}" https://getgroomgrid.com/
 # Expected: 200
+
+# Test redirects
+curl -sI https://getgroomgrid.com/signup | grep -E "^Location:"
+# Expected: Location: https://app.getgroomgrid.com/signup
+
+curl -sI https://getgroomgrid.com/plans | grep -E "^Location:"
+# Expected: Location: https://app.getgroomgrid.com/plans
 ```
 
 ---
@@ -122,7 +134,7 @@ Both prod and staging have their own `.env.local` at the app root.
 | `STRIPE_PRICE_SOLO` | price_ ID for Solo $29/mo plan |
 | `STRIPE_PRICE_SALON` | price_ ID for Salon $79/mo plan |
 | `STRIPE_PRICE_ENTERPRISE` | price_ ID for Enterprise $149/mo plan |
-| `NEXT_PUBLIC_APP_URL` | https://getgroomgrid.com |
+| `NEXT_PUBLIC_APP_URL` | https://app.getgroomgrid.com (for app) or https://getgroomgrid.com (for landing) |
 | `RESEND_API_KEY` | re_ key for transactional email |
 | `CRON_SECRET` | Secret token for cron job auth |
 | `NEXT_PUBLIC_GA4_MEASUREMENT_ID` | G-XXXXXXXXXX |
@@ -140,8 +152,17 @@ cd /var/www/groomgrid/prod && pm2 restart groomgrid-prod
 ## nginx Configuration
 
 Configs live at `/etc/nginx/sites-enabled/`:
-- `groomgrid-prod` → routes `getgroomgrid.com` → `localhost:3000`
+- `groomgrid-landing` → routes `getgroomgrid.com` → `localhost:3002`
+- `groomgrid-app` → routes `app.getgroomgrid.com` → `localhost:3000`
+- `groomgrid-prod` → routes `getgroomgrid.com` → `localhost:3002` (marketing site)
 - `groomgrid-staging` → routes `staging.getgroomgrid.com` → `localhost:3001`
+
+**Important Redirects:**
+The marketing site (`getgroomgrid.com`) redirects certain paths to the app subdomain:
+- `getgroomgrid.com/signup` → `app.getgroomgrid.com/signup`
+- `getgroomgrid.com/plans` → `app.getgroomgrid.com/plans`
+
+These redirects are configured in the `groomgrid-prod` nginx config (location blocks for `/signup` and `/plans`).
 
 To reload nginx after config changes:
 ```bash
@@ -260,10 +281,19 @@ pm2 list
 
 echo ""
 echo "=== HTTP Check ==="
-PROD_CODE=$(curl -o /dev/null -sw "%{http_code}" https://getgroomgrid.com/)
+LANDING_CODE=$(curl -o /dev/null -sw "%{http_code}" https://getgroomgrid.com/)
+APP_CODE=$(curl -o /dev/null -sw "%{http_code}" https://app.getgroomgrid.com/)
 STAGING_CODE=$(curl -o /dev/null -sw "%{http_code}" https://staging.getgroomgrid.com/)
-echo "Production: $PROD_CODE"
+echo "Landing (getgroomgrid.com): $LANDING_CODE"
+echo "App (app.getgroomgrid.com): $APP_CODE"
 echo "Staging: $STAGING_CODE"
+
+echo ""
+echo "=== Redirect Check ==="
+SIGNUP_REDIRECT=$(curl -sI https://getgroomgrid.com/signup | grep -o "https://app.getgroomgrid.com/signup")
+PLANS_REDIRECT=$(curl -sI https://getgroomgrid.com/plans | grep -o "https://app.getgroomgrid.com/plans")
+echo "Signup redirect: ${SIGNUP_REDIRECT:-FAILED}"
+echo "Plans redirect: ${PLANS_REDIRECT:-FAILED}"
 
 echo ""
 echo "=== DB Check ==="


### PR DESCRIPTION
## Summary
Fixed a critical conversion blocker where visitors clicking signup CTAs or navigating to `/signup` or `/plans` on `getgroomgrid.com` encountered 404 errors.

## Changes Made
### Infrastructure (Production Server)
1. **Added nginx redirects** in `/etc/nginx/sites-available/groomgrid-prod`:
   - `getgroomgrid.com/signup` → `app.getgroomgrid.com/signup`
   - `getgroomgrid.com/plans` → `app.getgroomgrid.com/plans`

2. **Verified redirects are working:**
   - ✅ `curl -sI https://getgroomgrid.com/signup` returns 301 → `https://app.getgroomgrid.com/signup`
   - ✅ `curl -sI https://getgroomgrid.com/plans` returns 301 → `https://app.getgroomgrid.com/plans`
   - ✅ Main landing page still returns 200
   - ✅ App subdomain still works correctly

### Documentation (This PR)
Updated `DEPLOY.md` to reflect:
- Current architecture with 3 PM2 processes (landing, app, staging)
- nginx redirect configuration for `/signup` and `/plans`
- Correct `NEXT_PUBLIC_APP_URL` values for each app
- Enhanced health check script with redirect verification

## Why This Matters
This was blocking ALL conversion from the marketing site. Without this fix, every visitor who tried to access `/signup` or `/plans` hit a dead end (404).

## Testing
```bash
# Test redirects
curl -sI https://getgroomgrid.com/signup | grep Location
# Expected: Location: https://app.getgroomgrid.com/signup

curl -sI https://getgroomgrid.com/plans | grep Location
# Expected: Location: https://app.getgroomgrid.com/plans

# Verify main site still works
curl -sI https://getgroomgrid.com/ | head -1
# Expected: HTTP/1.1 200 OK
```

## Supports Rock
- **Get first 100 paying subscribers** (0% complete, due Apr 30)
- This fix unblocks the conversion funnel from marketing site → app signup

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)