### PR TITLE
feat: Stripe subscription checkout end-to-end flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY="your-supabase-anon-key"
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="your-stripe-publishable-key"
 STRIPE_SECRET_KEY="your-stripe-secret-key"
 STRIPE_WEBHOOK_SECRET="your-stripe-webhook-secret"
+# Stripe Price IDs (from Stripe Dashboard > Products)
+STRIPE_PRICE_SOLO="price_1TJDgnG4DfZ9Hko3qZUifmgo"
+STRIPE_PRICE_SALON="price_1TJDguG4DfZ9Hko36faOkkXr"
+STRIPE_PRICE_ENTERPRISE="price_1TJDgvG4DfZ9Hko3vLzhNLZ1"
 
 # Resend
 RESEND_API_KEY="your-resend-api-key"

--- a/src/app/api/checkout/success/route.ts
+++ b/src/app/api/checkout/success/route.ts
@@ -47,7 +47,7 @@ export async function GET(req: NextRequest) {
       0
     );
 
-    return NextResponse.redirect(new URL(`/onboarding?session_id=${session_id}`, req.url));
+    return NextResponse.redirect(new URL(`/checkout/success?session_id=${session_id}`, req.url));
   } catch (error: any) {
     console.error('Checkout success error:', error);
     return NextResponse.redirect(new URL('/plans', req.url));

--- a/src/app/api/stripe/route.ts
+++ b/src/app/api/stripe/route.ts
@@ -24,6 +24,12 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Missing required field: planType' }, { status: 400 });
     }
 
+    // FIX 1: Add planType validation
+    const VALID_PLANS = ["solo", "salon", "enterprise"];
+    if (!VALID_PLANS.includes(planType)) {
+      return NextResponse.json({ error: "Invalid plan type" }, { status: 400 });
+    }
+
     const userId = authSession.user.id;
     const customerEmail = authSession.user.email ?? `${userId}@groomgrid.app`;
 
@@ -42,6 +48,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ url: session.url });
   } catch (error: any) {
     console.error('Stripe checkout error:', error);
-    return NextResponse.json({ error: error.message || 'Failed to create checkout session' }, { status: 500 });
+    // FIX 2: Sanitize error response (don't leak internal error details)
+    return NextResponse.json({ error: "Failed to create checkout session" }, { status: 500 });
   }
 }

--- a/src/app/api/stripe/route.ts
+++ b/src/app/api/stripe/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/next-auth-options';
+import { createCheckoutSession } from '@/lib/stripe';
+import prisma from '@/lib/prisma';
+
+/**
+ * POST /api/stripe
+ * Public-facing endpoint for Stripe checkout session creation.
+ * Accepts { planType } and uses the current authenticated user's session.
+ * Delegates to the same createCheckoutSession logic as /api/checkout.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const authSession = await getServerSession(authOptions);
+
+    if (!authSession?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { planType } = await req.json();
+
+    if (!planType) {
+      return NextResponse.json({ error: 'Missing required field: planType' }, { status: 400 });
+    }
+
+    const userId = authSession.user.id;
+    const customerEmail = authSession.user.email ?? `${userId}@groomgrid.app`;
+
+    const profile = await prisma.profile.findUnique({ where: { userId } });
+    if (!profile) {
+      return NextResponse.json({ error: 'Profile not found' }, { status: 404 });
+    }
+
+    const session = await createCheckoutSession({
+      userId,
+      planType: planType as 'solo' | 'salon' | 'enterprise',
+      customerEmail,
+      businessName: profile.businessName,
+    });
+
+    return NextResponse.json({ url: session.url });
+  } catch (error: any) {
+    console.error('Stripe checkout error:', error);
+    return NextResponse.json({ error: error.message || 'Failed to create checkout session' }, { status: 500 });
+  }
+}

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -26,6 +26,9 @@ export async function POST(req: Request) {
       case 'checkout.session.completed': {
         const session = event.data.object;
         const userId = session.metadata?.userId;
+        // planType lives on the checkout session metadata — capture it here
+        // since subscription.metadata may not have it at subscription.created time
+        const planType = session.metadata?.planType;
 
         if (userId) {
           await prisma.profile.update({
@@ -33,6 +36,8 @@ export async function POST(req: Request) {
             data: {
               stripeCustomerId: typeof session.customer === 'string' ? session.customer : undefined,
               stripeSubscriptionId: typeof session.subscription === 'string' ? session.subscription : undefined,
+              // Update planType here while we have reliable session metadata
+              ...(planType ? { planType } : {}),
             },
           });
         }
@@ -41,21 +46,31 @@ export async function POST(req: Request) {
 
       case 'customer.subscription.created': {
         const subscription = event.data.object;
+        // userId may be on subscription metadata (set via subscription_data.metadata)
         const userId = subscription.metadata?.userId;
 
         if (userId) {
+          // planType should already be updated from checkout.session.completed,
+          // but fall back to subscription metadata if present
+          const planType = subscription.metadata?.planType;
+
           await prisma.profile.update({
             where: { userId },
             data: {
-              subscriptionStatus: subscription.status === 'active' ? 'active' : subscription.status === 'trialing' ? 'trial' : 'past_due',
+              subscriptionStatus:
+                subscription.status === 'active'
+                  ? 'active'
+                  : subscription.status === 'trialing'
+                    ? 'trial'
+                    : 'past_due',
+              ...(planType ? { planType } : {}),
             },
           });
 
-          // Track subscription creation via GA4 Measurement Protocol
           await trackSubscriptionCreatedServer(
             userId,
             subscription.id,
-            subscription.metadata?.planType ?? 'unknown',
+            planType ?? 'unknown',
             subscription.status
           );
         }
@@ -67,14 +82,21 @@ export async function POST(req: Request) {
         const userId = subscription.metadata?.userId;
 
         if (userId) {
+          const planType = subscription.metadata?.planType;
+
           await prisma.profile.update({
             where: { userId },
             data: {
-              subscriptionStatus: subscription.status === 'active' ? 'active' : subscription.status === 'trialing' ? 'trial' : 'past_due',
+              subscriptionStatus:
+                subscription.status === 'active'
+                  ? 'active'
+                  : subscription.status === 'trialing'
+                    ? 'trial'
+                    : 'past_due',
+              ...(planType ? { planType } : {}),
             },
           });
 
-          // Track subscription status changes (upgrades, downgrades, renewals)
           await trackSubscriptionUpdatedServer(userId, subscription.id, subscription.status);
         }
         break;
@@ -90,8 +112,45 @@ export async function POST(req: Request) {
             data: { subscriptionStatus: 'cancelled' },
           });
 
-          // Track cancellation via GA4 Measurement Protocol
           await trackSubscriptionCancelledServer(userId, subscription.id);
+        }
+        break;
+      }
+
+      case 'invoice.payment_succeeded': {
+        const invoice = event.data.object;
+        const customerId = typeof invoice.customer === 'string' ? invoice.customer : null;
+
+        if (customerId) {
+          const profile = await prisma.profile.findFirst({
+            where: { stripeCustomerId: customerId },
+          });
+
+          if (profile) {
+            await prisma.profile.update({
+              where: { userId: profile.userId },
+              data: { subscriptionStatus: 'active' },
+            });
+          }
+        }
+        break;
+      }
+
+      case 'invoice.payment_failed': {
+        const invoice = event.data.object;
+        const customerId = typeof invoice.customer === 'string' ? invoice.customer : null;
+
+        if (customerId) {
+          const profile = await prisma.profile.findFirst({
+            where: { stripeCustomerId: customerId },
+          });
+
+          if (profile) {
+            await prisma.profile.update({
+              where: { userId: profile.userId },
+              data: { subscriptionStatus: 'past_due' },
+            });
+          }
         }
         break;
       }

--- a/src/app/checkout/success/page.tsx
+++ b/src/app/checkout/success/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export default function CheckoutSuccessPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const sessionId = searchParams.get('session_id');
+  const [countdown, setCountdown] = useState(5);
+
+  useEffect(() => {
+    if (countdown <= 0) {
+      router.push(`/onboarding${sessionId ? `?session_id=${sessionId}` : ''}`);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setCountdown((prev) => prev - 1);
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [countdown, router, sessionId]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-green-50 to-stone-50 flex items-center justify-center px-4">
+      <div className="max-w-md w-full bg-white rounded-2xl shadow-lg p-8 text-center">
+        {/* Success icon */}
+        <div className="w-20 h-20 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-6">
+          <svg
+            className="w-10 h-10 text-green-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+
+        <h1 className="text-3xl font-bold text-stone-900 mb-3">You&apos;re in!</h1>
+        <p className="text-stone-600 mb-2">
+          Your 14-day free trial has started. No charge until your trial ends.
+        </p>
+        <p className="text-stone-500 text-sm mb-8">
+          We&apos;ll send a confirmation to your email shortly.
+        </p>
+
+        <div className="bg-green-50 rounded-xl p-4 mb-8">
+          <p className="text-green-700 text-sm font-medium">
+            Trial active &mdash; full access for 14 days
+          </p>
+        </div>
+
+        <button
+          onClick={() => router.push(`/onboarding${sessionId ? `?session_id=${sessionId}` : ''}`)}
+          className="w-full bg-green-600 text-white font-semibold py-3 px-6 rounded-xl hover:bg-green-700 transition-colors mb-4"
+        >
+          Set Up Your Account
+        </button>
+
+        <p className="text-stone-400 text-xs">
+          Redirecting automatically in {countdown} second{countdown !== 1 ? 's' : ''}...
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/plans/page.tsx
+++ b/src/app/plans/page.tsx
@@ -16,7 +16,7 @@ const PLANS: Plan[] = [
     type: 'solo',
     price: 29,
     interval: 'monthly',
-    stripe_price_id: 'price_solo_placeholder',
+    stripe_price_id: '', // resolved server-side via STRIPE_PRICE_SOLO env var
     features: [
       '1 groomer account',
       'Unlimited clients & appointments',
@@ -31,7 +31,7 @@ const PLANS: Plan[] = [
     type: 'salon',
     price: 79,
     interval: 'monthly',
-    stripe_price_id: 'price_salon_placeholder',
+    stripe_price_id: '', // resolved server-side via STRIPE_PRICE_SALON env var
     popular: true,
     features: [
       'Everything in Solo',
@@ -47,7 +47,7 @@ const PLANS: Plan[] = [
     type: 'enterprise',
     price: 149,
     interval: 'monthly',
-    stripe_price_id: 'price_enterprise_placeholder',
+    stripe_price_id: '', // resolved server-side via STRIPE_PRICE_ENTERPRISE env var
     features: [
       'Everything in Salon',
       'Unlimited groomers',

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -43,7 +43,7 @@ export async function createCheckoutSession({
         businessName,
       },
     },
-    success_url: `${process.env.NEXT_PUBLIC_APP_URL}/onboarding?session_id={CHECKOUT_SESSION_ID}`,
+    success_url: `${process.env.NEXT_PUBLIC_APP_URL}/checkout/success?session_id={CHECKOUT_SESSION_ID}`,
     cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/plans`,
     allow_promotion_codes: true,
     billing_address_collection: 'required',


### PR DESCRIPTION
## Summary

- **Created `/api/stripe` endpoint** — public-facing checkout route that reads the authenticated user from NextAuth session, accepts `{planType}`, and delegates to `createCheckoutSession`
- **Fixed webhook `planType` propagation** — `checkout.session.completed` now updates `planType` from reliable session metadata; `customer.subscription.created` also syncs `planType` and subscription status; `customer.subscription.updated` also propagates `planType` when present
- **Added missing webhook handlers** — `invoice.payment_succeeded` (marks `active`) and `invoice.payment_failed` (marks `past_due`) now handled
- **Created `/checkout/success` page** — confirmation UI with 5-second countdown then redirects to `/onboarding`; `/api/checkout/success` and `stripe.ts` success_url now point here
- **Fixed placeholder price IDs** — removed `price_*_placeholder` strings from plans page; price lookup remains server-side via env vars
- **Updated `.env.example`** — documents `STRIPE_PRICE_SOLO/SALON/ENTERPRISE` with live price IDs found in Stripe

## Stripe products status

Products and prices already exist in Stripe (live mode):
- Solo: `price_1TJDgnG4DfZ9Hko3qZUifmgo` ($29/mo)
- Salon: `price_1TJDguG4DfZ9Hko36faOkkXr` ($79/mo)
- Enterprise: `price_1TJDgvG4DfZ9Hko3vLzhNLZ1` ($149/mo)

## STRIPE_WEBHOOK_SECRET

The env var reference exists in code (`process.env.STRIPE_WEBHOOK_SECRET`). Must be configured in production `.env` on the server. See `.env.example` for the variable name. To generate: run `stripe listen --forward-to <url>/api/stripe/webhook` locally, or create a webhook endpoint in the Stripe Dashboard pointing to `https://<domain>/api/stripe/webhook` with events: `checkout.session.completed`, `customer.subscription.created/updated/deleted`, `invoice.payment_succeeded`, `invoice.payment_failed`.

## Test plan

- [ ] Sign in → `/plans` → select plan → Stripe Checkout → complete payment → lands on `/checkout/success` with confirmation
- [ ] After 5 seconds (or button click), redirects to `/onboarding`
- [ ] Profile in DB has correct `planType`, `subscriptionStatus: 'trial'`, `stripeCustomerId`, `stripeSubscriptionId`
- [ ] Webhook receives `checkout.session.completed` → profile updated
- [ ] Webhook receives `customer.subscription.created` → `subscriptionStatus` and `planType` updated
- [ ] Webhook receives `invoice.payment_succeeded` → status set to `active`
- [ ] Webhook receives `invoice.payment_failed` → status set to `past_due`
- [ ] POST `/api/stripe` with `{planType: 'solo'}` from authenticated session returns `{url: <stripe-checkout-url>}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)