### PR TITLE
fix: resolve 3 pre-merge bugs in UX Improvements PR

### DIFF
--- a/src/app/clients/page.tsx
+++ b/src/app/clients/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
+import { Plus, Mail, Phone, Calendar, ChevronRight, Search } from 'lucide-react';
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { trackPageView } from '@/lib/ga4';
 
@@ -30,6 +31,7 @@ export default function ClientsPage() {
   const [filteredClients, setFilteredClients] = useState<Client[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [showAddModal, setShowAddModal] = useState(false);
+  const [loading, setLoading] = useState(true);
   const { isOnline } = useOnlineStatus();
 
   useEffect(() => {

--- a/src/app/plans/page.tsx
+++ b/src/app/plans/page.tsx
@@ -1,81 +1,310 @@
 'use client';
 
-import Link from 'next/link';
+import { useState, useEffect, useRef, Suspense } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useSession, signOut } from 'next-auth/react';
+import { Plan } from '@/types';
 import PlanCard from '@/components/funnel/PlanCard';
 import Testimonial from '@/components/funnel/Testimonial';
 import ValueProp from '@/components/funnel/ValueProp';
 import TrustSignals from '@/components/trust/TrustSignals';
-import { PLANS, TESTIMONIALS, FAQ_ITEMS } from '../pricing/pricing-data';
+import StickyPlanBar from '@/components/funnel/StickyPlanBar';
+import { BillingSummaryData } from '@/components/trust/BillingSummary';
+import { trackPageView, trackPlanSelected, trackBillingSummaryViewed } from '@/lib/ga4';
 
-const pricingSchema = {
-  '@context': 'https://schema.org',
-  '@type': 'OfferCatalog',
-  name: 'GroomGrid Pricing Plans',
-  description: 'Pet grooming business management software pricing options',
-  offers: PLANS.map(plan => ({
-    '@type': 'Offer',
-    name: plan.name,
-    price: plan.price,
-    priceCurrency: 'USD',
-    billingPeriod: 'Monthly',
-  })),
-};
+const PLANS: Plan[] = [
+  {
+    id: 'solo',
+    name: 'Solo',
+    type: 'solo',
+    price: 29,
+    interval: 'monthly',
+    stripe_price_id: '', // resolved server-side via STRIPE_PRICE_SOLO env var
+    features: [
+      '1 groomer account',
+      'Unlimited clients & appointments',
+      'Automated reminders',
+      'Revenue tracking',
+      'Mobile app access',
+    ],
+  },
+  {
+    id: 'salon',
+    name: 'Salon',
+    type: 'salon',
+    price: 79,
+    interval: 'monthly',
+    stripe_price_id: '', // resolved server-side via STRIPE_PRICE_SALON env var
+    popular: true,
+    features: [
+      'Everything in Solo',
+      'Up to 5 groomer accounts',
+      'Team scheduling',
+      'Staff performance metrics',
+      'Priority support',
+    ],
+  },
+  {
+    id: 'enterprise',
+    name: 'Enterprise',
+    type: 'enterprise',
+    price: 149,
+    interval: 'monthly',
+    stripe_price_id: '', // resolved server-side via STRIPE_PRICE_ENTERPRISE env var
+    features: [
+      'Everything in Salon',
+      'Unlimited groomers',
+      'Custom branding',
+      'API access',
+      'Dedicated account manager',
+    ],
+  },
+];
 
-export default function PublicPricingPage() {
-  const handleSelectPlan = () => {
-    // For the marketing page, we just redirect to signup
-    window.location.href = '/signup';
+const TESTIMONIALS = [
+  {
+    name: 'Sarah Mitchell',
+    business: 'Paws on Wheels',
+    quote: 'GroomGrid cut my booking time in half. I can focus on dogs, not paperwork.',
+  },
+  {
+    name: 'James Rodriguez',
+    business: 'Fur Perfect Salon',
+    quote: 'My team loves mobile app. We can check schedules from anywhere and no-shows dropped 40%.',
+  },
+];
+
+function PlansSkeleton() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-green-50 to-stone-50">
+      <div className="max-w-7xl mx-auto px-4 py-12">
+        <div className="h-8 w-48 bg-stone-200 rounded animate-pulse mx-auto mb-4" />
+        <div className="h-5 w-64 bg-stone-200 rounded animate-pulse mx-auto mb-12" />
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="bg-white rounded-2xl border-2 border-stone-200 p-6 animate-pulse">
+              <div className="h-6 w-24 bg-stone-200 rounded mx-auto mb-4" />
+              <div className="h-10 w-20 bg-stone-200 rounded mx-auto mb-2" />
+              <div className="h-4 w-32 bg-stone-200 rounded mx-auto mb-6" />
+              <div className="space-y-3">
+                {[0, 1, 2, 3].map((j) => (
+                  <div key={j} className="h-4 bg-stone-200 rounded" />
+                ))}
+              </div>
+              <div className="h-12 bg-stone-200 rounded-xl mt-6" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PlansPageInner() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { data: session, status } = useSession();
+  const [selectedPlan, setSelectedPlan] = useState<Plan | null>(null);
+  const [checkoutError, setCheckoutError] = useState<string | null>(null);
+  // useState (not useRef) so mutations trigger re-renders and the loading UI actually shows
+  const [isCheckoutInFlight, setIsCheckoutInFlight] = useState<boolean>(false);
+  const planGridRef = useRef<HTMLDivElement>(null);
+
+  // Get billing summary data for selected plan
+  const getBillingData = (): BillingSummaryData | null => {
+    if (!selectedPlan) return null;
+
+    return {
+      planName: selectedPlan.name,
+      todayAmount: 0, // Trial is free
+      recurringAmount: selectedPlan.price * 100, // Convert to cents
+      currency: "$",
+      isTrial: true,
+      trialDays: 14,
+    };
   };
+
+  useEffect(() => {
+    trackPageView('/plans', 'Plan Selection');
+
+    // Check for previously selected plan from URL
+    const planParam = searchParams.get('selected');
+    if (planParam && PLANS.find(p => p.id === planParam)) {
+      setSelectedPlan(PLANS.find(p => p.id === planParam) || null);
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/login');
+      return;
+    }
+
+    // Check if welcome screen has been shown
+    if (status === 'authenticated' && session?.user?.id) {
+      fetch('/api/profile')
+        .then((res) => res.json())
+        .then((data) => {
+          // If welcome hasn't been shown and user hasn't selected a plan yet, redirect to welcome
+          if (!data.welcomeShown && !data.stripeSubscriptionId) {
+            router.replace('/welcome');
+          }
+        })
+        .catch((err) => {
+          console.error('Failed to check welcome status:', err);
+          // Don't block page if check fails
+        });
+    }
+  }, [status, session, router]);
+
+  const handleSelectPlan = async (plan: Plan) => {
+    if (!session?.user?.id) return;
+    if (isCheckoutInFlight) return;
+
+    setSelectedPlan(plan);
+    setCheckoutError(null);
+    setIsCheckoutInFlight(true);
+
+    // Fire client-side GA4 event before redirect — window.gtag is available here
+    trackPlanSelected(plan.type, plan.price);
+
+    // Track billing summary viewed
+    trackBillingSummaryViewed(plan.name, plan.price * 100, true);
+
+    try {
+      const response = await fetch('/api/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          userId: session.user.id,
+          planType: plan.type,
+          customerEmail: session.user.email,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        // Handle API errors with redirect to error page
+        const errorType = data.errorType || 'generic';
+        const declineCode = data.declineCode || '';
+
+        setIsCheckoutInFlight(false);
+        router.push(`/checkout/error?error_type=${errorType}&decline_code=${declineCode}`);
+        setSelectedPlan(null);
+        return;
+      }
+
+      if (data.url) {
+        setIsCheckoutInFlight(false);
+        window.location.href = data.url;
+      } else {
+        throw new Error(data.error || 'Failed to create checkout');
+      }
+    } catch (err: any) {
+      console.error('Checkout error:', err);
+      setCheckoutError(err.message || 'Failed to proceed to checkout');
+      setIsCheckoutInFlight(false);
+      setSelectedPlan(null);
+    }
+  };
+
+  if (status === 'loading' || !session) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-green-50 to-stone-50 flex items-center justify-center">
+        <div className="text-center">Loading...</div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-stone-50">
       {/* Header */}
       <header className="bg-white border-b border-stone-200">
         <div className="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
-          <Link href="/" className="text-2xl font-bold text-green-600">GroomGrid</Link>
-          <Link 
-            href="/signup" 
-            className="px-4 py-2 rounded-lg bg-green-500 text-white text-sm font-semibold hover:bg-green-600 transition-colors"
+          <h1 className="text-2xl font-bold text-green-600">GroomGrid</h1>
+          <button
+            onClick={() => signOut({ callbackUrl: '/' })}
+            className="text-stone-600 hover:text-stone-900 text-sm"
           >
-            Start Free Trial
-          </Link>
+            Sign Out
+          </button>
         </div>
       </header>
 
       <main className="max-w-7xl mx-auto px-4 py-12">
         {/* Hero Section */}
         <div className="text-center mb-12">
-          <h1 className="text-4xl font-bold text-stone-900 mb-4">Simple, Transparent Pricing</h1>
-          <p className="text-xl text-stone-600">All plans include a 14-day free trial. No credit card required.</p>
+          <h2 className="text-4xl font-bold text-stone-900 mb-4">Choose Your Plan</h2>
+          <p className="text-xl text-stone-600">All plans include a 14-day free trial</p>
         </div>
 
-        {/* Plan Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
+        {/* Checkout Error Alert */}
+        {checkoutError && (
+          <div
+            className="bg-amber-50 border-2 border-amber-200 rounded-2xl p-6 mb-8"
+            role="alert"
+            aria-live="polite"
+          >
+            <div className="flex items-start gap-3">
+              <span className="text-2xl" aria-hidden="true">⚠️</span>
+              <div>
+                <h3 className="text-lg font-semibold text-amber-900 mb-2">Payment Trouble</h3>
+                <p className="text-amber-800 mb-4">{checkoutError}</p>
+                <button
+                  onClick={() => router.push('/checkout/error?error_type=generic')}
+                  className="text-amber-700 hover:text-amber-900 font-medium underline"
+                >
+                  View detailed error and recovery options
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Mobile layout: Plan Cards → Trust Signals → Value Props → Testimonials → FAQ */}
+        {/* Desktop layout: Value Props → Trust Signals → Plan Cards → Testimonials → FAQ */}
+
+        {/* Plan Cards — shown first on mobile, after ValueProp on desktop */}
+        <div ref={planGridRef} className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12 order-first md:order-none">
           {PLANS.map((plan) => (
             <PlanCard
               key={plan.id}
               plan={plan}
-              selected={false}
-              onSelect={handleSelectPlan}
+              selected={selectedPlan?.id === plan.id}
+              onSelect={() => handleSelectPlan(plan)}
+              isLoading={selectedPlan?.id === plan.id && isCheckoutInFlight}
+              isDimmed={isCheckoutInFlight && selectedPlan?.id !== plan.id}
+              hasError={!!checkoutError && selectedPlan?.id === plan.id}
             />
           ))}
         </div>
 
         {/* Trust Signals */}
         <div className="mb-8">
-          <TrustSignals location="plans" compact={true} />
+          <TrustSignals
+            showBillingSummary={!!selectedPlan}
+            billingData={getBillingData() || undefined}
+            location="plans"
+            compact={true}
+          />
         </div>
 
-        {/* Value Props */}
-        <div className="mb-8">
+        {/* Value Props — hidden on mobile (shown above plan cards on desktop via flex order) */}
+        <div className="hidden md:block mb-8">
+          <ValueProp />
+        </div>
+
+        {/* Value Props — shown below Trust Signals on mobile only */}
+        <div className="md:hidden mb-8">
           <ValueProp />
         </div>
 
         {/* Testimonials */}
         <div className="mb-12">
-          <h2 className="text-2xl font-bold text-stone-900 mb-6 text-center">
+          <h3 className="text-2xl font-bold text-stone-900 mb-6 text-center">
             Trusted by Professional Groomers
-          </h2>
+          </h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl mx-auto">
             {TESTIMONIALS.map((testimonial, index) => (
               <Testimonial key={index} {...testimonial} />
@@ -85,53 +314,44 @@ export default function PublicPricingPage() {
 
         {/* FAQ Section */}
         <div className="max-w-2xl mx-auto">
-          <h2 className="text-2xl font-bold text-stone-900 mb-6 text-center">Frequently Asked Questions</h2>
+          <h3 className="text-2xl font-bold text-stone-900 mb-6 text-center">Frequently Asked Questions</h3>
           <div className="space-y-4">
-            {FAQ_ITEMS.map((faq, index) => (
-              <div key={index} className="bg-white rounded-xl p-6">
-                <h3 className="font-semibold text-stone-900 mb-2">{faq.question}</h3>
-                <p className="text-stone-600 text-sm">{faq.answer}</p>
-              </div>
-            ))}
+            <div className="bg-white rounded-xl p-6">
+              <h4 className="font-semibold text-stone-900 mb-2">What happens after the free trial?</h4>
+              <p className="text-stone-600 text-sm">
+                After 14 days, you'll be charged for your chosen plan. You can cancel anytime before the trial ends with no charge.
+              </p>
+            </div>
+            <div className="bg-white rounded-xl p-6">
+              <h4 className="font-semibold text-stone-900 mb-2">Can I change plans later?</h4>
+              <p className="text-stone-600 text-sm">
+                Yes! You can upgrade or downgrade your plan at any time from your account settings.
+              </p>
+            </div>
+            <div className="bg-white rounded-xl p-6">
+              <h4 className="font-semibold text-stone-900 mb-2">Is my data secure?</h4>
+              <p className="text-stone-600 text-sm">
+                Absolutely. We use industry-standard encryption and your data is backed up daily.
+              </p>
+            </div>
           </div>
         </div>
       </main>
 
-      {/* Final CTA */}
-      <section className="py-12 bg-green-600 text-white text-center">
-        <div className="max-w-3xl mx-auto px-4">
-          <h2 className="text-3xl font-bold mb-4">Ready to grow your grooming business?</h2>
-          <p className="text-green-100 mb-6 max-w-xl mx-auto">
-            Join hundreds of professional groomers who save hours each week with GroomGrid.
-          </p>
-          <Link 
-            href="/signup" 
-            className="inline-block px-8 py-4 rounded-xl bg-white text-green-600 font-bold text-lg hover:bg-green-50 transition-colors"
-          >
-            Start Your Free Trial
-          </Link>
-          <p className="text-green-200 text-sm mt-3">14 days free · No credit card required</p>
-        </div>
-      </section>
-
-      {/* Footer */}
-      <footer className="px-6 py-8 text-center text-stone-400 text-sm border-t border-stone-100">
-        <p>
-          © 2026 GroomGrid ·{' '}
-          <a
-            href="mailto:hello@getgroomgrid.com"
-            className="hover:text-stone-600 transition-colors"
-          >
-            hello@getgroomgrid.com
-          </a>
-        </p>
-      </footer>
-
-      {/* Schema.org structured data */}
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(pricingSchema) }}
+      {/* Sticky Plan Bar (mobile only) */}
+      <StickyPlanBar
+        selectedPlan={selectedPlan}
+        onSelectPlan={handleSelectPlan}
+        planGridRef={planGridRef}
       />
     </div>
+  );
+}
+
+export default function PlansPage() {
+  return (
+    <Suspense fallback={<PlansSkeleton />}>
+      <PlansPageInner />
+    </Suspense>
   );
 }

--- a/src/components/funnel/PlanCard.tsx
+++ b/src/components/funnel/PlanCard.tsx
@@ -62,11 +62,13 @@ export default function PlanCard({ plan, selected, onSelect, isLoading, isDimmed
       </ul>
 
       <button
+        disabled={isLoading}
         className={cn(
           "w-full py-3 rounded-xl font-semibold transition-all",
           selected
             ? "bg-green-500 text-white hover:bg-green-600"
-            : "bg-stone-100 text-stone-700 hover:bg-stone-200"
+            : "bg-stone-100 text-stone-700 hover:bg-stone-200",
+          isLoading && "opacity-50 cursor-not-allowed"
         )}
       >
         {selected ? 'Selected' : 'Choose Plan'}


### PR DESCRIPTION
## Summary

- **BUG-1 (CRITICAL)**: `isCheckoutInFlight` was `useRef<boolean>` — ref mutations don't trigger re-renders, so the loading spinner and `pointer-events-none` guard in `PlansPageInner` were dead code. Converted to `useState<boolean>` and replaced all `.current` reads/writes with the state setter. Also brings in the authenticated checkout flow from the UX improvements feature branch (replacing the public pricing page that was on main).
- **BUG-2 (CRITICAL)**: `clients/page.tsx` referenced `loading`/`setLoading` without ever declaring them as state — hard runtime crash on page load. Added `const [loading, setLoading] = useState(true)` and the missing lucide-react imports (`Plus`, `Mail`, `Phone`, `Calendar`, `ChevronRight`, `Search`).
- **BUG-3 (HIGH)**: `PlanCard` button was missing `disabled={isLoading}`. CSS `pointer-events-none` on the wrapper div does not prevent keyboard (`Enter`/`Space`) or screen reader activation — keyboard users could double-fire `handleSelectPlan` during an in-flight checkout. Added `disabled={isLoading}` and `opacity-50 cursor-not-allowed` class.

## Files changed

| File | Bug | Change |
|------|-----|--------|
| `src/app/plans/page.tsx` | BUG-1 | `useRef<boolean>` → `useState<boolean>` for `isCheckoutInFlight`; authenticated checkout flow |
| `src/app/clients/page.tsx` | BUG-2 | Add `loading` state declaration + lucide imports |
| `src/components/funnel/PlanCard.tsx` | BUG-3 | Add `disabled={isLoading}` + `cursor-not-allowed` class to CTA button |

## Test plan

- [ ] Verify `plans/page.tsx` shows loading spinner when a plan is clicked (was invisible before)
- [ ] Verify clicking another plan card while checkout is in-flight is blocked (both visually and via keyboard)
- [ ] Verify `clients/page.tsx` loads without crashing — no `ReferenceError: loading is not defined`
- [ ] Verify all lucide icons render in the clients list (`Plus`, `Mail`, `Phone`, `Calendar`, `ChevronRight`, `Search`)
- [ ] Verify PlanCard button is `disabled` during loading (keyboard Tab → Enter cannot re-trigger checkout)

> Note: Jest test suite has a pre-existing broken environment (`Cannot find module 'indent-string'` across all 26 suites) that is unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)