### PR TITLE
feat: clarify payment flow IA with transparent expectations

### DIFF
--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import bcrypt from 'bcryptjs'
 import prisma from '@/lib/prisma'
+import { enrollUserInDrip } from '@/lib/email/enroll-drip'
 
 export async function POST(req: NextRequest) {
   try {
@@ -37,6 +38,13 @@ export async function POST(req: NextRequest) {
         },
       },
     })
+
+    // Auto-enroll new user in the welcome drip sequence (non-fatal)
+    try {
+      await enrollUserInDrip(user.id, user.email)
+    } catch (dripError) {
+      console.error('Drip enrollment failed (non-fatal):', dripError)
+    }
 
     return NextResponse.json({ success: true, userId: user.id })
   } catch (error) {

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -25,6 +25,7 @@ export async function POST(req: NextRequest) {
       planType: planType as 'solo' | 'salon' | 'enterprise',
       customerEmail: customerEmail || `${userId}@groomgrid.app`,
       businessName: profile.businessName,
+      signupSource: 'plans_page',
     });
 
     return NextResponse.json({ url: session.url });

--- a/src/app/api/checkout/success/route.ts
+++ b/src/app/api/checkout/success/route.ts
@@ -47,7 +47,7 @@ export async function GET(req: NextRequest) {
       0
     );
 
-    return NextResponse.redirect(new URL(`/checkout/success?session_id=${session_id}`, req.url));
+    return NextResponse.redirect(new URL(`/payment-success?session_id=${session_id}`, req.url));
   } catch (error: any) {
     console.error('Checkout success error:', error);
     return NextResponse.redirect(new URL('/plans', req.url));

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import ProgressIndicator from '@/components/funnel/ProgressIndicator';
 import Step1AddClient from '@/components/onboarding/Step1AddClient';
@@ -15,6 +15,8 @@ const DAYS_API_ORDER = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 
 
 export default function OnboardingPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const fromPayment = searchParams.get('from') === 'payment-success';
   const { data: session, status } = useSession();
   const [step, setStep] = useState(1);
   const [loading, setLoading] = useState(true);
@@ -257,6 +259,13 @@ export default function OnboardingPage() {
         )}
 
         <div className="bg-white rounded-2xl shadow-xl p-8">
+          {/* Payment success welcome banner */}
+          {fromPayment && step === 1 && (
+            <div className="mb-6 px-4 py-3 rounded-xl bg-green-50 border border-green-200 text-sm text-green-800">
+              <strong>Your 14-day free trial is active!</strong> Let&apos;s get your account set up so you&apos;re ready for your first appointment.
+            </div>
+          )}
+
           {/* Step-level error banner */}
           {stepError && (
             <div className="mb-4 px-4 py-3 rounded-xl bg-red-50 border border-red-200 text-sm text-red-700">

--- a/src/app/payment-review/page.tsx
+++ b/src/app/payment-review/page.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { PlanType } from '@/types';
+import { getPlanDetails, isValidPlanType } from '@/lib/payment-utils';
+import BillingSummary from '@/components/payment/BillingSummary';
+import SecurityBadges from '@/components/payment/SecurityBadges';
+import { CheckCircle2, ArrowRight, ArrowLeft } from 'lucide-react';
+import { trackPageView } from '@/lib/ga4';
+
+export default function PaymentReviewPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { data: session, status } = useSession();
+
+  const planParam = searchParams.get('plan') ?? '';
+  const planType: PlanType | null = isValidPlanType(planParam) ? planParam : null;
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    trackPageView('/payment-review', 'Payment Review');
+  }, []);
+
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/login');
+    }
+    if (status === 'authenticated' && !planType) {
+      router.push('/plans');
+    }
+  }, [status, planType, router]);
+
+  if (status === 'loading' || !session || !planType) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-green-50 to-stone-50 flex items-center justify-center">
+        <div className="text-center">Loading...</div>
+      </div>
+    );
+  }
+
+  const plan = getPlanDetails(planType);
+
+  const handleProceedToCheckout = async () => {
+    if (!session?.user?.id) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          userId: session.user.id,
+          planType,
+          customerEmail: session.user.email,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (data.url) {
+        window.location.href = data.url;
+      } else {
+        throw new Error(data.error || 'Failed to create checkout session');
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to proceed to checkout';
+      setError(message);
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-green-50 to-stone-50">
+      <header className="bg-white border-b border-stone-200">
+        <div className="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
+          <h1 className="text-2xl font-bold text-green-600">GroomGrid</h1>
+          <button
+            onClick={() => router.push('/plans')}
+            className="text-stone-500 hover:text-stone-800 text-sm flex items-center gap-1"
+          >
+            <ArrowLeft className="w-4 h-4" /> Back to plans
+          </button>
+        </div>
+      </header>
+
+      <main className="max-w-lg mx-auto px-4 py-12">
+        {/* Page heading */}
+        <div className="text-center mb-8">
+          <h2 className="text-3xl font-bold text-stone-900 mb-2">Review your order</h2>
+          <p className="text-stone-600">
+            You&apos;re choosing the <strong>{plan.name}</strong> plan. Review everything before continuing to payment.
+          </p>
+        </div>
+
+        {/* What's included */}
+        <div className="bg-white rounded-xl border border-stone-200 p-5 mb-4">
+          <h3 className="font-semibold text-stone-900 text-base mb-3">
+            What&apos;s included in {plan.name}
+          </h3>
+          <ul className="space-y-2">
+            {plan.features.map((feature) => (
+              <li key={feature} className="flex items-center gap-2 text-sm text-stone-700">
+                <CheckCircle2 className="w-4 h-4 text-green-500 flex-shrink-0" />
+                {feature}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Billing summary */}
+        <div className="mb-4">
+          <BillingSummary planType={planType} />
+        </div>
+
+        {/* What happens next */}
+        <div className="bg-blue-50 rounded-xl border border-blue-100 p-5 mb-6">
+          <h3 className="font-semibold text-stone-900 text-sm mb-3">What happens next</h3>
+          <ol className="space-y-2">
+            <li className="flex items-start gap-2 text-sm text-stone-700">
+              <span className="flex-shrink-0 w-5 h-5 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-xs font-bold">1</span>
+              You&apos;ll enter your card details on Stripe&apos;s secure checkout page
+            </li>
+            <li className="flex items-start gap-2 text-sm text-stone-700">
+              <span className="flex-shrink-0 w-5 h-5 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-xs font-bold">2</span>
+              Your 14-day free trial starts immediately — <strong>no charge today</strong>
+            </li>
+            <li className="flex items-start gap-2 text-sm text-stone-700">
+              <span className="flex-shrink-0 w-5 h-5 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-xs font-bold">3</span>
+              You&apos;ll get a confirmation email with your billing details
+            </li>
+            <li className="flex items-start gap-2 text-sm text-stone-700">
+              <span className="flex-shrink-0 w-5 h-5 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center text-xs font-bold">4</span>
+              We&apos;ll guide you through setting up your account
+            </li>
+          </ol>
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div className="mb-4 px-4 py-3 rounded-xl bg-red-50 border border-red-200 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {/* CTA */}
+        <button
+          onClick={handleProceedToCheckout}
+          disabled={loading}
+          className="w-full flex items-center justify-center gap-2 px-6 py-4 rounded-xl bg-green-500 text-white hover:bg-green-600 disabled:opacity-60 disabled:cursor-not-allowed transition-colors text-base font-semibold mb-4"
+        >
+          {loading ? 'Redirecting to Stripe...' : (
+            <>
+              Continue to Secure Checkout <ArrowRight className="w-5 h-5" />
+            </>
+          )}
+        </button>
+
+        <SecurityBadges />
+      </main>
+    </div>
+  );
+}

--- a/src/app/payment-success/page.tsx
+++ b/src/app/payment-success/page.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { CheckCircle2, ArrowRight } from 'lucide-react';
+import NextStepsCard from '@/components/payment/NextStepsCard';
+import SecurityBadges from '@/components/payment/SecurityBadges';
+import { trackPageView } from '@/lib/ga4';
+
+export default function PaymentSuccessPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const sessionId = searchParams.get('session_id');
+
+  useEffect(() => {
+    trackPageView('/payment-success', 'Payment Success');
+  }, []);
+
+  const handleStartSetup = () => {
+    router.push('/onboarding');
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-green-50 to-stone-50">
+      <header className="bg-white border-b border-stone-200">
+        <div className="max-w-7xl mx-auto px-4 py-4">
+          <h1 className="text-2xl font-bold text-green-600">GroomGrid</h1>
+        </div>
+      </header>
+
+      <main className="max-w-lg mx-auto px-4 py-12">
+        {/* Success indicator */}
+        <div className="text-center mb-8">
+          <div className="w-20 h-20 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <CheckCircle2 className="w-12 h-12 text-green-500" />
+          </div>
+          <h2 className="text-3xl font-bold text-stone-900 mb-2">You&apos;re in!</h2>
+          <p className="text-stone-600">
+            Your 14-day free trial has started. No charge until your trial ends.
+          </p>
+        </div>
+
+        {/* Trial active banner */}
+        <div className="bg-green-50 border border-green-200 rounded-xl p-4 mb-6 text-center">
+          <p className="text-green-700 text-sm font-medium">
+            Trial active &mdash; full access for 14 days, nothing charged today
+          </p>
+          <p className="text-green-600 text-xs mt-1">
+            A confirmation has been sent to your email
+          </p>
+        </div>
+
+        {/* Next steps */}
+        <div className="mb-6">
+          <NextStepsCard />
+        </div>
+
+        {/* Primary CTA */}
+        <button
+          onClick={handleStartSetup}
+          className="w-full flex items-center justify-center gap-2 px-6 py-4 rounded-xl bg-green-500 text-white hover:bg-green-600 transition-colors text-base font-semibold mb-2"
+        >
+          Set Up My Account <ArrowRight className="w-5 h-5" />
+        </button>
+
+        <button
+          onClick={() => router.push('/dashboard')}
+          className="w-full px-6 py-3 rounded-xl text-stone-600 hover:text-stone-900 text-sm font-medium transition-colors"
+        >
+          Skip setup, go to dashboard
+        </button>
+
+        <SecurityBadges />
+
+        {sessionId && (
+          <p className="text-center text-xs text-stone-400 mt-2">
+            Reference: {sessionId.slice(0, 16)}...
+          </p>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/plans/page.tsx
+++ b/src/app/plans/page.tsx
@@ -87,7 +87,7 @@ export default function PlansPage() {
     }
   }, [status]);
 
-  const handleSelectPlan = async (plan: Plan) => {
+  const handleSelectPlan = (plan: Plan) => {
     if (!session?.user?.id) return;
 
     setSelectedPlan(plan);
@@ -96,30 +96,8 @@ export default function PlansPage() {
     // Fire client-side GA4 event before redirect — window.gtag is available here
     trackPlanSelected(plan.type, plan.price);
 
-    try {
-      const response = await fetch('/api/checkout', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          userId: session.user.id,
-          planType: plan.type,
-          customerEmail: session.user.email,
-        }),
-      });
-
-      const data = await response.json();
-
-      if (data.url) {
-        window.location.href = data.url;
-      } else {
-        throw new Error(data.error || 'Failed to create checkout');
-      }
-    } catch (err: any) {
-      console.error('Checkout error:', err);
-      alert(err.message || 'Failed to proceed to checkout');
-      setLoading(false);
-      setSelectedPlan(null);
-    }
+    // Redirect to payment review page for transparent pre-checkout summary
+    router.push(`/payment-review?plan=${plan.type}`);
   };
 
   if (status === 'loading' || !session) {

--- a/src/components/onboarding/CompletionScreen.tsx
+++ b/src/components/onboarding/CompletionScreen.tsx
@@ -1,4 +1,22 @@
-import { CheckCircle2, ArrowRight } from 'lucide-react';
+import { CheckCircle2, ArrowRight, Users, Calendar, Share2 } from 'lucide-react';
+
+const POST_ONBOARDING_TIPS = [
+  {
+    icon: <Users className="w-5 h-5 text-green-500" />,
+    title: 'Add more clients',
+    description: 'Import clients or add them as they book',
+  },
+  {
+    icon: <Calendar className="w-5 h-5 text-green-500" />,
+    title: 'Book appointments',
+    description: 'Use the + button to book in 2 taps',
+  },
+  {
+    icon: <Share2 className="w-5 h-5 text-green-500" />,
+    title: 'Share your booking page',
+    description: 'Send clients your personal booking link',
+  },
+];
 
 export default function CompletionScreen({ onDashboard }: { onDashboard: () => void }) {
   return (
@@ -6,44 +24,30 @@ export default function CompletionScreen({ onDashboard }: { onDashboard: () => v
       <div className="w-20 h-20 mx-auto rounded-full bg-green-100 flex items-center justify-center">
         <CheckCircle2 className="w-12 h-12 text-green-500" />
       </div>
-      
+
       <div>
-        <h2 className="text-3xl font-bold text-stone-900 mb-2">You're All Set!</h2>
+        <h2 className="text-3xl font-bold text-stone-900 mb-2">You&apos;re All Set!</h2>
         <p className="text-stone-600">
-          Your GroomGrid account is ready to go. Here's what you can do now:
+          Your GroomGrid account is ready to go. Here&apos;s what you can do now:
         </p>
       </div>
 
       <div className="bg-stone-50 rounded-2xl p-6 text-left space-y-4">
-        <div className="flex items-start gap-3">
-          <div className="flex-shrink-0 w-8 h-8 rounded-full bg-green-500 flex items-center justify-center">
-            <span className="text-white text-sm font-bold">1</span>
+        {POST_ONBOARDING_TIPS.map((tip, index) => (
+          <div key={index} className="flex items-start gap-3">
+            <div className="flex-shrink-0 mt-0.5">{tip.icon}</div>
+            <div>
+              <h3 className="font-semibold text-stone-900">{tip.title}</h3>
+              <p className="text-sm text-stone-600">{tip.description}</p>
+            </div>
           </div>
-          <div>
-            <h3 className="font-semibold text-stone-900">Add more clients</h3>
-            <p className="text-sm text-stone-600">Import clients or add them as they book</p>
-          </div>
-        </div>
-        
-        <div className="flex items-start gap-3">
-          <div className="flex-shrink-0 w-8 h-8 rounded-full bg-green-500 flex items-center justify-center">
-            <span className="text-white text-sm font-bold">2</span>
-          </div>
-          <div>
-            <h3 className="font-semibold text-stone-900">Book appointments</h3>
-            <p className="text-sm text-stone-600">Use the + button to book in 2 taps</p>
-          </div>
-        </div>
-        
-        <div className="flex items-start gap-3">
-          <div className="flex-shrink-0 w-8 h-8 rounded-full bg-green-500 flex items-center justify-center">
-            <span className="text-white text-sm font-bold">3</span>
-          </div>
-          <div>
-            <h3 className="font-semibold text-stone-900">Track revenue</h3>
-            <p className="text-sm text-stone-600">See your earnings at a glance on the dashboard</p>
-          </div>
-        </div>
+        ))}
+      </div>
+
+      <div className="bg-blue-50 rounded-xl p-4 text-left">
+        <p className="text-sm text-blue-800">
+          <strong>Tip:</strong> Check your email — we sent you a getting-started guide with links to help docs and support.
+        </p>
       </div>
 
       <button

--- a/src/components/payment/BillingSummary.tsx
+++ b/src/components/payment/BillingSummary.tsx
@@ -1,0 +1,38 @@
+import { PlanType } from '@/types';
+import { getPlanDetails, formatTrialEndDate } from '@/lib/payment-utils';
+
+interface BillingSummaryProps {
+  planType: PlanType;
+}
+
+export default function BillingSummary({ planType }: BillingSummaryProps) {
+  const plan = getPlanDetails(planType);
+  const trialEndDate = formatTrialEndDate();
+
+  return (
+    <div className="bg-stone-50 rounded-xl border border-stone-200 p-5 space-y-4">
+      <h3 className="font-semibold text-stone-900 text-base">Order Summary</h3>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-stone-600 text-sm">Plan</span>
+          <span className="font-semibold text-stone-900">{plan.name}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-stone-600 text-sm">14-day free trial</span>
+          <span className="font-semibold text-green-600">$0.00 today</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-stone-600 text-sm">After trial ends</span>
+          <span className="font-semibold text-stone-900">${plan.price}/month</span>
+        </div>
+      </div>
+
+      <div className="border-t border-stone-200 pt-3">
+        <p className="text-xs text-stone-500">
+          Your free trial runs until <strong>{trialEndDate}</strong>. You won&apos;t be charged until then, and you can cancel any time before with no fee.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/payment/NextStepsCard.tsx
+++ b/src/components/payment/NextStepsCard.tsx
@@ -1,0 +1,64 @@
+import { ReactNode } from 'react';
+import { CheckCircle2, Calendar, Users, BarChart2 } from 'lucide-react';
+import Link from 'next/link';
+
+interface NextStep {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  href: string;
+  cta: string;
+}
+
+const NEXT_STEPS: NextStep[] = [
+  {
+    icon: <Users className="w-5 h-5 text-green-500" />,
+    title: 'Set up your profile',
+    description: 'Add your business info, services, and working hours',
+    href: '/onboarding',
+    cta: 'Start setup',
+  },
+  {
+    icon: <Calendar className="w-5 h-5 text-green-500" />,
+    title: 'Book your first appointment',
+    description: 'Add a client and schedule their first visit',
+    href: '/dashboard',
+    cta: 'Go to dashboard',
+  },
+  {
+    icon: <BarChart2 className="w-5 h-5 text-green-500" />,
+    title: 'Share your booking page',
+    description: 'Let clients book directly from a link you control',
+    href: '/dashboard',
+    cta: 'Get your link',
+  },
+];
+
+export default function NextStepsCard() {
+  return (
+    <div className="bg-white rounded-xl border border-stone-200 p-5 space-y-4">
+      <div className="flex items-center gap-2">
+        <CheckCircle2 className="w-5 h-5 text-green-500" />
+        <h3 className="font-semibold text-stone-900 text-base">What to do next</h3>
+      </div>
+
+      <div className="space-y-3">
+        {NEXT_STEPS.map((step, index) => (
+          <div key={index} className="flex items-start gap-3 p-3 rounded-lg bg-stone-50">
+            <div className="flex-shrink-0 mt-0.5">{step.icon}</div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-semibold text-stone-900">{step.title}</p>
+              <p className="text-xs text-stone-500 mt-0.5">{step.description}</p>
+            </div>
+            <Link
+              href={step.href}
+              className="flex-shrink-0 text-xs font-medium text-green-600 hover:text-green-700 whitespace-nowrap"
+            >
+              {step.cta} →
+            </Link>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/payment/SecurityBadges.tsx
+++ b/src/components/payment/SecurityBadges.tsx
@@ -1,0 +1,20 @@
+import { ShieldCheck, Lock, CreditCard } from 'lucide-react';
+
+export default function SecurityBadges() {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-4 py-4">
+      <div className="flex items-center gap-1.5 text-stone-500 text-sm">
+        <ShieldCheck className="w-4 h-4 text-green-500" />
+        <span>SSL Encrypted</span>
+      </div>
+      <div className="flex items-center gap-1.5 text-stone-500 text-sm">
+        <Lock className="w-4 h-4 text-green-500" />
+        <span>Secured by Stripe</span>
+      </div>
+      <div className="flex items-center gap-1.5 text-stone-500 text-sm">
+        <CreditCard className="w-4 h-4 text-green-500" />
+        <span>Cancel anytime</span>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/email/drip-templates.ts
+++ b/src/lib/email/drip-templates.ts
@@ -71,6 +71,8 @@ function p(text: string, muted = false): string {
 
 function step0(userName: string, appUrl: string): EmailContent {
   const firstName = userName.split(' ')[0]
+  const onboardingUrl = `${appUrl}/onboarding`
+  const docsUrl = `${appUrl}/docs`
 
   const html = emailWrapper(`
     ${h1(`Welcome to GroomGrid, ${firstName}! 🐾`)}
@@ -101,9 +103,9 @@ function step0(userName: string, appUrl: string): EmailContent {
       </tr>
     </table>
     ${p(`It only takes a few minutes and you'll never go back to spreadsheets.`)}
-    ${ctaButton('Set Up My Account', appUrl)}
+    ${ctaButton('Complete My Setup', onboardingUrl)}
     <br /><br />
-    ${p(`Questions? Just reply to this email — we're real people and we read everything.`, true)}
+    ${p(`Need help? <a href="${docsUrl}" style="color:${BRAND.primary};">Browse the getting-started guide</a> or reply to this email — we're real people and we read everything.`, true)}
   `)
 
   const text = `Welcome to GroomGrid, ${firstName}!
@@ -113,7 +115,8 @@ Here's how to get started:
 2. Add your first client — store pet details and notes.
 3. Book your first appointment — schedule and send reminders.
 
-Get started: ${appUrl}
+Complete your setup: ${onboardingUrl}
+Getting-started guide: ${docsUrl}
 
 Questions? Reply to this email.`
 

--- a/src/lib/email/payment-confirmation.ts
+++ b/src/lib/email/payment-confirmation.ts
@@ -1,0 +1,136 @@
+import { PlanType } from '@/types';
+import { getPlanDetails, formatTrialEndDate } from '@/lib/payment-utils';
+
+interface EmailContent {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+const BRAND = {
+  primary: '#22c55e',
+  bg: '#fafaf9',
+  text: '#292524',
+  textMuted: '#78716c',
+  border: '#e7e5e4',
+  white: '#ffffff',
+};
+
+function emailWrapper(body: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>GroomGrid</title>
+</head>
+<body style="margin:0;padding:0;background-color:${BRAND.bg};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,sans-serif;color:${BRAND.text};">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:${BRAND.bg};padding:40px 20px;">
+    <tr>
+      <td align="center">
+        <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background-color:${BRAND.white};border-radius:12px;border:1px solid ${BRAND.border};overflow:hidden;">
+          <tr>
+            <td style="background-color:${BRAND.primary};padding:24px 32px;">
+              <p style="margin:0;font-size:22px;font-weight:700;color:${BRAND.white};letter-spacing:-0.5px;">🐾 GroomGrid</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:32px;">
+              ${body}
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px 32px;border-top:1px solid ${BRAND.border};background-color:${BRAND.bg};">
+              <p style="margin:0;font-size:13px;color:${BRAND.textMuted};text-align:center;">
+                GroomGrid — Built for groomers, by groomers.<br />
+                <a href="{{unsubscribe_url}}" style="color:${BRAND.textMuted};">Unsubscribe</a>
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
+function ctaButton(label: string, href: string): string {
+  return `<a href="${href}" style="display:inline-block;background-color:${BRAND.primary};color:${BRAND.white};font-weight:600;font-size:15px;padding:14px 28px;border-radius:8px;text-decoration:none;margin-top:24px;">${label}</a>`;
+}
+
+function h1(text: string): string {
+  return `<h1 style="margin:0 0 16px 0;font-size:24px;font-weight:700;color:${BRAND.text};line-height:1.3;">${text}</h1>`;
+}
+
+function p(text: string, muted = false): string {
+  return `<p style="margin:0 0 14px 0;font-size:15px;line-height:1.6;color:${muted ? BRAND.textMuted : BRAND.text};">${text}</p>`;
+}
+
+export function getPaymentConfirmationEmail(
+  userName: string,
+  planType: PlanType,
+  appUrl: string
+): EmailContent {
+  const firstName = userName.split(' ')[0];
+  const plan = getPlanDetails(planType);
+  const trialEndDate = formatTrialEndDate();
+  const onboardingUrl = `${appUrl}/onboarding`;
+
+  const html = emailWrapper(`
+    ${h1(`Your GroomGrid trial has started, ${firstName}! 🎉`)}
+    ${p(`You're on the <strong>${plan.name} plan</strong> — full access, no charge for 14 days.`)}
+
+    <table cellpadding="0" cellspacing="0" style="width:100%;margin:16px 0 24px 0;border-collapse:collapse;border:1px solid ${BRAND.border};border-radius:8px;overflow:hidden;">
+      <tr style="background-color:${BRAND.bg};">
+        <td style="padding:12px 20px;border-bottom:1px solid ${BRAND.border};">
+          <p style="margin:0;font-size:13px;color:${BRAND.textMuted};">Plan</p>
+          <p style="margin:4px 0 0 0;font-size:16px;font-weight:600;color:${BRAND.text};">${plan.name}</p>
+        </td>
+        <td style="padding:12px 20px;border-bottom:1px solid ${BRAND.border};border-left:1px solid ${BRAND.border};">
+          <p style="margin:0;font-size:13px;color:${BRAND.textMuted};">Charged today</p>
+          <p style="margin:4px 0 0 0;font-size:16px;font-weight:600;color:${BRAND.primary};">$0.00</p>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding:12px 20px;">
+          <p style="margin:0;font-size:13px;color:${BRAND.textMuted};">First charge</p>
+          <p style="margin:4px 0 0 0;font-size:16px;font-weight:600;color:${BRAND.text};">${trialEndDate}</p>
+        </td>
+        <td style="padding:12px 20px;border-left:1px solid ${BRAND.border};">
+          <p style="margin:0;font-size:13px;color:${BRAND.textMuted};">Amount</p>
+          <p style="margin:4px 0 0 0;font-size:16px;font-weight:600;color:${BRAND.text};">$${plan.price}/month</p>
+        </td>
+      </tr>
+    </table>
+
+    ${p(`You can cancel any time before <strong>${trialEndDate}</strong> and you won't be charged. Manage your billing from your account settings.`)}
+
+    ${p(`<strong>Your next step:</strong> finish setting up your account so you're ready for your first appointment.`)}
+
+    ${ctaButton('Complete Your Setup', onboardingUrl)}
+
+    <br /><br />
+    ${p(`Questions? Just reply to this email — we read everything.`, true)}
+  `);
+
+  const text = `Hi ${firstName},
+
+Your GroomGrid ${plan.name} trial has started!
+
+- Plan: ${plan.name}
+- Charged today: $0.00
+- First charge: ${trialEndDate} ($${plan.price}/month)
+
+You can cancel any time before ${trialEndDate} with no charge.
+
+Complete your setup: ${onboardingUrl}
+
+Questions? Reply to this email.`;
+
+  return {
+    subject: `Your GroomGrid trial is active — here's what to expect`,
+    html,
+    text,
+  };
+}

--- a/src/lib/payment-utils.ts
+++ b/src/lib/payment-utils.ts
@@ -1,0 +1,61 @@
+import { PlanType } from '@/types';
+
+export interface PlanDetails {
+  name: string;
+  price: number;
+  features: string[];
+}
+
+export const PLAN_DETAILS: Record<PlanType, PlanDetails> = {
+  solo: {
+    name: 'Solo',
+    price: 29,
+    features: [
+      '1 groomer account',
+      'Unlimited clients & appointments',
+      'Automated reminders',
+      'Revenue tracking',
+      'Mobile app access',
+    ],
+  },
+  salon: {
+    name: 'Salon',
+    price: 79,
+    features: [
+      'Everything in Solo',
+      'Up to 5 groomer accounts',
+      'Team scheduling',
+      'Staff performance metrics',
+      'Priority support',
+    ],
+  },
+  enterprise: {
+    name: 'Enterprise',
+    price: 149,
+    features: [
+      'Everything in Salon',
+      'Unlimited groomers',
+      'Custom branding',
+      'API access',
+      'Dedicated account manager',
+    ],
+  },
+};
+
+export function getPlanDetails(planType: PlanType): PlanDetails {
+  return PLAN_DETAILS[planType];
+}
+
+export function formatTrialEndDate(): string {
+  const date = new Date();
+  date.setDate(date.getDate() + 14);
+  return date.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+export function isValidPlanType(value: string): value is PlanType {
+  return ['solo', 'salon', 'enterprise'].includes(value);
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -9,6 +9,7 @@ export interface CreateCheckoutSessionParams {
   planType: 'solo' | 'salon' | 'enterprise';
   customerEmail: string;
   businessName: string;
+  signupSource?: string;
 }
 
 const PRICE_IDS = {
@@ -22,9 +23,10 @@ export async function createCheckoutSession({
   planType,
   customerEmail,
   businessName,
+  signupSource = 'unknown',
 }: CreateCheckoutSessionParams) {
   const priceId = PRICE_IDS[planType];
-  
+
   const session = await stripe.checkout.sessions.create({
     customer_email: customerEmail,
     mode: 'subscription',
@@ -35,15 +37,22 @@ export async function createCheckoutSession({
         quantity: 1,
       },
     ],
+    metadata: {
+      userId,
+      planType,
+      businessName,
+      signupSource,
+    },
     subscription_data: {
       trial_period_days: 14,
       metadata: {
         userId,
         planType,
         businessName,
+        signupSource,
       },
     },
-    success_url: `${process.env.NEXT_PUBLIC_APP_URL}/checkout/success?session_id={CHECKOUT_SESSION_ID}`,
+    success_url: `${process.env.NEXT_PUBLIC_APP_URL}/api/checkout/success?session_id={CHECKOUT_SESSION_ID}`,
     cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/plans`,
     allow_promotion_codes: true,
     billing_address_collection: 'required',


### PR DESCRIPTION
## Summary

- Adds `/payment-review` pre-checkout page showing billing summary, plan features, and a step-by-step "what happens next" walkthrough before the user reaches Stripe
- Adds `/payment-success` post-checkout confirmation page with NextStepsCard and onboarding CTA, replacing the old `/checkout/success` auto-redirect
- Wires the full flow: plans → payment-review → Stripe → /api/checkout/success → payment-success → onboarding
- Auto-enrolls new signups in the welcome drip email sequence
- Improves welcome drip email with explicit onboarding URL and docs link
- Adds payment confirmation email template for immediate post-payment send
- Adds trust badges (SSL, Stripe, cancel anytime) on review and success pages

## New files
- `src/app/payment-review/page.tsx` — pre-payment review page
- `src/app/payment-success/page.tsx` — post-payment confirmation page
- `src/components/payment/SecurityBadges.tsx` — SSL/Stripe/cancel trust badges
- `src/components/payment/BillingSummary.tsx` — trial + billing preview
- `src/components/payment/NextStepsCard.tsx` — post-payment guidance card
- `src/lib/email/payment-confirmation.ts` — immediate post-payment email template
- `src/lib/payment-utils.ts` — shared plan details and helpers

## Modified files
- `src/app/plans/page.tsx` — redirect to /payment-review instead of direct checkout
- `src/app/api/checkout/route.ts` — pass signupSource metadata
- `src/lib/stripe.ts` — add session-level metadata, fix success_url routing
- `src/app/api/checkout/success/route.ts` — redirect to /payment-success
- `src/app/onboarding/page.tsx` — show welcome banner when arriving from payment
- `src/components/onboarding/CompletionScreen.tsx` — add post-onboarding tips
- `src/lib/email/drip-templates.ts` — improve welcome email with onboarding/docs links
- `src/app/api/auth/signup/route.ts` — auto-enroll in drip on signup

## Test plan
- [ ] Select a plan → lands on /payment-review with correct plan name and pricing
- [ ] BillingSummary shows $0 today and correct monthly price after trial
- [ ] "What happens next" steps are visible and accurate
- [ ] Clicking "Continue to Secure Checkout" calls /api/checkout and redirects to Stripe
- [ ] After Stripe checkout, /api/checkout/success redirects to /payment-success
- [ ] /payment-success shows NextStepsCard and trial active banner
- [ ] "Set Up My Account" button navigates to /onboarding
- [ ] New signup triggers drip enrollment in database

🤖 Generated with [Claude Code](https://claude.com/claude-code)