### PR TITLE
fix: deploy script stops app before npm install to prevent OOM restarts

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# GroomGrid Production Deploy Script
+# Usage: ./scripts/deploy.sh [prod|staging]
+# Stops the app before npm install to prevent OOM on 1GB droplet
+set -e
+
+ENV="${1:-prod}"
+APP_DIR="/var/www/groomgrid/${ENV}"
+PM2_NAME="groomgrid-${ENV}"
+
+echo "=== GroomGrid Deploy: ${ENV} ==="
+echo ""
+
+# 1. Pull latest code
+echo "[1/5] Pulling latest code..."
+cd "$APP_DIR"
+git pull origin main
+
+# 2. Stop app BEFORE npm install to free memory
+# On a 1GB droplet, npm install while the app is running causes OOM kills.
+echo "[2/5] Stopping app to free memory for install..."
+pm2 stop "$PM2_NAME" 2>/dev/null || true
+
+# 3. Install deps (with app stopped, full RAM available for npm)
+echo "[3/5] Installing dependencies..."
+npm ci --omit=dev
+
+# 4. Build
+echo "[4/5] Building..."
+NODE_ENV=production node_modules/.bin/next build
+
+# 5. Restart app
+echo "[5/5] Starting app..."
+pm2 restart "$PM2_NAME" || pm2 start "$PM2_NAME"
+pm2 save
+
+echo ""
+echo "=== Deploy complete: ${ENV} ==="
+pm2 status "$PM2_NAME"


### PR DESCRIPTION
## Problem
`groomgrid-prod` has **237 restarts** accumulated from OOM kills during deployments. Root cause confirmed via `dmesg`:

```
Out of memory: Killed process 782834 (npm install) total-vm:2338424kB
```

On a 1GB DO droplet, running `npm install` while the Next.js app is live exhausts RAM + swap, triggering the OOM killer. PM2 then restarts the app, which stabilizes quickly — but the restart counter keeps climbing, masking real crashes.

## Fix
New script at `scripts/deploy.sh` that:
1. Pulls latest code
2. **Stops the app first** to free ~200-400MB RAM
3. Runs `npm ci --omit=dev` (faster + deterministic vs `npm install`)
4. Builds
5. Restarts

## Test plan
- [ ] Run `./scripts/deploy.sh prod` on next deployment
- [ ] Verify no OOM kills in `dmesg`
- [ ] PM2 restart counter stays at 0 after deploy
- [ ] App comes back online after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)