### PR TITLE
fix: Remove duplicate indexes in Prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,8 +48,6 @@ model Profile {
   @@index([stripeCustomerId])
   @@index([subscriptionStatus])
   @@map("profiles")
-  @@index([stripeCustomerId])
-  @@index([subscriptionStatus])
 }
 
 model Client {
@@ -113,11 +111,10 @@ model Appointment {
   @@index([userId, startTime])
   @@index([userId, status, reminderSent])
   @@index([userId, status, dayOfReminderSent])
-  @@map("appointments")
-  @@index([userId, startTime])
   @@index([userId, status, startTime, endTime])
   @@index([status, reminderSent, startTime])
   @@index([status, dayOfReminderSent, startTime])
+  @@map("appointments")
 }
 
 model BusinessHours {


### PR DESCRIPTION
This PR fixes duplicate index definitions in the Prisma schema:

## Changes
- **Profile model**: Removed duplicate @@index([stripeCustomerId]) and @@index([subscriptionStatus])
- **Appointment model**: Removed duplicate @@index([userId, startTime]) and consolidated index definitions

## Impact
Resolves Prisma validation errors:
- "The given constraint name 'profiles_stripe_customer_id_idx' has to be unique"
- "The given constraint name 'profiles_subscription_status_idx' has to be unique"
- "The given constraint name 'appointments_user_id_start_time_idx' has to be unique"

## Testing
- Prisma schema validation now passes
- Prisma Client generates successfully

## Notes
- This unblocks the build pipeline
- Remaining issue: tailwindcss dependency not installing properly (separate investigation needed)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>