### PR TITLE
fix: Schema.org OfferCatalog on /plans + trust signals on /login

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { signIn } from 'next-auth/react';
 import { AlertCircle, ArrowRight, Lock, Mail } from 'lucide-react';
+import TrustSignals from '@/components/trust/TrustSignals';
 
 function LoginForm() {
   const router = useRouter();
@@ -135,6 +136,10 @@ function LoginForm() {
             Start free trial
           </Link>
         </p>
+
+        <div className="mt-6 pt-6 border-t border-stone-100">
+          <TrustSignals location="login" compact={true} />
+        </div>
       </div>
     </div>
   );

--- a/src/app/plans/page.tsx
+++ b/src/app/plans/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useSession, signOut } from 'next-auth/react';
+import Script from 'next/script';
 import { Plan } from '@/types';
 import PlanCard from '@/components/funnel/PlanCard';
 import Testimonial from '@/components/funnel/Testimonial';
@@ -233,6 +234,27 @@ function PlansPageInner() {
       </header>
 
       <main className="max-w-7xl mx-auto px-4 py-12">
+        {/* Schema.org OfferCatalog structured data for rich results */}
+        <Script
+          id="pricing-schema"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "OfferCatalog",
+              "name": "GroomGrid Pricing Plans",
+              "itemListElement": PLANS.map((plan, i) => ({
+                "@type": "Offer",
+                "position": i + 1,
+                "name": plan.name,
+                "price": plan.price,
+                "priceCurrency": "USD",
+                "description": plan.features.join(', '),
+              })),
+            }),
+          }}
+        />
+
         {/* Hero Section */}
         <div className="text-center mb-12">
           <h2 className="text-4xl font-bold text-stone-900 mb-4">Choose Your Plan</h2>

--- a/src/components/trust/PciBadge.tsx
+++ b/src/components/trust/PciBadge.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 import Tooltip from "@/components/ui/Tooltip";
 import { useAnalytics } from "@/hooks/use-analytics";
 
-export default function PciBadge({ className, location = "plans" }: { className?: string; location?: "plans" | "success" | "billing" | "signup" }) {
+export default function PciBadge({ className, location = "plans" }: { className?: string; location?: "plans" | "success" | "billing" | "signup" | "login" }) {
   const { track } = useAnalytics();
 
   const handleClick = () => {

--- a/src/components/trust/TrustSignals.tsx
+++ b/src/components/trust/TrustSignals.tsx
@@ -11,7 +11,7 @@ import BillingSummary from "./BillingSummary";
 interface TrustSignalsProps {
   showBillingSummary?: boolean;
   billingData?: BillingSummaryData;
-  location?: "plans" | "success" | "billing" | "signup";
+  location?: "plans" | "success" | "billing" | "signup" | "login";
   compact?: boolean;
 }
 
@@ -22,7 +22,7 @@ export default function TrustSignals({
   compact = false 
 }: TrustSignalsProps) {
   return (
-    <div className={location === "signup" ? "space-y-3" : "space-y-6"}>
+    <div className={location === "signup" || location === "login" ? "space-y-3" : "space-y-6"}>
       {/* Top row: Secure Header + PCI Badge */}
       <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
         <SecureHeader location={location} />


### PR DESCRIPTION
## Summary

- **Schema.org JSON-LD on /plans** — restores the `OfferCatalog` structured data block that was dropped when `plans/page.tsx` was rewritten. Two prior attempts (#106, #111) were closed without merging. This is a purely additive `<Script>` tag — no logic changes, no risk to checkout flow.
- **Trust signals on /login** — mirrors exactly what PR #110 did for `/signup`. Adds `<TrustSignals location="login" compact={true} />` below the sign-in form. Extended the `location` union in `TrustSignals.tsx` and `PciBadge.tsx` to include `"login"` (TypeScript-safe). Applied compact spacing (`space-y-3`) for login the same as signup.
- **Deleted bad branch** — `cortex/arjun-patel/login-trust-signals-tests` removed from remote. That branch strips ARIA `id`/`htmlFor` pairs (accessibility regression), removes `jest.setup.js` polyfills and stripe test path exclusions (re-introduces SIGTRAP crash), and breaks dashboard test assertions. It must not be merged.

## Files changed

| File | Change |
|------|--------|
| `src/app/plans/page.tsx` | Add `import Script from 'next/script'` + `OfferCatalog` JSON-LD block |
| `src/app/login/page.tsx` | Import + render `TrustSignals location="login" compact` |
| `src/components/trust/TrustSignals.tsx` | Add `"login"` to location union; apply compact spacing for login |
| `src/components/trust/PciBadge.tsx` | Add `"login"` to location union |

## Test plan

- [x] 22 test suites, 481 tests — all pass (`NODE_ENV=test jest`)
- [x] No new TypeScript errors in changed files (pre-existing module-not-found errors in e2e/ and scripts/ are unrelated)
- [x] `cortex/arjun-patel/login-trust-signals-tests` branch deleted from remote

## Context

- Issue 1 (P2021 crash-loop): Already resolved — PR #115 and #116 both merged to main
- Issue 2 (Plans Schema.org): Fixed in this PR ✅
- Issue 3 (Login trust signals): Fixed in this PR ✅
- Issue 4 (Bad arjun-patel branch): Deleted ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)