### PR TITLE
fix: Tailwind v4 @apply compatibility in globals.css — unblocks production build

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,10 +29,11 @@
 
 @layer base {
   * {
-    @apply border-border;
+    border-color: hsl(var(--border));
   }
   body {
-    @apply bg-background text-foreground;
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
   }
 }
 


### PR DESCRIPTION
## Summary

- Replaces `@apply bg-background`, `@apply text-foreground`, and `@apply border-border` with direct CSS property declarations
- Tailwind v4 with `@tailwindcss/postcss` cannot resolve these `@apply` references when colors are defined via `hsl(var(--...))` in `tailwind.config.ts`
- This was causing the production build to crash with: `Error: Cannot apply unknown utility class 'bg-background'`

## Root Cause

Production build was failing silently. The `.next` directory existed but had no `BUILD_ID`, causing PM2 to crash-loop 141+ times. Server had been patched manually, but the fix was never committed to the repo.

## Files Changed
- `src/app/globals.css` — 3-line change (2 `@apply` → direct CSS)

## Test plan
- [x] Local build passes
- [x] CI passes (build is non-breaking — equivalent visual output)
- [ ] Production `npm run build` succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)