### PR TITLE
fix: Resolve critical build blockers for MVP deployment

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,8 +24,6 @@ model User {
   appointments    Appointment[]
   businessHours   BusinessHours[]
   paymentLockouts PaymentLockout[]
-
-  paymentLockouts PaymentLockout[]
   @@map("users")
 }
 

--- a/src/app/plans/page.tsx
+++ b/src/app/plans/page.tsx
@@ -1,26 +1,11 @@
 'use client';
 
-import type { Metadata } from 'next';
 import Link from 'next/link';
 import PlanCard from '@/components/funnel/PlanCard';
 import Testimonial from '@/components/funnel/Testimonial';
 import ValueProp from '@/components/funnel/ValueProp';
 import TrustSignals from '@/components/trust/TrustSignals';
 import { PLANS, TESTIMONIALS, FAQ_ITEMS } from '../pricing/pricing-data';
-
-export const metadata: Metadata = {
-  title: 'Pricing | GroomGrid - Simple, Affordable Pet Grooming Software',
-  description: 'Transparent pricing for GroomGrid. Choose from Solo, Salon, or Enterprise plans. All plans include a 14-day free trial. No hidden fees.',
-  alternates: {
-    canonical: 'https://getgroomgrid.com/plans',
-  },
-  openGraph: {
-    title: 'Pricing | GroomGrid - Simple, Affordable Pet Grooming Software',
-    description: 'Transparent pricing for GroomGrid. Choose from Solo, Salon, or Enterprise plans. All plans include a 14-day free trial. No hidden fees.',
-    url: 'https://getgroomgrid.com/plans',
-    type: 'website',
-  },
-};
 
 const pricingSchema = {
   '@context': 'https://schema.org',


### PR DESCRIPTION
This PR resolves critical build errors preventing MVP deployment:

## Changes
- **Prisma Schema**: Removed duplicate  field in User model (was defined twice on lines 26 and 28)
- **Plans Page**: Removed metadata export from client component (not allowed in Next.js)

## Impact
These fixes resolve the following build errors:
- Prisma validation error: "Field 'paymentLockouts' is already defined on model 'User'"
- Next.js error: "You are attempting to export 'metadata' from a component marked with 'use client'"

## Testing
- Schema validation now passes
- Plans page no longer throws metadata export error

## Notes
- This unblocks the MVP deployment pipeline
- Remaining issue: tailwindcss dependency not installing properly (separate investigation needed)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>