### PR TITLE
feat: enhance health endpoint with DB and env connectivity checks

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 /** @type {import('jest').Config} */
 const config = {
   testEnvironment: 'jest-environment-jsdom',
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.js', '<rootDir>/src/tests/setupTestEnv.ts'],,
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   transform: {
     '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }],
   },

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,6 +1,18 @@
 require('@testing-library/jest-dom')
 
+// Polyfill TextEncoder/TextDecoder for Prisma in jsdom environment
+const { TextEncoder, TextDecoder } = require('util');
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = TextEncoder;
+}
+if (typeof global.TextDecoder === 'undefined') {
+  global.TextDecoder = TextDecoder;
+}
+
 // Mock environment variables
+process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/groomgrid_test'
+process.env.NEXTAUTH_URL = 'http://localhost:3000'
+process.env.NEXTAUTH_SECRET = 'test-secret-for-jest'
 process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
 process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID = 'G-TEST123'
 process.env.STRIPE_SECRET_KEY = 'sk_test_test123'

--- a/src/app/api/__tests__/health.test.ts
+++ b/src/app/api/__tests__/health.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for the health check endpoint and utilities.
+ *
+ * We test the health-check utility functions directly rather than
+ * trying to spin up the Next.js server — that gives us fast, deterministic
+ * unit tests that cover the real logic.
+ */
+
+import {
+  checkDatabase,
+  checkEnvironmentVars,
+  computeStatus,
+  buildHealthReport,
+  HealthCheckResult,
+} from '@/lib/health-check';
+
+// Mock prisma to avoid real DB connections in tests
+jest.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    $queryRaw: jest.fn(),
+  },
+}));
+
+// Import the mocked prisma so we can control it in tests
+import prisma from '@/lib/prisma';
+
+const mockQueryRaw = prisma.$queryRaw as jest.MockedFunction<typeof prisma.$queryRaw>;
+
+describe('health-check utilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('checkDatabase', () => {
+    it('returns pass when DB query succeeds', async () => {
+      mockQueryRaw.mockResolvedValueOnce([{ '?column?': 1 }]);
+
+      const result = await checkDatabase();
+
+      expect(result.name).toBe('database');
+      expect(result.status).toBe('pass');
+      expect(result.message).toBe('PostgreSQL is reachable');
+      expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+      expect(mockQueryRaw).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns fail when DB query throws', async () => {
+      mockQueryRaw.mockRejectedValueOnce(new Error('connection refused'));
+
+      const result = await checkDatabase();
+
+      expect(result.name).toBe('database');
+      expect(result.status).toBe('fail');
+      expect(result.message).toContain('connection refused');
+      expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('returns fail with non-Error thrown', async () => {
+      mockQueryRaw.mockRejectedValueOnce('string error');
+
+      const result = await checkDatabase();
+
+      expect(result.status).toBe('fail');
+      expect(result.message).toContain('string error');
+    });
+  });
+
+  describe('checkEnvironmentVars', () => {
+    it('returns pass for all vars when they are set', () => {
+      process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+      process.env.NEXTAUTH_URL = 'http://localhost:3000';
+      process.env.NEXTAUTH_SECRET = 'test-secret';
+      process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+
+      const results = checkEnvironmentVars();
+
+      expect(results).toHaveLength(4);
+      for (const result of results) {
+        expect(result.status).toBe('pass');
+      }
+    });
+
+    it('returns fail for missing DATABASE_URL', () => {
+      delete process.env.DATABASE_URL;
+      process.env.NEXTAUTH_URL = 'http://localhost:3000';
+      process.env.NEXTAUTH_SECRET = 'test-secret';
+      process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+
+      const results = checkEnvironmentVars();
+      const dbCheck = results.find((r) => r.name === 'env:DATABASE_URL');
+
+      expect(dbCheck).toBeDefined();
+      expect(dbCheck!.status).toBe('fail');
+      expect(dbCheck!.message).toContain('DATABASE_URL');
+    });
+
+    it('returns fail for multiple missing vars', () => {
+      delete process.env.DATABASE_URL;
+      delete process.env.NEXTAUTH_SECRET;
+      process.env.NEXTAUTH_URL = 'http://localhost:3000';
+      process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+
+      const results = checkEnvironmentVars();
+      const failures = results.filter((r) => r.status === 'fail');
+
+      expect(failures).toHaveLength(2);
+      expect(failures.map((r) => r.name)).toContain('env:DATABASE_URL');
+      expect(failures.map((r) => r.name)).toContain('env:NEXTAUTH_SECRET');
+    });
+  });
+
+  describe('computeStatus', () => {
+    it('returns healthy when all checks pass', () => {
+      const checks: HealthCheckResult[] = [
+        { name: 'database', status: 'pass', message: 'ok' },
+        { name: 'env:DATABASE_URL', status: 'pass', message: 'ok' },
+      ];
+
+      expect(computeStatus(checks)).toBe('healthy');
+    });
+
+    it('returns critical when any check fails', () => {
+      const checks: HealthCheckResult[] = [
+        { name: 'database', status: 'pass', message: 'ok' },
+        { name: 'env:DATABASE_URL', status: 'fail', message: 'missing' },
+      ];
+
+      expect(computeStatus(checks)).toBe('critical');
+    });
+
+    it('returns critical when all checks fail', () => {
+      const checks: HealthCheckResult[] = [
+        { name: 'database', status: 'fail', message: 'down' },
+        { name: 'env:DATABASE_URL', status: 'fail', message: 'missing' },
+      ];
+
+      expect(computeStatus(checks)).toBe('critical');
+    });
+
+    it('returns healthy for empty checks array', () => {
+      expect(computeStatus([])).toBe('healthy');
+    });
+  });
+
+  describe('buildHealthReport', () => {
+    it('returns a complete report with all required fields', async () => {
+      mockQueryRaw.mockResolvedValueOnce([{ '?column?': 1 }]);
+      process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+      process.env.NEXTAUTH_URL = 'http://localhost:3000';
+      process.env.NEXTAUTH_SECRET = 'test-secret';
+      process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+
+      const report = await buildHealthReport();
+
+      expect(report).toHaveProperty('status');
+      expect(report).toHaveProperty('timestamp');
+      expect(report).toHaveProperty('version');
+      expect(report).toHaveProperty('environment');
+      expect(report).toHaveProperty('uptimeSeconds');
+      expect(report).toHaveProperty('checks');
+      expect(report.checks.length).toBeGreaterThanOrEqual(2); // at least DB + env checks
+    });
+
+    it('reports critical when database is unreachable', async () => {
+      mockQueryRaw.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+      process.env.NEXTAUTH_URL = 'http://localhost:3000';
+      process.env.NEXTAUTH_SECRET = 'test-secret';
+      process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+
+      const report = await buildHealthReport();
+
+      expect(report.status).toBe('critical');
+      const dbCheck = report.checks.find((c) => c.name === 'database');
+      expect(dbCheck!.status).toBe('fail');
+    });
+
+    it('reports critical when env vars are missing', async () => {
+      mockQueryRaw.mockResolvedValueOnce([{ '?column?': 1 }]);
+      delete process.env.DATABASE_URL;
+      process.env.NEXTAUTH_URL = 'http://localhost:3000';
+      process.env.NEXTAUTH_SECRET = 'test-secret';
+      process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+
+      const report = await buildHealthReport();
+
+      expect(report.status).toBe('critical');
+    });
+
+    it('reports healthy when everything is configured', async () => {
+      mockQueryRaw.mockResolvedValueOnce([{ '?column?': 1 }]);
+      process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+      process.env.NEXTAUTH_URL = 'http://localhost:3000';
+      process.env.NEXTAUTH_SECRET = 'test-secret';
+      process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+
+      const report = await buildHealthReport();
+
+      expect(report.status).toBe('healthy');
+      for (const check of report.checks) {
+        expect(check.status).toBe('pass');
+      }
+    });
+  });
+});

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,9 +1,19 @@
-import { NextResponse } from 'next/server';
+/**
+ * Health Check API
+ *
+ * GET /api/health
+ * Returns system connectivity status: database reachability,
+ * environment variable presence, and aggregate health.
+ */
 
-export async function GET() {
-  return NextResponse.json({ 
-    status: 'ok', 
-    timestamp: new Date().toISOString(),
-    version: process.env.APP_VERSION || 'unknown'
-  });
+import { NextResponse } from 'next/server';
+import { buildHealthReport, HealthReport } from '@/lib/health-check';
+
+export async function GET(): Promise<NextResponse<HealthReport>> {
+  const report = await buildHealthReport();
+
+  // Return 503 when critical so load balancers / monitors detect the issue.
+  const httpStatus = report.status === 'critical' ? 503 : 200;
+
+  return NextResponse.json(report, { status: httpStatus });
 }

--- a/src/lib/health-check.ts
+++ b/src/lib/health-check.ts
@@ -1,0 +1,122 @@
+/**
+ * Health Check Utilities
+ *
+ * Provides functions to verify system connectivity — database reachability,
+ * environment variable presence, and overall service health.
+ * Follows the analytics-verification pattern of individual check results
+ * with an aggregate status.
+ */
+
+export interface HealthCheckResult {
+  name: string;
+  status: 'pass' | 'fail';
+  message: string;
+  latencyMs?: number;
+  details?: Record<string, unknown>;
+}
+
+export interface HealthReport {
+  status: 'healthy' | 'degraded' | 'critical';
+  timestamp: string;
+  version: string;
+  environment: string;
+  uptimeSeconds: number;
+  checks: HealthCheckResult[];
+}
+
+/**
+ * Check database connectivity by running a lightweight query.
+ * Uses the existing prisma singleton — no side effects.
+ */
+export async function checkDatabase(): Promise<HealthCheckResult> {
+  const start = Date.now();
+  try {
+    // Dynamic import to avoid crashes if prisma module is misconfigured.
+    // The prisma singleton is cached so this doesn't create new connections.
+    const { default: prisma } = await import('@/lib/prisma');
+    await prisma.$queryRaw`SELECT 1`;
+    const latencyMs = Date.now() - start;
+    return {
+      name: 'database',
+      status: 'pass',
+      message: 'PostgreSQL is reachable',
+      latencyMs,
+    };
+  } catch (error) {
+    const latencyMs = Date.now() - start;
+    return {
+      name: 'database',
+      status: 'fail',
+      message: `Database unreachable: ${error instanceof Error ? error.message : String(error)}`,
+      latencyMs,
+    };
+  }
+}
+
+/**
+ * Check that required environment variables for core app modules are present.
+ * This checks the 'app' module vars (NEXTAUTH_URL, NEXTAUTH_SECRET, NEXT_PUBLIC_APP_URL)
+ * plus DATABASE_URL since the health endpoint depends on DB connectivity.
+ */
+export function checkEnvironmentVars(): HealthCheckResult[] {
+  const checks: HealthCheckResult[] = [];
+
+  const criticalVars: Array<{ name: string; label: string }> = [
+    { name: 'DATABASE_URL', label: 'Database connection string' },
+    { name: 'NEXTAUTH_URL', label: 'NextAuth URL' },
+    { name: 'NEXTAUTH_SECRET', label: 'NextAuth secret' },
+    { name: 'NEXT_PUBLIC_APP_URL', label: 'Public app URL' },
+  ];
+
+  for (const { name, label } of criticalVars) {
+    const value = process.env[name];
+    if (!value) {
+      checks.push({
+        name: `env:${name}`,
+        status: 'fail',
+        message: `${label} (${name}) is not set`,
+      });
+    } else {
+      checks.push({
+        name: `env:${name}`,
+        status: 'pass',
+        message: `${label} is configured`,
+      });
+    }
+  }
+
+  return checks;
+}
+
+/**
+ * Compute aggregate status from individual check results.
+ * - All pass → healthy
+ * - Any fail → critical (for MVP, degraded is unused but reserved)
+ */
+export function computeStatus(checks: HealthCheckResult[]): 'healthy' | 'degraded' | 'critical' {
+  const failures = checks.filter((c) => c.status === 'fail').length;
+  if (failures > 0) return 'critical';
+  return 'healthy';
+}
+
+/**
+ * Build a complete health report.
+ */
+export async function buildHealthReport(): Promise<HealthReport> {
+  const checks: HealthCheckResult[] = [];
+
+  // Database check (async)
+  checks.push(await checkDatabase());
+
+  // Environment variable checks (sync)
+  checks.push(...checkEnvironmentVars());
+
+  return {
+    status: computeStatus(checks),
+    timestamp: new Date().toISOString(),
+    version: process.env.APP_VERSION || 'unknown',
+    environment: process.env.NODE_ENV || 'unknown',
+    uptimeSeconds: Math.floor(process.uptime()),
+    checks,
+  };
+}


### PR DESCRIPTION
## Summary

- **Enhanced `/api/health`** to verify actual system connectivity instead of returning a static `{status: 'ok'}` response
- **Database check**: Runs `SELECT 1` via Prisma to confirm PostgreSQL is reachable (with latency measurement)
- **Environment check**: Validates critical env vars are present (`DATABASE_URL`, `NEXTAUTH_URL`, `NEXTAUTH_SECRET`, `NEXT_PUBLIC_APP_URL`)
- **Aggregate status**: Returns `healthy` or `critical` following the existing `/api/analytics/verify` pattern
- **503 on critical**: Returns HTTP 503 when status is critical, so load balancers/monitors detect the issue

## Files Changed

| File | Change |
|------|--------|
| `src/lib/health-check.ts` | **New** — Reusable health check utilities (`checkDatabase`, `checkEnvironmentVars`, `computeStatus`, `buildHealthReport`) |
| `src/app/api/health/route.ts` | **Modified** — Enhanced to use health-check utilities, returns 503 when critical |
| `src/app/api/__tests__/health.test.ts` | **Modified** — Complete test suite (14 tests, was previously empty) |
| `jest.config.js` | **Fixed** — Syntax error (double comma), removed setupTestEnv from global setup |
| `jest.setup.js` | **Fixed** — Added TextEncoder/TextDecoder polyfill for Prisma in jsdom, added missing env vars |

## Test Results

```
Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
```

Tests cover:
- ✅ DB query success → pass with latency
- ✅ DB query failure → fail with error message
- ✅ Non-Error thrown → fail gracefully
- ✅ All env vars present → all pass
- ✅ Missing DATABASE_URL → fail
- ✅ Multiple missing vars → all reported
- ✅ computeStatus: all pass → healthy
- ✅ computeStatus: any fail → critical
- ✅ computeStatus: empty → healthy
- ✅ Full report: all fields present
- ✅ Full report: critical when DB down
- ✅ Full report: critical when env missing
- ✅ Full report: healthy when all good

## API Response Example

```json
{
  "status": "healthy",
  "timestamp": "2026-04-16T14:01:00.000Z",
  "version": "unknown",
  "environment": "production",
  "uptimeSeconds": 3642,
  "checks": [
    { "name": "database", "status": "pass", "message": "PostgreSQL is reachable", "latencyMs": 3 },
    { "name": "env:DATABASE_URL", "status": "pass", "message": "Database connection string is configured" },
    { "name": "env:NEXTAUTH_URL", "status": "pass", "message": "NextAuth URL is configured" },
    { "name": "env:NEXTAUTH_SECRET", "status": "pass", "message": "NextAuth secret is configured" },
    { "name": "env:NEXT_PUBLIC_APP_URL", "status": "pass", "message": "Public app URL is configured" }
  ]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)