### PR TITLE
Add real-time signup validation

### DIFF
--- a/src/app/api/auth/validate-email/route.ts
+++ b/src/app/api/auth/validate-email/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const email = searchParams.get('email');
+
+    if (!email) {
+      return NextResponse.json(
+        { error: 'Email parameter is required' },
+        { status: 400 }
+      );
+    }
+
+    const trimmedEmail = email.trim().toLowerCase();
+
+    // Basic email format check
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(trimmedEmail)) {
+      return NextResponse.json({
+        isValid: false,
+        error: 'Invalid email format',
+      });
+    }
+
+    // Check if email already exists
+    const existingUser = await prisma.user.findUnique({
+      where: { email: trimmedEmail },
+    });
+
+    if (existingUser) {
+      return NextResponse.json({
+        isValid: false,
+        error: 'Email already in use',
+      });
+    }
+
+    return NextResponse.json({
+      isValid: true,
+    });
+  } catch (error) {
+    console.error('Email validation error:', error);
+    return NextResponse.json(
+      { error: 'Failed to validate email' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,11 +1,14 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { signIn } from 'next-auth/react';
-import { AlertCircle, ArrowRight, Lock, Building, Mail } from 'lucide-react';
+import { AlertCircle, ArrowRight, Lock, Building, Mail, Check, X } from 'lucide-react';
 import { trackSignupStarted, trackAccountCreated } from '@/lib/ga4';
+import { validateEmail, validatePassword, validateBusinessName } from '@/lib/validators';
+
+type FieldState = 'untouched' | 'touched' | 'valid' | 'invalid' | 'pending-validation';
 
 export default function SignupPage() {
   const router = useRouter();
@@ -17,14 +20,94 @@ export default function SignupPage() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
+  // Field-level validation states
+  const [fieldStates, setFieldStates] = useState<{
+    email: FieldState;
+    password: FieldState;
+    businessName: FieldState;
+  }>({
+    email: 'untouched',
+    password: 'untouched',
+    businessName: 'untouched',
+  });
+
+  const [fieldErrors, setFieldErrors] = useState<{
+    email?: string;
+    password?: string;
+    businessName?: string;
+  }>({});
+
   useEffect(() => {
     if (formData.businessName) {
       trackSignupStarted(formData.businessName);
     }
   }, [formData.businessName]);
 
+  // Async email validation (checks if email exists)
+  const validateEmailAvailability = useCallback(async (email: string) => {
+    try {
+      const res = await fetch(\`/api/auth/validate-email?email=\${encodeURIComponent(email)}\`);
+      const data = await res.json();
+
+      if (!data.isValid) {
+        return { isValid: false, error: data.error || 'Email is not available' };
+      }
+
+      return { isValid: true };
+    } catch {
+      return { isValid: true }; // On API error, allow validation to proceed
+    }
+  }, []);
+
+  // Blur handlers for each field
+  const handleBlur = useCallback(async (field: 'email' | 'password' | 'businessName') => {
+    setFieldStates(prev => ({ ...prev, [field]: 'touched' }));
+
+    const value = formData[field];
+    let validationResult;
+
+    switch (field) {
+      case 'email':
+        // Async validation for email
+        setFieldStates(prev => ({ ...prev, email: 'pending-validation' }));
+        validationResult = await validateEmailAvailability(value);
+        break;
+      case 'password':
+        validationResult = validatePassword(value);
+        break;
+      case 'businessName':
+        validationResult = validateBusinessName(value);
+        break;
+    }
+
+    if (validationResult.isValid) {
+      setFieldStates(prev => ({ ...prev, [field]: 'valid' }));
+      setFieldErrors(prev => ({ ...prev, [field]: undefined }));
+    } else {
+      setFieldStates(prev => ({ ...prev, [field]: 'invalid' }));
+      setFieldErrors(prev => ({ ...prev, [field]: validationResult.error }));
+    }
+  }, [formData, validateEmailAvailability]);
+
+  const handleFieldChange = (field: 'email' | 'password' | 'businessName', value: string) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+
+    // Clear error state while typing if field was invalid
+    if (fieldStates[field] === 'invalid') {
+      setFieldStates(prev => ({ ...prev, [field]: 'touched' }));
+      setFieldErrors(prev => ({ ...prev, [field]: undefined }));
+    }
+  };
+
+  const isFormValid = (): boolean => {
+    return fieldStates.email === 'valid' &&
+           fieldStates.password === 'valid' &&
+           fieldStates.businessName === 'valid';
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
     setError('');
     setLoading(true);
 
@@ -94,6 +177,7 @@ export default function SignupPage() {
         )}
 
         <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Business Name Field */}
           <div>
             <label className="block text-sm font-medium text-stone-700 mb-1">Business Name</label>
             <div className="relative">
@@ -101,14 +185,31 @@ export default function SignupPage() {
               <input
                 type="text"
                 value={formData.businessName}
-                onChange={(e) => setFormData({ ...formData, businessName: e.target.value })}
+                onChange={(e) => handleFieldChange('businessName', e.target.value)}
+                onBlur={() => handleBlur('businessName')}
                 placeholder="e.g., Paws on Wheels"
                 required
-                className="w-full pl-10 pr-4 py-3 rounded-xl border border-stone-200 focus:ring-2 focus:ring-green-500 focus:border-transparent outline-none transition-all"
+                className={\`w-full pl-10 pr-10 py-3 rounded-xl border outline-none transition-all \${
+                  fieldStates.businessName === 'valid'
+                    ? 'border-green-500 focus:ring-green-500'
+                    : fieldStates.businessName === 'invalid'
+                    ? 'border-red-500 focus:ring-red-500'
+                    : 'border-stone-200 focus:ring-green-500 focus:border-transparent'
+                }\`}
               />
+              {fieldStates.businessName === 'valid' && (
+                <Check className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-green-500" />
+              )}
+              {fieldStates.businessName === 'invalid' && (
+                <X className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-red-500" />
+              )}
             </div>
+            {fieldErrors.businessName && (
+              <p className="mt-1 text-xs text-red-500">{fieldErrors.businessName}</p>
+            )}
           </div>
 
+          {/* Email Field */}
           <div>
             <label className="block text-sm font-medium text-stone-700 mb-1">Email Address</label>
             <div className="relative">
@@ -116,15 +217,39 @@ export default function SignupPage() {
               <input
                 type="email"
                 value={formData.email}
-                onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+                onChange={(e) => handleFieldChange('email', e.target.value)}
+                onBlur={() => handleBlur('email')}
                 placeholder="you@example.com"
                 required
                 autoComplete="email"
-                className="w-full pl-10 pr-4 py-3 rounded-xl border border-stone-200 focus:ring-2 focus:ring-green-500 focus:border-transparent outline-none transition-all"
+                className={\`w-full pl-10 pr-10 py-3 rounded-xl border outline-none transition-all \${
+                  fieldStates.email === 'valid'
+                    ? 'border-green-500 focus:ring-green-500'
+                    : fieldStates.email === 'invalid'
+                    ? 'border-red-500 focus:ring-red-500'
+                    : fieldStates.email === 'pending-validation'
+                    ? 'border-amber-400'
+                    : 'border-stone-200 focus:ring-green-500 focus:border-transparent'
+                }\`}
               />
+              {fieldStates.email === 'valid' && (
+                <Check className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-green-500" />
+              )}
+              {fieldStates.email === 'invalid' && (
+                <X className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-red-500" />
+              )}
+              {fieldStates.email === 'pending-validation' && (
+                <div className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5">
+                  <div className="w-5 h-5 border-2 border-amber-400 border-t-transparent rounded-full animate-spin" />
+                </div>
+              )}
             </div>
+            {fieldErrors.email && (
+              <p className="mt-1 text-xs text-red-500">{fieldErrors.email}</p>
+            )}
           </div>
 
+          {/* Password Field */}
           <div>
             <label className="block text-sm font-medium text-stone-700 mb-1">Password</label>
             <div className="relative">
@@ -132,19 +257,35 @@ export default function SignupPage() {
               <input
                 type="password"
                 value={formData.password}
-                onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+                onChange={(e) => handleFieldChange('password', e.target.value)}
+                onBlur={() => handleBlur('password')}
                 placeholder="Min. 8 characters"
                 required
                 minLength={8}
                 autoComplete="new-password"
-                className="w-full pl-10 pr-4 py-3 rounded-xl border border-stone-200 focus:ring-2 focus:ring-green-500 focus:border-transparent outline-none transition-all"
+                className={\`w-full pl-10 pr-10 py-3 rounded-xl border outline-none transition-all \${
+                  fieldStates.password === 'valid'
+                    ? 'border-green-500 focus:ring-green-500'
+                    : fieldStates.password === 'invalid'
+                    ? 'border-red-500 focus:ring-red-500'
+                    : 'border-stone-200 focus:ring-green-500 focus:border-transparent'
+                }\`}
               />
+              {fieldStates.password === 'valid' && (
+                <Check className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-green-500" />
+              )}
+              {fieldStates.password === 'invalid' && (
+                <X className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-red-500" />
+              )}
             </div>
+            {fieldErrors.password && (
+              <p className="mt-1 text-xs text-red-500">{fieldErrors.password}</p>
+            )}
           </div>
 
           <button
             type="submit"
-            disabled={loading}
+            disabled={loading || !isFormValid()}
             className="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-green-500 text-white font-semibold hover:bg-green-600 disabled:bg-stone-300 disabled:cursor-not-allowed transition-colors"
           >
             {loading ? (

--- a/src/hooks/use-form-validation.ts
+++ b/src/hooks/use-form-validation.ts
@@ -1,0 +1,153 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+/**
+ * Field state types for validation
+ */
+export type FieldState = 'untouched' | 'touched' | 'valid' | 'invalid' | 'pending-validation';
+
+/**
+ * Field validation result
+ */
+export interface FieldValidationResult {
+  isValid: boolean;
+  error?: string;
+}
+
+/**
+ * Props for useFieldValidation hook
+ */
+export interface UseFieldValidationProps {
+  name: string;
+  validatorFn: (value: string) => FieldValidationResult;
+  asyncValidatorFn?: (value: string) => Promise<FieldValidationResult>;
+}
+
+/**
+ * Return type for useFieldValidation
+ */
+export interface UseFieldValidationReturn {
+  value: string;
+  state: FieldState;
+  error: string | undefined;
+  touched: boolean;
+  setValue: (value: string) => void;
+  handleBlur: () => Promise<void>;
+  handleChange: (value: string) => void;
+}
+
+/**
+ * Hook for managing individual field validation state
+ */
+export function useFieldValidation({
+  name,
+  validatorFn,
+  asyncValidatorFn,
+}: UseFieldValidationProps): UseFieldValidationReturn {
+  const [value, setValue] = useState('');
+  const [state, setState] = useState<FieldState>('untouched');
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  const handleBlur = useCallback(async () => {
+    if (state === 'untouched') {
+      setState('touched');
+    }
+
+    // Run sync validation first
+    const syncResult = validatorFn(value);
+    if (!syncResult.isValid) {
+      setState('invalid');
+      setError(syncResult.error);
+      return;
+    }
+
+    // If async validation exists and not yet validated
+    if (asyncValidatorFn && state !== 'valid') {
+      setState('pending-validation');
+      const asyncResult = await asyncValidatorFn(value);
+      if (asyncResult.isValid) {
+        setState('valid');
+        setError(undefined);
+      } else {
+        setState('invalid');
+        setError(asyncResult.error);
+      }
+    } else if (!asyncValidatorFn) {
+      // Only sync validation
+      setState('valid');
+      setError(undefined);
+    }
+  }, [value, state, validatorFn, asyncValidatorFn]);
+
+  const handleChange = useCallback((newValue: string) => {
+    setValue(newValue);
+    
+    // Clear error state while typing (unless still invalid on blur)
+    if (state === 'invalid') {
+      setState('touched');
+      setError(undefined);
+    }
+  }, [state]);
+
+  return {
+    value,
+    state,
+    error,
+    touched: state !== 'untouched',
+    setValue,
+    handleBlur,
+    handleChange,
+  };
+}
+
+/**
+ * Props for useFormValidation hook
+ */
+export interface UseFormValidationProps {
+  fields: Record<string, UseFieldValidationProps>;
+}
+
+/**
+ * Return type for useFormValidation
+ */
+export interface UseFormValidationReturn {
+  fieldStates: Record<string, FieldState>;
+  fieldErrors: Record<string, string | undefined>;
+  isFormValid: boolean;
+  isValidating: boolean;
+}
+
+/**
+ * Hook for managing multiple field validations
+ * Provides overall form validation state
+ */
+export function useFormValidation({ fields }: UseFormValidationProps): UseFormValidationReturn {
+  const [fieldStates, setFieldStates] = useState<Record<string, FieldState>>({});
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string | undefined>>({});
+
+  // Initialize field states on mount
+  Object.keys(fields).forEach((fieldName) => {
+    if (!fieldStates[fieldName]) {
+      setFieldStates((prev) => ({
+        ...prev,
+        [fieldName]: 'untouched',
+      }));
+    }
+  });
+
+  const isFormValid = Object.entries(fieldStates).every(
+    ([_, state]) => state === 'valid'
+  );
+
+  const isValidating = Object.values(fieldStates).some(
+    (state) => state === 'pending-validation'
+  );
+
+  return {
+    fieldStates,
+    fieldErrors,
+    isFormValid,
+    isValidating,
+  };
+}

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,0 +1,95 @@
+/**
+ * Validation utilities for form fields
+ * Provides reusable validation functions for email, password, and business name
+ */
+
+/**
+ * Email validation result
+ */
+export interface EmailValidationResult {
+  isValid: boolean;
+  error?: string;
+}
+
+/**
+ * Password validation result
+ */
+export interface PasswordValidationResult {
+  isValid: boolean;
+  error?: string;
+}
+
+/**
+ * Business name validation result
+ */
+export interface BusinessNameValidationResult {
+  isValid: boolean;
+  error?: string;
+}
+
+/**
+ * Email regex pattern (same as used in booking API)
+ */
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Validates email format
+ */
+export function validateEmail(email: string): EmailValidationResult {
+  const trimmedEmail = email.trim();
+
+  if (!trimmedEmail) {
+    return { isValid: false, error: 'Email is required' };
+  }
+
+  if (!emailRegex.test(trimmedEmail)) {
+    return { isValid: false, error: 'Please enter a valid email address' };
+  }
+
+  return { isValid: true };
+}
+
+/**
+ * Validates password
+ * Requirements: at least 8 characters
+ */
+export function validatePassword(password: string): PasswordValidationResult {
+  if (!password) {
+    return { isValid: false, error: 'Password is required' };
+  }
+
+  if (password.length < 8) {
+    return { isValid: false, error: 'Password must be at least 8 characters' };
+  }
+
+  return { isValid: true };
+}
+
+/**
+ * Validates business name
+ * Requirements: at least 2 characters, max 100 characters, no special characters (alphanumeric, spaces, hyphens allowed)
+ */
+export function validateBusinessName(name: string): BusinessNameValidationResult {
+  const trimmedName = name.trim();
+
+  if (!trimmedName) {
+    return { isValid: false, error: 'Business name is required' };
+  }
+
+  if (trimmedName.length < 2) {
+    return { isValid: false, error: 'Business name must be at least 2 characters' };
+  }
+
+  if (trimmedName.length > 100) {
+    return { isValid: false, error: 'Business name must be less than 100 characters' };
+  }
+
+  // Allow alphanumeric, spaces, hyphens, apostrophes, and periods
+  const businessNameRegex = /^[a-zA-Z0-9\s\-\'\.]+$/;
+
+  if (!businessNameRegex.test(trimmedName)) {
+    return { isValid: false, error: 'Business name can only contain letters, numbers, spaces, hyphens, and apostrophes' };
+  }
+
+  return { isValid: true };
+}


### PR DESCRIPTION
## Summary
Add inline validation to signup form fields (email, password, business name) with:
- Real-time validation state management (valid/invalid/pending/touched/untouched)
- Success states (green checkmark) and error states (red X)
- Error messages shown on blur for invalid fields
- Async email availability checking with loading spinner
- Submit button disabled until all fields pass validation

## Changes

### New Files Created
- `src/lib/validators.ts` - Reusable validation utilities
  - \`validateEmail()\` - Email format validation
  - \`validatePassword()\` - Password length validation (min 8 chars)
  - \`validateBusinessName()\` - Business name validation (2-100 chars, allowed characters)
  
- `src/hooks/use-form-validation.ts` - Custom hooks for validation state management
  - \`useFieldValidation()\` - Individual field validation hook
  - \`useFormValidation()\` - Multi-field validation hook
  - \`FieldState\` type: untouched, touched, valid, invalid, pending-validation

- `src/app/api/auth/validate-email/route.ts` - Email availability API endpoint
  - GET endpoint checks if email exists in database
  - Returns \`{isValid, error?}\` for client-side validation

### Modified Files
- `src/app/signup/page.tsx` - Enhanced with real-time validation
  - Added \`fieldStates\` and \`fieldErrors\` state
  - Added \`handleBlur()\` for per-field validation on blur
  - Added \`handleFieldChange()\` for clearing errors while typing
  - Added \`validateEmailAvailability()\` for async email checking
  - Added visual indicators (green check, red X, loading spinner)
  - Updated submit button to check \`isFormValid()\` before allowing submission

## Testing
No test files exist in codebase. Manual testing recommended to verify:
- Email format validation works
- Password length validation works
- Business name validation works (2-100 chars, allowed chars)
- Email availability check shows loading spinner and validates correctly
- Submit button is disabled until all fields are valid
- Error messages display inline below each field
- Success states show green checkmark for valid fields

## Notes
- No API contract breaking changes - existing \`/api/auth/signup\` endpoint unchanged
- Email availability is optional enhancement - if API fails, form proceeds (graceful degradation)
- Validation follows existing codebase patterns from \`FeatureRequestForm\` and \`BugReportModal\`
- Uses existing \`lucide-react\` icons (Check, X, AlertCircle, ArrowRight, Lock, Building, Mail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)