### PR TITLE
fix: add rate limiting to /api/auth/signup endpoint

### DIFF
--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -2,7 +2,59 @@ import { NextRequest, NextResponse } from 'next/server'
 import bcrypt from 'bcryptjs'
 import prisma from '@/lib/prisma'
 
+// Simple in-memory rate limiter for signup attempts
+// For production, use @upstash/ratelimit with Redis
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>()
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000 // 15 minutes
+const MAX_SIGNUP_ATTEMPTS = 5
+
+function getRateLimitKey(req: NextRequest): string {
+  const forwarded = req.headers.get('x-forwarded-for')
+  const ip = forwarded ? forwarded.split(',')[0].trim() : 'unknown'
+  return ip
+}
+
+function checkRateLimit(req: NextRequest): { allowed: boolean; retryAfter?: number } {
+  const key = getRateLimitKey(req)
+  const now = Date.now()
+  const record = rateLimitMap.get(key)
+
+  if (!record || now > record.resetAt) {
+    // Start new window
+    rateLimitMap.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS })
+    return { allowed: true }
+  }
+
+  if (record.count >= MAX_SIGNUP_ATTEMPTS) {
+    const retryAfter = Math.ceil((record.resetAt - now) / 1000)
+    return { allowed: false, retryAfter }
+  }
+
+  record.count++
+  return { allowed: true }
+}
+
 export async function POST(req: NextRequest) {
+  // Check rate limit
+  const { allowed, retryAfter } = checkRateLimit(req)
+  if (!allowed) {
+    return NextResponse.json(
+      {
+        error: 'Too many signup attempts',
+        message: `You've reached the maximum signup attempts. Please wait 15 minutes before trying again, or contact support if you need immediate assistance.`,
+      },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(retryAfter),
+          'X-RateLimit-Limit': String(MAX_SIGNUP_ATTEMPTS),
+          'X-RateLimit-Remaining': '0',
+          'X-RateLimit-Reset': String(Date.now() + (retryAfter || 0) * 1000),
+        },
+      }
+    )
+  }
+
   try {
     const { email, password, businessName } = await req.json()
 


### PR DESCRIPTION
## Summary

Implements IP-based rate limiting (5 attempts per 15 minutes) to prevent automated account creation attacks on the signup endpoint.

## Changes

- Added in-memory rate limiter with sliding window (15 min window, 5 max attempts)
- Returns 429 Too Many Requests with appropriate headers when limit exceeded:
  - `Retry-After`: Seconds until retry is allowed
  - `X-RateLimit-Limit`: Maximum attempts allowed
  - `X-RateLimit-Remaining`: Remaining attempts
  - `X-RateLimit-Reset`: Unix timestamp when window resets
- User-friendly error message with support contact suggestion

## Security Impact

Prevents:
- **Automated attacks**: Bots cannot flood the signup endpoint
- **Database flooding**: Fake account creation is rate-limited
- **Resource waste**: Reduces unnecessary Stripe trial creations
- **Support burden**: Fewer fake accounts to clean up

## Testing

To test locally:
```bash
# Send 6 signup requests in quick succession
for i in {1..6}; do
  curl -X POST http://localhost:3000/api/auth/signup     -H 'Content-Type: application/json'     -d '{"email":"test@example.com","password":"test123","businessName":"Test Biz"}'
done
# The 6th request should return 429
```

## References

Fixes Mawsome-Agency/groomgrid-app#39