### PR TITLE
fix: correct authOptions import in ab-test API routes

### DIFF
--- a/src/app/api/ab-test/assign/route.ts
+++ b/src/app/api/ab-test/assign/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { assignVariant } from '@/lib/ab-test';
 import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
+import { authOptions } from '@/lib/next-auth-options';
 
 export async function POST(request: NextRequest) {
   try {

--- a/src/app/api/ab-test/conversion/route.ts
+++ b/src/app/api/ab-test/conversion/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { trackConversion } from '@/lib/ab-test';
 import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
+import { authOptions } from '@/lib/next-auth-options';
 
 export async function POST(request: NextRequest) {
   try {


### PR DESCRIPTION
Fixes wrong import path '@/lib/auth' → '@/lib/next-auth-options' in new ab-test API routes. Causing build worker crash in production.