### PR TITLE
fix: add prisma generate to build script and postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
+    "postinstall": "prisma generate",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"

--- a/src/app/api/ab-test/assign/route.ts
+++ b/src/app/api/ab-test/assign/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { assignVariant } from '@/lib/ab-test';
 import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
+import { authOptions } from '@/lib/next-auth-options';
 
 export async function POST(request: NextRequest) {
   try {

--- a/src/app/api/ab-test/conversion/route.ts
+++ b/src/app/api/ab-test/conversion/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { trackConversion } from '@/lib/ab-test';
 import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
+import { authOptions } from '@/lib/next-auth-options';
 
 export async function POST(request: NextRequest) {
   try {


### PR DESCRIPTION
## Summary
- Adds `prisma generate` before `next build` in the build script
- Adds `postinstall` hook so Prisma client regenerates after `npm install`
- Fixes `Property 'aBTest' does not exist on type 'PrismaClient'` build error (ABTest models from PR #44 were never compiled into the client)

## Test plan
- [ ] `npm run build` should now succeed without TypeScript errors on `prisma.aBTest`
- [ ] Production deploy should complete and `app.getgroomgrid.com` should return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)