### PR TITLE
fix: Apply 3 core conversion funnel fixes

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -17,14 +17,14 @@ const PLAN_DATA = {
 
 export async function POST(req: NextRequest) {
   try {
-    const { userId, planType, customerEmail } = await req.json();
+    const { userId, planType, customerEmail, clientId } = await req.json();
 
     if (!userId || !planType) {
       return NextResponse.json(
-        { 
+        {
           error: 'Missing required fields',
           errorType: 'generic',
-        }, 
+        },
         { status: 400 }
       );
     }
@@ -46,6 +46,7 @@ export async function POST(req: NextRequest) {
       customerEmail: customerEmail || `${userId}@groomgrid.app`,
       businessName: profile.businessName,
       planData: PLAN_DATA[planType as keyof typeof PLAN_DATA], // Pass plan data for metadata
+      clientId,
     });
 
     // Track payment initiated event

--- a/src/app/plans/page.tsx
+++ b/src/app/plans/page.tsx
@@ -10,7 +10,7 @@ import ValueProp from '@/components/funnel/ValueProp';
 import TrustSignals from '@/components/trust/TrustSignals';
 import StickyPlanBar from '@/components/funnel/StickyPlanBar';
 import { BillingSummaryData } from '@/components/trust/BillingSummary';
-import { trackPageView, trackPlanSelected, trackBillingSummaryViewed } from '@/lib/ga4';
+import { trackPageView, trackPlanSelected, trackBillingSummaryViewed, getGA4ClientId } from '@/lib/ga4';
 
 const PLANS: Plan[] = [
   {
@@ -178,6 +178,7 @@ function PlansPageInner() {
           userId: session.user.id,
           planType: plan.type,
           customerEmail: session.user.email,
+          clientId: getGA4ClientId(),
         }),
       });
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -25,12 +25,6 @@ export default function SignupPage() {
 
   const { errors, validateField, clearFieldError } = useFormValidation();
 
-  useEffect(() => {
-    if (formData.businessName) {
-      trackSignupStarted(formData.businessName);
-    }
-  }, [formData.businessName]);
-
   const handleFieldChange = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
     // Clear error when value changes
@@ -61,6 +55,9 @@ export default function SignupPage() {
     e.preventDefault();
     setError('');
     setLoading(true);
+
+    // Track signup started event
+    trackSignupStarted(formData.businessName);
 
     try {
       const res = await fetch('/api/auth/signup', {

--- a/src/lib/ga4-server.ts
+++ b/src/lib/ga4-server.ts
@@ -84,13 +84,16 @@ export async function trackServerEvent(
 // ── Typed helpers ────────────────────────────────────────────────────────────
 
 export async function trackCheckoutCompletedServer(
+  clientId: string,
   userId: string,
   sessionId: string,
   planType: string,
   trialStarted: boolean
 ): Promise<void> {
+  // Use the provided clientId if available; fall back to userId for client_id
+  const effectiveClientId = clientId || userId;
   await trackServerEvent(
-    userId, // use userId as client_id; GA4 will dedupe on user_id
+    effectiveClientId,
     {
       name: 'checkout_completed',
       params: {
@@ -104,13 +107,15 @@ export async function trackCheckoutCompletedServer(
 }
 
 export async function trackSubscriptionCreatedServer(
+  clientId: string,
   userId: string,
   subscriptionId: string,
   planType: string,
   status: string
 ): Promise<void> {
+  const effectiveClientId = clientId || userId;
   await trackServerEvent(
-    userId,
+    effectiveClientId,
     {
       name: 'subscription_created',
       params: {

--- a/src/lib/ga4.ts
+++ b/src/lib/ga4.ts
@@ -199,3 +199,26 @@ export function trackABTestConverted(testName: string, variant: 'A' | 'B', event
     timestamp: new Date().toISOString(),
   });
 }
+
+// Get GA4 Client ID from cookie
+export function getGA4ClientId(): string | null {
+  if (typeof window === 'undefined') return null;
+  
+  const gaCookie = document.cookie
+    .split('; ')
+    .find((row) => row.startsWith('_ga='));
+    
+  if (!gaCookie) return null;
+  
+  // _ga cookie format: _ga=GA1.2.1234567890.1234567890
+  // We want the client ID: 1234567890.1234567890
+  const gaParts = gaCookie.split('=');
+  if (gaParts.length !== 2) return null;
+  
+  const gaValue = gaParts[1];
+  const clientIdParts = gaValue.split('.');
+  if (clientIdParts.length < 4) return null;
+  
+  // Return the last two parts joined by a period (client ID)
+  return `${clientIdParts[2]}.${clientIdParts[3]}`;
+}

--- a/src/lib/payment-completion.ts
+++ b/src/lib/payment-completion.ts
@@ -25,6 +25,7 @@ export interface CompletionPayload {
   stripeCustomerId?: string;
   stripeSubscriptionId?: string;
   subscriptionStatus?: string;
+  clientId?: string;
 }
 
 /**
@@ -56,7 +57,7 @@ export async function triggerPaymentCompletionHandler(
     id: string;
     customer: string | Stripe.Customer | Stripe.DeletedCustomer | null;
     subscription: string | Stripe.Subscription | null;
-    metadata?: { userId?: string; planType?: string };
+    metadata?: { userId?: string; planType?: string; clientId?: string };
   }
 ): Promise<void> {
   // Extract paymentId - use session.id if payment_intent is null
@@ -75,6 +76,7 @@ export async function triggerPaymentCompletionHandler(
   }
 
   const planType = session.metadata?.planType ?? 'unknown';
+  const clientId = session.metadata?.clientId;
 
   // Extract Stripe IDs with type guards
   const stripeCustomerId = typeof session.customer === 'string' ? session.customer : undefined;
@@ -116,8 +118,8 @@ export async function triggerPaymentCompletionHandler(
 
     // Fire GA4 events AFTER transaction succeeds
     // Order matters for funnel tracking
-    await trackCheckoutCompletedServer(userId, session.id, planType, true);
-    
+    await trackCheckoutCompletedServer(clientId || userId, userId, session.id, planType, true);
+
     if (stripeSubscriptionId) {
       await trackSubscriptionStartedServer(
         userId,

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -10,6 +10,7 @@ export interface CreateCheckoutSessionParams {
   customerEmail: string;
   businessName: string;
   planData?: { name: string; price: number };
+  clientId?: string;
 }
 
 const PRICE_IDS = {
@@ -24,6 +25,7 @@ export async function createCheckoutSession({
   customerEmail,
   businessName,
   planData,
+  clientId,
 }: CreateCheckoutSessionParams) {
   const priceId = PRICE_IDS[planType];
 
@@ -46,6 +48,7 @@ export async function createCheckoutSession({
         planName: planData?.name || planType,
         planPrice: planData?.price?.toString() || '0',
         isTrial: 'true',
+        clientId: clientId || '',
       },
     },
     success_url: `${process.env.NEXT_PUBLIC_APP_URL}/checkout/success?session_id={CHECKOUT_SESSION_ID}`,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,7 @@ import { getToken } from 'next-auth/jwt'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
-const protectedRoutes = ['/dashboard', '/onboarding', '/welcome', '/admin']
+const protectedRoutes = ['/dashboard', '/onboarding', '/welcome', '/admin', '/plans']
 const authRoutes = ['/login', '/signup']
 
 export async function middleware(request: NextRequest) {


### PR DESCRIPTION
## Summary

This PR applies the 3 core fixes for conversion funnel tracking without any scope creep. The original `cortex/fix-conversion-funnel-issues` branch had 34 files with 2000+ lines of unrelated changes (SEO pages, blog content, docs, tests). This clean branch contains ONLY the 3 core fixes.

## The 3 Core Fixes

### Fix 1: Middleware - Add /plans to protected routes
**Problem:** The `/plans` page was not protected, allowing unauthenticated users to access it.
**Solution:** Updated `protectedRoutes` array in `src/middleware.ts` to include `'/plans'`.

### Fix 2: GA4 Client ID Stitching - Track users across devices
**Problem:** GA4 events were using userId as client_id, breaking cross-device tracking (e.g., user signs up on mobile, pays on desktop).
**Solution:** 
- Added `getGA4ClientId()` function to extract GA4 client ID from `_ga` cookie
- Updated `trackCheckoutCompletedServer()` and `trackSubscriptionCreatedServer()` to accept `clientId` parameter with fallback to `userId`
- Added `clientId` to `CreateCheckoutSessionParams` interface and Stripe metadata
- Updated plans page to pass `clientId` to checkout API
- Updated checkout API to accept and forward `clientId`
- Updated payment-completion handler to pass `clientId` from session metadata

### Fix 3: Signup Dedup - Prevent duplicate signup_started events
**Problem:** `trackSignupStarted` was firing in a `useEffect` on every `businessName` change, causing duplicate events.
**Solution:** Removed the `useEffect` and moved `trackSignupStarted` call to `handleSubmit` before the API call, ensuring it fires only once per signup attempt.

## Files Modified

8 files changed, 48 insertions(+), 16 deletions(-):
- `src/middleware.ts` - Added /plans to protected routes
- `src/lib/ga4.ts` - Added getGA4ClientId() function
- `src/lib/ga4-server.ts` - Added clientId parameter to tracking functions
- `src/lib/stripe.ts` - Added clientId to interface and metadata
- `src/lib/payment-completion.ts` - Pass clientId from session metadata
- `src/app/plans/page.tsx` - Pass clientId to checkout API
- `src/app/api/checkout/route.ts` - Accept and forward clientId
- `src/app/signup/page.tsx` - Move trackSignupStarted to handleSubmit

## Testing

- Build compiles successfully: `npm run build` ✓
- No type errors in modified files
- All changes are surgical and focused on the 3 core fixes
- No scope creep (no SEO files, blog pages, docs, or tests)

## Related Issues

This PR addresses the conversion funnel tracking issues identified in the original `cortex/fix-conversion-funnel-issues` branch, but without the scope creep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)