### PR TITLE
feat: Add 4-step progress indicator to signup flow

### DIFF
--- a/src/app/plans/page.tsx
+++ b/src/app/plans/page.tsx
@@ -7,6 +7,7 @@ import { Plan } from '@/types';
 import PlanCard from '@/components/funnel/PlanCard';
 import Testimonial from '@/components/funnel/Testimonial';
 import ValueProp from '@/components/funnel/ValueProp';
+import ProgressIndicator from '@/components/funnel/ProgressIndicator';
 import { trackPageView, trackPlanSelected } from '@/lib/ga4';
 
 const PLANS: Plan[] = [
@@ -146,6 +147,14 @@ export default function PlansPage() {
       </header>
 
       <main className="max-w-7xl mx-auto px-4 py-12">
+        {/* Progress Indicator - shows user is on step 3 of 4 */}
+        <div className="mb-8">
+          <ProgressIndicator
+            currentStep={3}
+            totalSteps={4}
+            stepLabels={['Account Info', 'Business Details', 'Plan Selection', 'Payment']}
+          />
+        </div>
         {/* Hero Section */}
         <div className="text-center mb-12">
           <h2 className="text-4xl font-bold text-stone-900 mb-4">Choose Your Plan</h2>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { signIn } from 'next-auth/react';
 import { AlertCircle, ArrowRight, Lock, Building, Mail } from 'lucide-react';
 import { trackSignupStarted, trackAccountCreated } from '@/lib/ga4';
+import ProgressIndicator from '@/components/funnel/ProgressIndicator';
 
 export default function SignupPage() {
   const router = useRouter();
@@ -82,6 +83,11 @@ export default function SignupPage() {
           <Link href="/" className="inline-block mb-4">
             <span className="text-2xl font-bold text-green-600">GroomGrid</span>
           </Link>
+          <ProgressIndicator
+            currentStep={1}
+            totalSteps={4}
+            stepLabels={['Account Info', 'Business Details', 'Plan Selection', 'Payment']}
+          />
           <h1 className="text-3xl font-bold text-stone-900 mb-2">Create Account</h1>
           <p className="text-stone-600">Start your 14-day free trial</p>
         </div>

--- a/src/components/funnel/ProgressIndicator.tsx
+++ b/src/components/funnel/ProgressIndicator.tsx
@@ -1,43 +1,57 @@
-import { CheckCircle, Circle } from 'lucide-react';
+import { CheckCircle, AlertCircle, MinusCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export type StepState = 'completed' | 'current' | 'upcoming' | 'error' | 'skipped';
 
 interface ProgressIndicatorProps {
   currentStep: number;
   totalSteps: number;
   stepLabels: string[];
+  stepStates?: StepState[];
 }
 
-export default function ProgressIndicator({ currentStep, totalSteps, stepLabels }: ProgressIndicatorProps) {
+export default function ProgressIndicator({ currentStep, totalSteps, stepLabels, stepStates }: ProgressIndicatorProps) {
+  const progressPercent = Math.round(((currentStep - 1) / (totalSteps - 1)) * 100);
+
   return (
     <div className="w-full max-w-2xl mx-auto mb-8">
       <div className="flex items-center justify-between">
         {stepLabels.map((label, index) => {
           const stepNumber = index + 1;
-          const isCompleted = stepNumber < currentStep;
-          const isCurrent = stepNumber === currentStep;
-          const isUpcoming = stepNumber > currentStep;
+          // Use stepStates if provided, otherwise calculate from currentStep
+          const stepState = stepStates?.[index] ?? (() => {
+            if (stepNumber < currentStep) return 'completed';
+            if (stepNumber === currentStep) return 'current';
+            return 'upcoming';
+          })();
 
           return (
             <div key={stepNumber} className="flex-1 flex flex-col items-center">
               <div
                 className={cn(
                   "w-10 h-10 rounded-full flex items-center justify-center mb-2 transition-all",
-                  isCompleted && "bg-green-500 text-white",
-                  isCurrent && "bg-green-500 text-white ring-4 ring-green-100",
-                  isUpcoming && "bg-stone-100 text-stone-400"
+                  stepState === 'completed' && "bg-green-500 text-white",
+                  stepState === 'current' && "bg-green-500 text-white ring-4 ring-green-100",
+                  stepState === 'upcoming' && "bg-stone-100 text-stone-400",
+                  stepState === 'error' && "bg-red-500 text-white ring-4 ring-red-100",
+                  stepState === 'skipped' && "bg-stone-200 text-stone-500"
                 )}
               >
-                {isCompleted ? (
-                  <CheckCircle className="w-6 h-6" />
-                ) : (
+                {stepState === 'completed' && <CheckCircle className="w-6 h-6" />}
+                {stepState === 'error' && <AlertCircle className="w-6 h-6" />}
+                {stepState === 'skipped' && <MinusCircle className="w-6 h-6" />}
+                {(stepState === 'current' || stepState === 'upcoming') && (
                   <span className="text-sm font-semibold">{stepNumber}</span>
                 )}
               </div>
               <span
                 className={cn(
                   "text-xs font-medium text-center max-w-[80px]",
-                  isCurrent && "text-green-700",
-                  isCompleted && "text-stone-600",
-                  isUpcoming && "text-stone-400"
+                  stepState === 'current' && "text-green-700",
+                  stepState === 'completed' && "text-stone-600",
+                  stepState === 'upcoming' && "text-stone-400",
+                  stepState === 'error' && "text-red-700",
+                  stepState === 'skipped' && "text-stone-500 line-through decoration-stone-400"
                 )}
               >
                 {label}
@@ -46,19 +60,20 @@ export default function ProgressIndicator({ currentStep, totalSteps, stepLabels 
           );
         })}
       </div>
-      
+
       {/* Progress bar */}
       <div className="relative mt-2">
-        <div className="absolute top-0 left-0 h-1 bg-stone-200 w-full rounded-full" />
+        <div className="absolute top-0 left-0 h-1 bg-stone-200 w-full rounded-full" aria-hidden="true" />
         <div
+          role="progressbar"
+          aria-valuenow={progressPercent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`Step ${currentStep} of ${totalSteps}`}
           className="absolute top-0 left-0 h-1 bg-green-500 rounded-full transition-all duration-300"
-          style={{ width: `${((currentStep - 1) / (totalSteps - 1)) * 100}%` }}
+          style={{ width: `${progressPercent}%` }}
         />
       </div>
     </div>
   );
-}
-
-function cn(...classes: (string | boolean | undefined | null)[]) {
-  return classes.filter(Boolean).join(' ');
 }


### PR DESCRIPTION
## Summary
Add step progress indicators to signup flow showing: **Account Info → Business Details → Plan Selection → Payment**. Handle states: not-started, in-progress, completed, error, skipped.

## Changes Made

### 1. ProgressIndicator Component Enhancement (`src/components/funnel/ProgressIndicator.tsx`)
- Add `stepStates` optional prop for per-step state overrides
- Support states: `completed`, `current`, `upcoming`, `error`, `skipped`
- Add visual styles for error (red with ring) and skipped (gray with line-through)
- Import `cn()` from `@/lib/utils.ts` instead of duplicating
- Export `StepState` type for external usage
- Add proper ARIA attributes for accessibility

### 2. Signup Page Update (`src/app/signup/page.tsx`)
- Import `ProgressIndicator` component
- Show 4-step progress indicator with step 1 (Account Info) highlighted
- Steps: Account Info → Business Details → Plan Selection → Payment

### 3. Plans Page Update (`src/app/plans/page.tsx`)
- Import `ProgressIndicator` component
- Show 4-step progress indicator with step 3 (Plan Selection) highlighted
- Steps 1-2 (Account Info, Business Details) show as completed
- Step 4 (Payment) is upcoming

## Testing
- Manual verification: Both pages show correct 4-step indicators
- Progress bar calculates correctly for 4-step flow
- Visual consistency with existing design tokens (green primary, rounded-xl, shadows)
- Accessibility: Proper ARIA labels and roles

## Related Rock
Supports: [Engineering] Deploy stable GroomGrid MVP to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)