### PR TITLE
fix: add missing payment_lockouts and ab_tests migrations (checkout broken)

### DIFF
--- a/prisma/migrations/20260417000000_add_payment_lockouts_table/migration.sql
+++ b/prisma/migrations/20260417000000_add_payment_lockouts_table/migration.sql
@@ -1,0 +1,41 @@
+-- CreateTable: payment_lockouts
+-- Idempotency guard for Stripe checkout sessions.
+-- Prevents duplicate subscriptions when webhooks are delayed or retried.
+
+CREATE TABLE IF NOT EXISTS "payment_lockouts" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "payment_id" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'processing',
+    "session_id" TEXT NOT NULL,
+    "error_message" TEXT,
+    "retry_count" INTEGER NOT NULL DEFAULT 0,
+    "last_retry_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "payment_lockouts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex: unique guard on (user_id, payment_id)
+CREATE UNIQUE INDEX IF NOT EXISTS "payment_lockouts_user_id_payment_id_key"
+    ON "payment_lockouts"("user_id", "payment_id");
+
+-- CreateIndex: lookup index for webhook handlers
+CREATE INDEX IF NOT EXISTS "payment_lockouts_user_id_payment_id_idx"
+    ON "payment_lockouts"("user_id", "payment_id");
+
+-- AddForeignKey: cascade delete when user is removed
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'payment_lockouts_user_id_fkey'
+    ) THEN
+        ALTER TABLE "payment_lockouts"
+            ADD CONSTRAINT "payment_lockouts_user_id_fkey"
+            FOREIGN KEY ("user_id")
+            REFERENCES "users"("id")
+            ON DELETE CASCADE
+            ON UPDATE CASCADE;
+    END IF;
+END $$;

--- a/prisma/migrations/20260417000001_add_ab_tests_tables/migration.sql
+++ b/prisma/migrations/20260417000001_add_ab_tests_tables/migration.sql
@@ -1,0 +1,96 @@
+-- CreateTable: ab_tests
+-- A/B testing framework: experiment definitions.
+
+CREATE TABLE IF NOT EXISTS "ab_tests" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "variantA" JSONB NOT NULL DEFAULT '{}',
+    "variantB" JSONB NOT NULL DEFAULT '{}',
+    "splitRatio" INTEGER NOT NULL DEFAULT 50,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "started_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "ended_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ab_tests_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "ab_tests_name_key" ON "ab_tests"("name");
+
+-- CreateTable: ab_test_assignments
+-- Tracks which variant each user/session was assigned.
+
+CREATE TABLE IF NOT EXISTS "ab_test_assignments" (
+    "id" TEXT NOT NULL,
+    "test_id" TEXT NOT NULL,
+    "user_id" TEXT,
+    "session_id" TEXT,
+    "variant" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ab_test_assignments_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "ab_test_assignments_test_id_user_id_key"
+    ON "ab_test_assignments"("test_id", "user_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "ab_test_assignments_test_id_session_id_key"
+    ON "ab_test_assignments"("test_id", "session_id");
+CREATE INDEX IF NOT EXISTS "ab_test_assignments_test_id_variant_idx"
+    ON "ab_test_assignments"("test_id", "variant");
+
+-- CreateTable: ab_test_conversions
+-- Tracks conversion events for each assignment.
+
+CREATE TABLE IF NOT EXISTS "ab_test_conversions" (
+    "id" TEXT NOT NULL,
+    "test_id" TEXT NOT NULL,
+    "assignment_id" TEXT NOT NULL,
+    "user_id" TEXT,
+    "session_id" TEXT,
+    "event" TEXT NOT NULL,
+    "metadata" JSONB,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ab_test_conversions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "ab_test_conversions_test_id_event_idx"
+    ON "ab_test_conversions"("test_id", "event");
+
+-- AddForeignKey: ab_test_assignments → ab_tests
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'ab_test_assignments_test_id_fkey'
+    ) THEN
+        ALTER TABLE "ab_test_assignments"
+            ADD CONSTRAINT "ab_test_assignments_test_id_fkey"
+            FOREIGN KEY ("test_id") REFERENCES "ab_tests"("id")
+            ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+-- AddForeignKey: ab_test_conversions → ab_tests
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'ab_test_conversions_test_id_fkey'
+    ) THEN
+        ALTER TABLE "ab_test_conversions"
+            ADD CONSTRAINT "ab_test_conversions_test_id_fkey"
+            FOREIGN KEY ("test_id") REFERENCES "ab_tests"("id")
+            ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+-- AddForeignKey: ab_test_conversions → ab_test_assignments
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'ab_test_conversions_assignment_id_fkey'
+    ) THEN
+        ALTER TABLE "ab_test_conversions"
+            ADD CONSTRAINT "ab_test_conversions_assignment_id_fkey"
+            FOREIGN KEY ("assignment_id") REFERENCES "ab_test_assignments"("id")
+            ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary
- Creates `prisma/migrations/20260417000000_add_payment_lockouts_table/migration.sql` — missing table that caused every checkout to crash (P2021)
- Creates `prisma/migrations/20260417000001_add_ab_tests_tables/migration.sql` — ab_tests, ab_test_assignments, ab_test_conversions also absent from prod
- All statements use `IF NOT EXISTS` and guarded FK constraints — safe against any DB state

## Root Cause
The `PaymentLockout` model was added to `schema.prisma` but no migration file was ever created. Production tables for `payment_lockouts`, `ab_tests`, `ab_test_assignments`, `ab_test_conversions` were never created. Every call to `POST /api/checkout` hit `prisma.paymentLockout.findFirst()` first and crashed with `P2021`.

## Test plan
- [ ] Merge PR → deploy to prod → run `prisma migrate resolve --applied` for existing migrations → `prisma migrate deploy` → tables created
- [ ] `POST /api/checkout` returns Stripe checkout URL (not 500)
- [ ] `/api/health` returns healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)