### PR TITLE
feat: Complete signup-to-paid conversion tracking in GA4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ STRIPE_PRICE_SOLO="price_1TJDgnG4DfZ9Hko3qZUifmgo"
 STRIPE_PRICE_SALON="price_1TJDguG4DfZ9Hko36faOkkXr"
 STRIPE_PRICE_ENTERPRISE="price_1TJDgvG4DfZ9Hko3vLzhNLZ1"
 
+# GA4 Measurement Protocol
+GA4_API_SECRET="your-ga4-api-secret"
+
 # Resend
 RESEND_API_KEY="your-resend-api-key"
 

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/next-auth-options';
 import { createCheckoutSession } from '@/lib/stripe';
 import prisma from '@/lib/prisma';
+import { trackPaymentInitiatedServer } from '@/lib/ga4-server';
 
 // Note: trackPlanSelected is intentionally fired client-side (plans/page.tsx)
 // before this API call. window.gtag is unavailable in server routes.
@@ -27,7 +28,10 @@ export async function POST(req: NextRequest) {
       businessName: profile.businessName,
     });
 
-    return NextResponse.json({ url: session.url });
+    // Track payment initiated event
+    await trackPaymentInitiatedServer(userId, session.id, planType);
+
+    return NextResponse.json({ url: session.url, sessionId: session.id });
   } catch (error: any) {
     console.error('Checkout error:', error);
     return NextResponse.json({ error: error.message || 'Failed to create checkout session' }, { status: 500 });

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -6,6 +6,8 @@ import {
   trackSubscriptionCreatedServer,
   trackSubscriptionUpdatedServer,
   trackSubscriptionCancelledServer,
+  trackPaymentSuccessServer,
+  trackPaymentFailedServer,
 } from '@/lib/ga4-server';
 
 export async function POST(req: Request) {
@@ -131,6 +133,13 @@ export async function POST(req: Request) {
               where: { userId: profile.userId },
               data: { subscriptionStatus: 'active' },
             });
+
+            // Track payment success in GA4
+            await trackPaymentSuccessServer(
+              profile.userId,
+              invoice.id,
+              invoice.amount_paid || 0
+            );
           }
         }
         break;
@@ -150,6 +159,13 @@ export async function POST(req: Request) {
               where: { userId: profile.userId },
               data: { subscriptionStatus: 'past_due' },
             });
+
+            // Track payment failure in GA4
+            await trackPaymentFailedServer(
+              profile.userId,
+              invoice.id,
+              invoice.last_payment_error?.message || 'unknown'
+            );
           }
         }
         break;

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { signIn } from 'next-auth/react';
 import { AlertCircle, ArrowRight, Lock, Building, Mail } from 'lucide-react';
-import { trackSignupStarted, trackAccountCreated } from '@/lib/ga4';
+import { trackSignupStarted, trackAccountCreated, trackSignupError } from '@/lib/ga4';
 
 export default function SignupPage() {
   const router = useRouter();
@@ -43,6 +43,7 @@ export default function SignupPage() {
 
       if (!res.ok) {
         const message = data.error || 'Failed to create account';
+        trackSignupError(message, 'api_response');
         if (message.includes('already in use')) {
           setError('An account with this email already exists. Try signing in instead.');
         } else {
@@ -62,6 +63,7 @@ export default function SignupPage() {
       });
 
       if (result?.error) {
+        trackSignupError(result.error, 'sign_in');
         setError('Account created but sign-in failed. Please sign in manually.');
         router.push('/login');
         return;
@@ -69,6 +71,7 @@ export default function SignupPage() {
 
       router.push('/plans');
     } catch (err: any) {
+      trackSignupError(err.message || 'network_error', 'catch_block');
       setError(err.message || 'Failed to create account');
     } finally {
       setLoading(false);

--- a/src/lib/ga4-server.ts
+++ b/src/lib/ga4-server.ts
@@ -177,3 +177,58 @@ export async function trackSubscriptionStartedServer(
     userId
   );
 }
+
+export async function trackPaymentInitiatedServer(
+  userId: string,
+  sessionId: string,
+  planType: string
+): Promise<void> {
+  await trackServerEvent(
+    userId,
+    {
+      name: 'payment_initiated',
+      params: {
+        session_id: sessionId,
+        plan_type: planType,
+      },
+    },
+    userId
+  );
+}
+
+export async function trackPaymentSuccessServer(
+  userId: string,
+  invoiceId: string,
+  amount: number
+): Promise<void> {
+  await trackServerEvent(
+    userId,
+    {
+      name: 'payment_success',
+      params: {
+        invoice_id: invoiceId,
+        amount,
+        currency: 'USD',
+      },
+    },
+    userId
+  );
+}
+
+export async function trackPaymentFailedServer(
+  userId: string,
+  invoiceId: string,
+  reason: string
+): Promise<void> {
+  await trackServerEvent(
+    userId,
+    {
+      name: 'payment_failed',
+      params: {
+        invoice_id: invoiceId,
+        reason,
+      },
+    },
+    userId
+  );
+}

--- a/src/lib/ga4.ts
+++ b/src/lib/ga4.ts
@@ -108,3 +108,10 @@ export function trackPageView(pagePath: string, pageTitle: string) {
     page_title: pageTitle,
   });
 }
+export function trackSignupError(error: string, context: string) {
+  trackEvent('signup_error', {
+    error,
+    context,
+    timestamp: new Date().toISOString(),
+  });
+}


### PR DESCRIPTION
## Summary

Adds missing GA4 conversion tracking events for complete signup-to-paid funnel analysis.

## Changes

### New GA4 Tracking Functions Added

**Client-side (src/lib/ga4.ts):**
- `trackSignupError(error, context)` - Track signup failures with error details and context

**Server-side (src/lib/ga4-server.ts):**
- `trackPaymentInitiatedServer(userId, sessionId, planType)` - Track when checkout session is created
- `trackPaymentSuccessServer(userId, invoiceId, amount)` - Track successful invoice payments
- `trackPaymentFailedServer(userId, invoiceId, reason)` - Track failed invoice payments with reason

### Event Wiring

**Signup page (src/app/signup/page.tsx):**
- Added `trackSignupError` calls in all error paths:
  - API error response failures (e.g., email already in use)
  - Sign-in failure after account creation
  - Network/other errors in catch block

**Checkout route (src/app/api/checkout/route.ts):**
- Added `trackPaymentInitiatedServer` call after successful checkout session creation
- Updated response to include `sessionId` for client reference

**Webhook route (src/app/api/stripe/webhook/route.ts):**
- Added `trackPaymentSuccessServer` call on \`invoice.payment_succeeded\` event
- Added `trackPaymentFailedServer` call on \`invoice.payment_failed\` event
- Includes error reason from \`invoice.last_payment_error.message\`

### Configuration

**.env.example:**
- Added documentation for \`GA4_API_SECRET\` environment variable

## Testing

The following GA4 events should now be tracked:
1. \`signup_error\` - When signup fails (API error, network error)
2. \`payment_initiated\` - When checkout session is created
3. \`payment_success\` - When invoice payment succeeds
4. \`payment_failed\` - When invoice payment fails

Existing events (unchanged):
- \`signup_started\` - Business name entry in signup form
- \`account_created\` - After successful account creation
- \`plan_selected\` - On plan selection page
- \`checkout_completed\` - After checkout success redirect
- \`subscription_created\` - On subscription creation
- \`subscription_updated\` - On subscription update
- \`subscription_cancelled\` - On subscription cancellation
- \`subscription_started\` - After trial activation
- \`onboarding_step_completed\` - After each onboarding step
- \`onboarding_skipped\` - When user skips onboarding

## Build Note

Build has pre-existing error with tailwindcss/next-font integration (unrelated to this PR).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>