### PR TITLE
Add trust signals and micro-interactions to signup page

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -8,6 +8,8 @@ import { AlertCircle, ArrowRight, Lock, Building, Mail, Eye, EyeOff, Check } fro
 import { trackSignupStarted, trackAccountCreated, trackSignupError } from '@/lib/ga4';
 import { useFormValidation } from '@/hooks/use-form-validation';
 import PasswordStrengthMeter from '@/components/auth/PasswordStrengthMeter';
+import TrustSignals from '@/components/trust/TrustSignals';
+import './signup.css';
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -116,7 +118,7 @@ export default function SignupPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-stone-50 flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-xl p-8 max-w-md w-full">
+      <div className="bg-white rounded-2xl shadow-xl p-8 max-w-md w-full signup-card">
         <div className="text-center mb-8">
           <Link href="/" className="inline-block mb-4">
             <span className="text-2xl font-bold text-green-600">GroomGrid</span>
@@ -132,7 +134,7 @@ export default function SignupPage() {
           }`}
         >
           {error && (
-            <div className="flex items-start gap-2 p-3 rounded-lg bg-red-50 text-red-700 text-sm mb-4">
+            <div className="flex items-start gap-2 p-3 rounded-lg bg-red-50 text-red-700 text-sm mb-4 error-flash">
               <AlertCircle className="w-5 h-5 flex-shrink-0 mt-0.5" />
               <span>{error}</span>
             </div>
@@ -231,11 +233,16 @@ export default function SignupPage() {
           <button
             type="submit"
             disabled={loading || submitSuccess}
-            className={`w-full flex items-center justify-center gap-2 px-6 py-3 rounded-xl font-semibold transition-colors ${
-              submitSuccess
-                ? 'bg-green-500 text-white'
-                : 'bg-green-500 text-white hover:bg-green-600 disabled:bg-stone-300 disabled:cursor-not-allowed'
-            }`}
+            className={`w-full flex items-center justify-center gap-2 px-6 py-3 rounded-xl font-semibold
+  transition-[transform,box-shadow,background-color] duration-150 ease-out
+  hover:scale-[1.02] hover:shadow-md
+  active:scale-[0.98]
+  motion-reduce:hover:scale-100 motion-reduce:active:scale-100 motion-reduce:hover:shadow-none
+  ${
+    submitSuccess
+      ? "bg-green-500 text-white"
+      : "bg-green-500 text-white hover:bg-green-600 disabled:bg-stone-300 disabled:cursor-not-allowed"
+  }`}
           >
             {submitSuccess ? (
               <>
@@ -254,6 +261,10 @@ export default function SignupPage() {
             )}
           </button>
         </form>
+
+        <div className="mt-6">
+          <TrustSignals location="signup" compact={true} />
+        </div>
 
         <p className="text-center text-sm text-stone-600 mt-6">
           Already have an account?{' '}

--- a/src/app/signup/signup.css
+++ b/src/app/signup/signup.css
@@ -1,0 +1,39 @@
+@keyframes fadeSlideUp {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.signup-card {
+  animation: fadeSlideUp 400ms ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .signup-card {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes borderFlash {
+  0% { border-left-color: #f87171; } /* red-400 */
+  100% { border-left-color: transparent; }
+}
+
+.error-flash {
+  border-left: 4px solid transparent;
+  animation: borderFlash 2s ease-out forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .error-flash {
+    animation: none;
+    border-left: 4px solid #f87171;
+  }
+}

--- a/src/components/trust/PciBadge.tsx
+++ b/src/components/trust/PciBadge.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 import Tooltip from "@/components/ui/Tooltip";
 import { useAnalytics } from "@/hooks/use-analytics";
 
-export default function PciBadge({ className, location = "plans" }: { className?: string; location?: "plans" | "success" | "billing" }) {
+export default function PciBadge({ className, location = "plans" }: { className?: string; location?: "plans" | "success" | "billing" | "signup" }) {
   const { track } = useAnalytics();
 
   const handleClick = () => {

--- a/src/components/trust/SecureHeader.tsx
+++ b/src/components/trust/SecureHeader.tsx
@@ -4,11 +4,11 @@ import { Lock, Shield } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useAnalytics } from "@/hooks/use-analytics";
 
-export default function SecureHeader({ className }: { className?: string }) {
+export default function SecureHeader({ className, location = "plans" }: { className?: string; location?: string }) {
   const { track } = useAnalytics();
 
   const handleClick = () => {
-    track("trust_badge_interacted", { badge_type: "secure_header", location: "plans" });
+    track("trust_badge_interacted", { badge_type: "secure_header", location });
   };
 
   return (

--- a/src/components/trust/TrustSignals.tsx
+++ b/src/components/trust/TrustSignals.tsx
@@ -11,7 +11,7 @@ import BillingSummary from "./BillingSummary";
 interface TrustSignalsProps {
   showBillingSummary?: boolean;
   billingData?: BillingSummaryData;
-  location?: "plans" | "success" | "billing";
+  location?: "plans" | "success" | "billing" | "signup";
   compact?: boolean;
 }
 
@@ -22,10 +22,10 @@ export default function TrustSignals({
   compact = false 
 }: TrustSignalsProps) {
   return (
-    <div className="space-y-6">
+    <div className={location === "signup" ? "space-y-3" : "space-y-6"}>
       {/* Top row: Secure Header + PCI Badge */}
       <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
-        <SecureHeader />
+        <SecureHeader location={location} />
         <PciBadge location={location} />
       </div>
 


### PR DESCRIPTION
## Summary

Adds trust signals and micro-interactions to the signup page to reduce bounce rate (currently 80%). This is a reviewed build with 5 pre-resolved issues.

## Changes

### TrustSignals Component
- Extended `location` type union to include `"signup"`
- Updated spacing to use conditional: `location === "signup" ? "space-y-3" : "space-y-6"` (plans page spacing unchanged)
- Pass `location` prop through to `<SecureHeader>` for accurate analytics

### SecureHeader Component
- Added `location` prop with default `"plans"`
- Analytics call now uses prop instead of hardcoded `"plans"`

### PciBadge Component
- Extended `location` type union to include `"signup"` for type safety (recommendation from review)

### Signup Page
- Added imports: `TrustSignals` component and `./signup.css` styles
- Form card: Added `signup-card` class for fade-in + slide-up animation
- Error banner: Added `error-flash` class for animated left-border flash
- Submit button: Replaced `transition-colors` with targeted transitions:
  - `transition-[transform,box-shadow,background-color] duration-150 ease-out`
  - `hover:scale-[1.02] hover:shadow-md active:scale-[0.98]`
  - `motion-reduce:hover:scale-100 motion-reduce:active:scale-100 motion-reduce:hover:shadow-none`
- TrustSignals: Rendered below form with `location="signup" compact={true}`

### New File: signup.css
- `@keyframes fadeSlideUp` for card entrance animation
- `.signup-card` class with 400ms ease-out both animation
- `@keyframes borderFlash` for error banner flash effect
- `.error-flash` class with 2s ease-out forwards animation
- All animations respect `@media (prefers-reduced-motion: reduce)` for accessibility

## Accessibility
- All animations respect `prefers-reduced-motion: reduce` media query
- No layout shift from animations (transform-based, not affecting flow)
- Motion-reduce Tailwind variants disable scale effects for reduced motion preference

## Testing
- TypeScript compilation: No new errors (pre-existing test errors unrelated to changes)
- Mobile-friendly: Verified at 375px viewport
- PasswordStrengthMeter still renders correctly below password field

## Acceptance Criteria

- [x] TrustSignals rendered below form on signup page, compact mode, location="signup"
- [x] SecureHeader passes correct location to analytics (not hardcoded "plans")
- [x] TrustSignals type union includes "signup"
- [x] TrustSignals spacing uses `location === "signup"` gate, not `compact`
- [x] Plans page TrustSignals spacing unchanged (still space-y-6)
- [x] Form card has fade-in + slide-up animation on mount (CSS-only)
- [x] Submit button has scale hover/active states (1.02/0.98) with specific property transitions
- [x] Error banner has animated left-border flash
- [x] ALL animations respect `prefers-reduced-motion: reduce`
- [x] No layout shift on any animation
- [x] PasswordStrengthMeter still renders correctly below password field
- [x] Mobile-friendly — no horizontal scroll at 375px viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)