### PR TITLE
fix: Prisma v7 CI breaking change - remove deprecated url property

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url = env("DATABASE_URL")
 }
 
 model User {


### PR DESCRIPTION
## Summary
Fixes the CI failure caused by Prisma 7 breaking change. The `url` property in the datasource block is no longer supported in schema files.

## Changes
- Removed `url = env("DATABASE_URL")` from `prisma/schema.prisma` datasource block
- Connection URL is now configured in `prisma.config.ts` (already present)

## Impact
- Unblocks all 6 open PRs that were failing CI
- Allows production to deploy the 4 pending commits with important fixes
- `prisma generate` now works correctly with Prisma 7.7.0

## Testing
- Verified `prisma generate` runs successfully
- Schema validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)