### PR TITLE
docs: Confirm middleware update for /plans route is already implemented

### DIFF
--- a/TASK_COMPLETION.md
+++ b/TASK_COMPLETION.md
@@ -1,0 +1,16 @@
+# Task Completion Note
+
+The task "Update middleware to make /plans publicly accessible" has already been completed.
+
+## Verification Summary
+
+1. **Current State**: The `/plans` route is NOT in the `protectedRoutes` array in `src/middleware.ts`
+2. **Historical Fixes**: 
+   - Commit `c702b1d`: "fix: make /plans public" (April 7, 2026)
+   - Commit `ca8e987`: "feat: Create public marketing pricing page" (April 14, 2026)
+3. **E2E Tests**: Existing tests verify that `/plans` is accessible without authentication
+4. **Page Design**: The `/plans` page (`src/app/plans/page.tsx`) is designed as a public marketing page
+
+## Conclusion
+
+No changes are needed to the middleware as the `/plans` route is already publicly accessible. The bug described in the task appears to have been fixed in a previous development cycle.


### PR DESCRIPTION
This PR adds documentation confirming that the task 'Update middleware to make /plans publicly accessible' was already completed in previous commits.

## Summary of Findings
- The `/plans` route is already NOT in the `protectedRoutes` array in `src/middleware.ts`
- Historical commits (c702b1d and ca8e987) already implemented this fix
- The `/plans` page is designed as a public marketing page
- Existing E2E tests verify the route is accessible without authentication

No code changes were needed as the fix was already in place.