### PR TITLE
fix(e2e): resolve signup rate-limit exhaustion in complete user journey tests

### DIFF
--- a/e2e/signup-to-dashboard.spec.ts
+++ b/e2e/signup-to-dashboard.spec.ts
@@ -203,12 +203,11 @@ test.describe('Full signup-to-dashboard journey', () => {
   // ── Step 12: Onboarding page accessible ──────────────────────────────────
 
   test('step 12: onboarding page loads for authenticated user', async ({ page }) => {
-    const freshEmail = generateTestEmail();
-    await page.request.post('/api/auth/signup', {
-      data: { email: freshEmail, password, businessName },
-    });
+    // Reuse the shared account from beforeAll — no fresh signup needed here.
+    // Steps 12-15 don't test the signup flow; they test post-auth page behaviour.
+    // Creating a new account each time exhausts the 5-attempt rate-limit bucket.
     await page.goto('/login');
-    await page.getByLabel(/Email Address/i).fill(freshEmail);
+    await page.getByLabel(/Email Address/i).fill(email);
     await page.getByLabel(/Password/i).fill(password);
     await page.getByRole('button', { name: /Sign In/i }).click();
     await expect(page).toHaveURL(/\/(welcome|plans|dashboard|onboarding)/, { timeout: 30_000 });
@@ -220,12 +219,9 @@ test.describe('Full signup-to-dashboard journey', () => {
   // ── Step 13: Onboarding step 1 renders client form ───────────────────────
 
   test('step 13: onboarding step 1 shows client name and pet name fields', async ({ page }) => {
-    const freshEmail = generateTestEmail();
-    await page.request.post('/api/auth/signup', {
-      data: { email: freshEmail, password, businessName },
-    });
+    // Reuse the shared account from beforeAll — avoids surplus signup API calls.
     await page.goto('/login');
-    await page.getByLabel(/Email Address/i).fill(freshEmail);
+    await page.getByLabel(/Email Address/i).fill(email);
     await page.getByLabel(/Password/i).fill(password);
     await page.getByRole('button', { name: /Sign In/i }).click();
     await expect(page).toHaveURL(/\/(welcome|plans|dashboard|onboarding)/, { timeout: 30_000 });
@@ -244,12 +240,9 @@ test.describe('Full signup-to-dashboard journey', () => {
   // ── Step 14: Skip onboarding tutorial ────────────────────────────────────
 
   test('step 14: skip tutorial button navigates to dashboard', async ({ page }) => {
-    const freshEmail = generateTestEmail();
-    await page.request.post('/api/auth/signup', {
-      data: { email: freshEmail, password, businessName },
-    });
+    // Reuse the shared account from beforeAll — avoids surplus signup API calls.
     await page.goto('/login');
-    await page.getByLabel(/Email Address/i).fill(freshEmail);
+    await page.getByLabel(/Email Address/i).fill(email);
     await page.getByLabel(/Password/i).fill(password);
     await page.getByRole('button', { name: /Sign In/i }).click();
     await expect(page).toHaveURL(/\/(welcome|plans|dashboard|onboarding)/, { timeout: 30_000 });
@@ -267,12 +260,9 @@ test.describe('Full signup-to-dashboard journey', () => {
   // ── Step 15: Dashboard renders with welcome card ──────────────────────────
 
   test('step 15: dashboard renders welcome card for new users', async ({ page }) => {
-    const freshEmail = generateTestEmail();
-    await page.request.post('/api/auth/signup', {
-      data: { email: freshEmail, password, businessName },
-    });
+    // Reuse the shared account from beforeAll — avoids surplus signup API calls.
     await page.goto('/login');
-    await page.getByLabel(/Email Address/i).fill(freshEmail);
+    await page.getByLabel(/Email Address/i).fill(email);
     await page.getByLabel(/Password/i).fill(password);
     await page.getByRole('button', { name: /Sign In/i }).click();
     await expect(page).toHaveURL(/\/(welcome|plans|dashboard|onboarding)/, { timeout: 30_000 });

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -2,42 +2,16 @@ import { NextRequest, NextResponse } from 'next/server'
 import bcrypt from 'bcryptjs'
 import prisma from '@/lib/prisma'
 import { sendWelcomeEmail } from '@/lib/email/welcome'
-
-// Simple in-memory rate limiter for signup attempts
-// For production, use @upstash/ratelimit with Redis
-const rateLimitMap = new Map<string, { count: number; resetAt: number }>()
-const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000 // 15 minutes
-const MAX_SIGNUP_ATTEMPTS = 5
-
-function getRateLimitKey(req: NextRequest): string {
-  const forwarded = req.headers.get('x-forwarded-for')
-  const ip = forwarded ? forwarded.split(',')[0].trim() : 'unknown'
-  return ip
-}
-
-function checkRateLimit(req: NextRequest): { allowed: boolean; retryAfter?: number } {
-  const key = getRateLimitKey(req)
-  const now = Date.now()
-  const record = rateLimitMap.get(key)
-
-  if (!record || now > record.resetAt) {
-    // Start new window
-    rateLimitMap.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS })
-    return { allowed: true }
-  }
-
-  if (record.count >= MAX_SIGNUP_ATTEMPTS) {
-    const retryAfter = Math.ceil((record.resetAt - now) / 1000)
-    return { allowed: false, retryAfter }
-  }
-
-  record.count++
-  return { allowed: true }
-}
+import {
+  getRateLimitKey,
+  checkRateLimit,
+  MAX_SIGNUP_ATTEMPTS,
+} from '@/lib/signup-rate-limit'
 
 export async function POST(req: NextRequest) {
   // Check rate limit
-  const { allowed, retryAfter } = checkRateLimit(req)
+  const key = getRateLimitKey(req.headers)
+  const { allowed, retryAfter } = checkRateLimit(key)
   if (!allowed) {
     return NextResponse.json(
       {

--- a/src/lib/__tests__/signup-rate-limit.test.ts
+++ b/src/lib/__tests__/signup-rate-limit.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for the signup rate limiter.
+ *
+ * This module was extracted from src/app/api/auth/signup/route.ts so its
+ * core logic can be tested without a running Next.js server or Prisma
+ * connection.
+ *
+ * Key invariant these tests protect:
+ *   The E2E complete-user-journey suite makes exactly 5 calls to
+ *   /api/auth/signup across all 15 steps (1 browser form + 4 API).
+ *   MAX_SIGNUP_ATTEMPTS is 5, so the 5th call must succeed and the 6th
+ *   must be rejected. Any accidental addition of a fresh-user-creation
+ *   step in the E2E suite (steps 6-15) will cause 429s that cascade
+ *   into timeout failures — which is the bug this fix addresses.
+ */
+
+import {
+  checkRateLimit,
+  getRateLimitKey,
+  resetRateLimitMap,
+  MAX_SIGNUP_ATTEMPTS,
+  RATE_LIMIT_WINDOW_MS,
+} from '../signup-rate-limit'
+
+/** Minimal headers shim so we can test getRateLimitKey without NextRequest. */
+function makeHeaders(forwardedFor?: string): { get(name: string): string | null } {
+  return {
+    get(name: string) {
+      if (name === 'x-forwarded-for') return forwardedFor ?? null
+      return null
+    },
+  }
+}
+
+beforeEach(() => {
+  resetRateLimitMap()
+})
+
+// ── getRateLimitKey ──────────────────────────────────────────────────────────
+
+describe('getRateLimitKey', () => {
+  it('returns the first IP from a single-value x-forwarded-for header', () => {
+    expect(getRateLimitKey(makeHeaders('1.2.3.4'))).toBe('1.2.3.4')
+  })
+
+  it('returns the first IP from a comma-separated x-forwarded-for chain', () => {
+    expect(getRateLimitKey(makeHeaders('10.0.0.1, 172.16.0.1, 192.168.0.1'))).toBe('10.0.0.1')
+  })
+
+  it('trims whitespace around the IP', () => {
+    expect(getRateLimitKey(makeHeaders('  203.0.113.5  '))).toBe('203.0.113.5')
+  })
+
+  it('falls back to "unknown" when x-forwarded-for is absent', () => {
+    expect(getRateLimitKey(makeHeaders())).toBe('unknown')
+  })
+
+  it('falls back to "unknown" when x-forwarded-for is an empty string', () => {
+    expect(getRateLimitKey(makeHeaders(''))).toBe('unknown')
+  })
+})
+
+// ── checkRateLimit ───────────────────────────────────────────────────────────
+
+describe('checkRateLimit', () => {
+  const KEY = '1.2.3.4'
+  const T0 = 1_000_000_000_000 // arbitrary fixed timestamp
+
+  describe('happy path — within budget', () => {
+    it('allows the first attempt', () => {
+      expect(checkRateLimit(KEY, T0)).toEqual({ allowed: true })
+    })
+
+    it(`allows up to ${MAX_SIGNUP_ATTEMPTS} consecutive attempts`, () => {
+      for (let i = 0; i < MAX_SIGNUP_ATTEMPTS; i++) {
+        expect(checkRateLimit(KEY, T0).allowed).toBe(true)
+      }
+    })
+
+    it('allows attempt #5 (the last one within the limit)', () => {
+      // Exhaust 4 attempts first
+      for (let i = 0; i < MAX_SIGNUP_ATTEMPTS - 1; i++) {
+        checkRateLimit(KEY, T0)
+      }
+      // 5th must still be allowed
+      expect(checkRateLimit(KEY, T0)).toEqual({ allowed: true })
+    })
+  })
+
+  describe('rate limit enforcement', () => {
+    it('blocks the 6th attempt in the same window', () => {
+      for (let i = 0; i < MAX_SIGNUP_ATTEMPTS; i++) {
+        checkRateLimit(KEY, T0)
+      }
+      const result = checkRateLimit(KEY, T0)
+      expect(result.allowed).toBe(false)
+    })
+
+    it('returns a positive retryAfter when blocked', () => {
+      for (let i = 0; i < MAX_SIGNUP_ATTEMPTS; i++) checkRateLimit(KEY, T0)
+      const { retryAfter } = checkRateLimit(KEY, T0)
+      expect(retryAfter).toBeGreaterThan(0)
+    })
+
+    it('reports retryAfter = window remaining in seconds', () => {
+      for (let i = 0; i < MAX_SIGNUP_ATTEMPTS; i++) checkRateLimit(KEY, T0)
+      // 5 seconds into the window
+      const { retryAfter } = checkRateLimit(KEY, T0 + 5_000)
+      expect(retryAfter).toBe(Math.ceil((RATE_LIMIT_WINDOW_MS - 5_000) / 1000))
+    })
+
+    it('keeps blocking throughout the entire window', () => {
+      for (let i = 0; i < MAX_SIGNUP_ATTEMPTS; i++) checkRateLimit(KEY, T0)
+      // 14 minutes later — still within the 15-minute window
+      expect(checkRateLimit(KEY, T0 + 14 * 60_000).allowed).toBe(false)
+    })
+  })
+
+  describe('window reset', () => {
+    it('resets the counter after the window expires', () => {
+      for (let i = 0; i < MAX_SIGNUP_ATTEMPTS; i++) checkRateLimit(KEY, T0)
+      // Blocked at T0
+      expect(checkRateLimit(KEY, T0).allowed).toBe(false)
+      // One millisecond past the window end — new window starts
+      const afterWindow = T0 + RATE_LIMIT_WINDOW_MS + 1
+      expect(checkRateLimit(KEY, afterWindow).allowed).toBe(true)
+    })
+
+    it('starts a fresh counter after window reset', () => {
+      for (let i = 0; i < MAX_SIGNUP_ATTEMPTS; i++) checkRateLimit(KEY, T0)
+      const afterWindow = T0 + RATE_LIMIT_WINDOW_MS + 1
+      // New window: should allow MAX_SIGNUP_ATTEMPTS again
+      for (let i = 0; i < MAX_SIGNUP_ATTEMPTS; i++) {
+        expect(checkRateLimit(KEY, afterWindow).allowed).toBe(true)
+      }
+      // 6th attempt in the new window should be blocked
+      expect(checkRateLimit(KEY, afterWindow).allowed).toBe(false)
+    })
+  })
+
+  describe('isolation between IPs', () => {
+    it('tracks different keys independently', () => {
+      const IP_A = '1.1.1.1'
+      const IP_B = '2.2.2.2'
+
+      // Exhaust IP_A
+      for (let i = 0; i < MAX_SIGNUP_ATTEMPTS; i++) checkRateLimit(IP_A, T0)
+      expect(checkRateLimit(IP_A, T0).allowed).toBe(false)
+
+      // IP_B is unaffected
+      expect(checkRateLimit(IP_B, T0).allowed).toBe(true)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles "unknown" key without throwing', () => {
+      expect(() => checkRateLimit('unknown', T0)).not.toThrow()
+    })
+
+    it('returns allowed:true on first call for any key', () => {
+      expect(checkRateLimit('new-ip-never-seen', T0).allowed).toBe(true)
+    })
+
+    it('MAX_SIGNUP_ATTEMPTS constant is 5 (E2E test budget assumption)', () => {
+      // The E2E complete-user-journey suite relies on this value being 5.
+      // Steps 1-9 consume exactly 5 API calls; steps 12-15 reuse the shared
+      // account and make zero new signup calls. If this constant changes,
+      // the E2E spec must be audited to match.
+      expect(MAX_SIGNUP_ATTEMPTS).toBe(5)
+    })
+  })
+})

--- a/src/lib/signup-rate-limit.ts
+++ b/src/lib/signup-rate-limit.ts
@@ -1,0 +1,59 @@
+/**
+ * In-memory rate limiter for signup attempts.
+ *
+ * Uses a single sliding-window bucket per IP address. For production scale,
+ * swap this out for @upstash/ratelimit backed by Redis.
+ *
+ * Exported so the logic can be unit-tested independently of the Next.js
+ * request context and Prisma bindings.
+ */
+
+export const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000 // 15 minutes
+export const MAX_SIGNUP_ATTEMPTS = 5
+
+export interface RateLimitRecord {
+  count: number
+  resetAt: number
+}
+
+// Module-level map so the window persists across requests within a process.
+// Tests can clear it between runs by calling resetRateLimitMap().
+let rateLimitMap = new Map<string, RateLimitRecord>()
+
+/** Reset the map — only for use in tests. */
+export function resetRateLimitMap(): void {
+  rateLimitMap = new Map()
+}
+
+/** Derive a stable key from the request's remote IP. */
+export function getRateLimitKey(headers: { get(name: string): string | null }): string {
+  const forwarded = headers.get('x-forwarded-for')
+  return forwarded ? forwarded.split(',')[0].trim() : 'unknown'
+}
+
+/**
+ * Check whether the given key is within its rate-limit budget.
+ *
+ * Side-effect: increments the counter if allowed, or starts a new window
+ * if the previous window has expired.
+ */
+export function checkRateLimit(
+  key: string,
+  now = Date.now()
+): { allowed: boolean; retryAfter?: number } {
+  const record = rateLimitMap.get(key)
+
+  if (!record || now > record.resetAt) {
+    // New window or expired window — reset counter
+    rateLimitMap.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS })
+    return { allowed: true }
+  }
+
+  if (record.count >= MAX_SIGNUP_ATTEMPTS) {
+    const retryAfter = Math.ceil((record.resetAt - now) / 1000)
+    return { allowed: false, retryAfter }
+  }
+
+  record.count++
+  return { allowed: true }
+}


### PR DESCRIPTION
## Summary

- **Root cause**: Steps 12-15 in `e2e/signup-to-dashboard.spec.ts` each called `page.request.post('/api/auth/signup')` with fresh emails. Combined with the 5 calls from steps 4-9 (1 browser form + 4 API), this hit the `MAX_SIGNUP_ATTEMPTS = 5` bucket, producing 429s. The fresh accounts were never created, so the subsequent `/login` form fills timed out waiting for Suspense hydration on the CPU-stressed 1-vCPU staging droplet.
- **E2E fix**: Steps 12-15 now reuse the shared `email`/`password` from `beforeAll`. Total signup API calls across the full suite: **5** (exactly at the limit). Steps 6-9 still exercise the signup creation path.
- **Refactor + unit tests**: Extracted `checkRateLimit` / `getRateLimitKey` from `route.ts` into `src/lib/signup-rate-limit.ts` so the logic is testable without a live Next.js server or Prisma connection. Added **18 unit tests** covering: happy path, rate enforcement (6th call blocked), retryAfter calculation, window reset, multi-IP isolation, and edge cases including the `MAX_SIGNUP_ATTEMPTS = 5` constant assertion that documents the E2E budget assumption.

## Changed Files

| File | Change |
|------|--------|
| `e2e/signup-to-dashboard.spec.ts:205-290` | Steps 12-15 use shared `email` instead of fresh signup per step |
| `src/app/api/auth/signup/route.ts` | Delegates to `@/lib/signup-rate-limit` |
| `src/lib/signup-rate-limit.ts` | New — extracted rate limiter module |
| `src/lib/__tests__/signup-rate-limit.test.ts` | New — 18 unit tests |

## Test plan

- [x] `npm test` — **628 passed, 18 new** — no regressions (9 pre-existing `@testing-library/dom` suite failures unchanged)
- [x] Signup API call count in E2E spec audited: 5 total (within `MAX_SIGNUP_ATTEMPTS`)
- [x] All 18 new rate limiter unit tests pass in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)