### PR TITLE
feat: implement email verification flow and wire trackEmailVerified()

### DIFF
--- a/prisma/migrations/20260417000002_add_token_models/migration.sql
+++ b/prisma/migrations/20260417000002_add_token_models/migration.sql
@@ -1,0 +1,58 @@
+-- CreateTable: password_reset_tokens
+-- Stores one-time tokens for password reset flow.
+-- Uses IF NOT EXISTS so the migration is idempotent if the table already exists.
+
+CREATE TABLE IF NOT EXISTS "password_reset_tokens" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "used_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "password_reset_tokens_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "password_reset_tokens_token_key"
+    ON "password_reset_tokens"("token");
+
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'password_reset_tokens_user_id_fkey'
+    ) THEN
+        ALTER TABLE "password_reset_tokens"
+            ADD CONSTRAINT "password_reset_tokens_user_id_fkey"
+            FOREIGN KEY ("user_id")
+            REFERENCES "users"("id")
+            ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+-- CreateTable: email_verification_tokens
+-- Stores one-time tokens for email address verification.
+
+CREATE TABLE IF NOT EXISTS "email_verification_tokens" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "used_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "email_verification_tokens_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "email_verification_tokens_token_key"
+    ON "email_verification_tokens"("token");
+
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'email_verification_tokens_user_id_fkey'
+    ) THEN
+        ALTER TABLE "email_verification_tokens"
+            ADD CONSTRAINT "email_verification_tokens_user_id_fkey"
+            FOREIGN KEY ("user_id")
+            REFERENCES "users"("id")
+            ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,14 +16,16 @@ model User {
   createdAt     DateTime @default(now()) @map("created_at")
   updatedAt     DateTime @updatedAt @map("updated_at")
 
-  profile         Profile?
-  dripQueue       DripEmailQueue[]
-  feedback        Feedback[]
-  analyticsEvents AnalyticsEvent[]
-  clients         Client[]
-  appointments    Appointment[]
-  businessHours   BusinessHours[]
-  paymentLockouts PaymentLockout[]
+  profile                 Profile?
+  dripQueue               DripEmailQueue[]
+  feedback                Feedback[]
+  analyticsEvents         AnalyticsEvent[]
+  clients                 Client[]
+  appointments            Appointment[]
+  businessHours           BusinessHours[]
+  paymentLockouts         PaymentLockout[]
+  passwordResetTokens     PasswordResetToken[]
+  emailVerificationTokens EmailVerificationToken[]
   @@map("users")
 }
 
@@ -205,6 +207,32 @@ model PaymentLockout {
   @@unique([userId, paymentId])
   @@index([userId, paymentId])
   @@map("payment_lockouts")
+}
+
+model PasswordResetToken {
+  id        String    @id @default(cuid())
+  userId    String    @map("user_id")
+  token     String    @unique
+  expiresAt DateTime  @map("expires_at")
+  usedAt    DateTime? @map("used_at")
+  createdAt DateTime  @default(now()) @map("created_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("password_reset_tokens")
+}
+
+model EmailVerificationToken {
+  id        String    @id @default(cuid())
+  userId    String    @map("user_id")
+  token     String    @unique
+  expiresAt DateTime  @map("expires_at")
+  usedAt    DateTime? @map("used_at")
+  createdAt DateTime  @default(now()) @map("created_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("email_verification_tokens")
 }
 
 // A/B Testing Framework

--- a/src/app/api/auth/__tests__/verify-email.test.ts
+++ b/src/app/api/auth/__tests__/verify-email.test.ts
@@ -1,0 +1,182 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for /api/auth/verify-email GET handler.
+ *
+ * Tests the four outcomes:
+ *   1. Missing token param → redirect to /login?error=missing-token
+ *   2. Token not found / expired / already used → redirect to /login?error=invalid-token
+ *   3. DB error → redirect to /login?error=verification-failed
+ *   4. Valid token → marks user verified, marks token used, calls trackEmailVerified,
+ *      redirects to /login?verified=true
+ */
+
+import { NextRequest } from 'next/server'
+
+// Mock prisma before importing the route
+jest.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    emailVerificationToken: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    user: {
+      update: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  },
+}))
+
+// Mock ga4 so trackEmailVerified can be asserted without window/gtag
+jest.mock('@/lib/ga4', () => ({
+  trackEmailVerified: jest.fn(),
+}))
+
+import prisma from '@/lib/prisma'
+import { trackEmailVerified } from '@/lib/ga4'
+import { GET } from '../verify-email/route'
+
+const mockFindUnique = prisma.emailVerificationToken.findUnique as jest.Mock
+const mockTransaction = prisma.$transaction as jest.Mock
+const mockTrackEmailVerified = trackEmailVerified as jest.Mock
+
+const BASE_URL = 'http://localhost:3000'
+
+function makeRequest(token?: string): NextRequest {
+  const url = token
+    ? `${BASE_URL}/api/auth/verify-email?token=${token}`
+    : `${BASE_URL}/api/auth/verify-email`
+  return new NextRequest(url)
+}
+
+describe('GET /api/auth/verify-email', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('missing token', () => {
+    it('redirects to /login?error=missing-token when no token param', async () => {
+      const req = makeRequest()
+      const res = await GET(req)
+
+      expect(res.status).toBe(307)
+      expect(res.headers.get('location')).toContain('/login?error=missing-token')
+      expect(mockFindUnique).not.toHaveBeenCalled()
+      expect(mockTrackEmailVerified).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('invalid / expired / used token', () => {
+    it('redirects to /login?error=invalid-token when token is not found', async () => {
+      mockFindUnique.mockResolvedValueOnce(null)
+
+      const req = makeRequest('unknown-token')
+      const res = await GET(req)
+
+      expect(res.status).toBe(307)
+      expect(res.headers.get('location')).toContain('/login?error=invalid-token')
+      expect(mockTransaction).not.toHaveBeenCalled()
+      expect(mockTrackEmailVerified).not.toHaveBeenCalled()
+    })
+
+    it('redirects to /login?error=invalid-token when token is expired', async () => {
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'tok_1',
+        userId: 'user_1',
+        token: 'expired-token',
+        expiresAt: new Date(Date.now() - 1000), // already expired
+        usedAt: null,
+      })
+
+      const req = makeRequest('expired-token')
+      const res = await GET(req)
+
+      expect(res.status).toBe(307)
+      expect(res.headers.get('location')).toContain('/login?error=invalid-token')
+      expect(mockTransaction).not.toHaveBeenCalled()
+      expect(mockTrackEmailVerified).not.toHaveBeenCalled()
+    })
+
+    it('redirects to /login?error=invalid-token when token has already been used', async () => {
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'tok_1',
+        userId: 'user_1',
+        token: 'used-token',
+        expiresAt: new Date(Date.now() + 60_000),
+        usedAt: new Date(),
+      })
+
+      const req = makeRequest('used-token')
+      const res = await GET(req)
+
+      expect(res.status).toBe(307)
+      expect(res.headers.get('location')).toContain('/login?error=invalid-token')
+      expect(mockTransaction).not.toHaveBeenCalled()
+      expect(mockTrackEmailVerified).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('database error', () => {
+    it('redirects to /login?error=verification-failed on unexpected DB error', async () => {
+      mockFindUnique.mockRejectedValueOnce(new Error('DB connection lost'))
+
+      const req = makeRequest('good-token')
+      const res = await GET(req)
+
+      expect(res.status).toBe(307)
+      expect(res.headers.get('location')).toContain('/login?error=verification-failed')
+      expect(mockTrackEmailVerified).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('successful verification', () => {
+    it('marks user emailVerified, marks token used, calls trackEmailVerified, redirects to /login?verified=true', async () => {
+      const userId = 'user_abc'
+      const tokenId = 'tok_abc'
+
+      mockFindUnique.mockResolvedValueOnce({
+        id: tokenId,
+        userId,
+        token: 'valid-token',
+        expiresAt: new Date(Date.now() + 60_000),
+        usedAt: null,
+      })
+      mockTransaction.mockResolvedValueOnce(undefined)
+
+      const req = makeRequest('valid-token')
+      const res = await GET(req)
+
+      // Verify transaction was called with both update operations
+      expect(mockTransaction).toHaveBeenCalledTimes(1)
+      const [ops] = mockTransaction.mock.calls[0]
+      expect(Array.isArray(ops)).toBe(true)
+      expect(ops).toHaveLength(2)
+
+      // trackEmailVerified fires with the correct userId
+      expect(mockTrackEmailVerified).toHaveBeenCalledTimes(1)
+      expect(mockTrackEmailVerified).toHaveBeenCalledWith(userId)
+
+      // Redirects to success
+      expect(res.status).toBe(307)
+      expect(res.headers.get('location')).toContain('/login?verified=true')
+    })
+
+    it('does not call trackEmailVerified when transaction fails', async () => {
+      mockFindUnique.mockResolvedValueOnce({
+        id: 'tok_1',
+        userId: 'user_1',
+        token: 'valid-token',
+        expiresAt: new Date(Date.now() + 60_000),
+        usedAt: null,
+      })
+      mockTransaction.mockRejectedValueOnce(new Error('Transaction failed'))
+
+      const req = makeRequest('valid-token')
+      const res = await GET(req)
+
+      expect(mockTrackEmailVerified).not.toHaveBeenCalled()
+      expect(res.headers.get('location')).toContain('/login?error=verification-failed')
+    })
+  })
+})

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import bcrypt from 'bcryptjs'
+import crypto from 'crypto'
 import prisma from '@/lib/prisma'
 import { sendWelcomeEmail } from '@/lib/email/welcome'
+import { sendVerificationEmail } from '@/lib/email/verify-email'
+
+// Verification token expires in 24 hours
+const VERIFICATION_TOKEN_EXPIRY_MS = 24 * 60 * 60 * 1000
 
 // Simple in-memory rate limiter for signup attempts
 // For production, use @upstash/ratelimit with Redis
@@ -91,7 +96,25 @@ export async function POST(req: NextRequest) {
       },
     })
 
+    // Generate and store an email verification token
+    const verificationToken = crypto.randomBytes(32).toString('hex')
+    const verificationExpiresAt = new Date(Date.now() + VERIFICATION_TOKEN_EXPIRY_MS)
+
+    await prisma.emailVerificationToken.create({
+      data: {
+        userId: user.id,
+        token: verificationToken,
+        expiresAt: verificationExpiresAt,
+      },
+    })
+
     // Non-blocking — fire and forget so signup response is never delayed
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://getgroomgrid.com'
+    const verifyUrl = `${appUrl}/api/auth/verify-email?token=${verificationToken}`
+
+    sendVerificationEmail(user.email, verifyUrl).catch(err =>
+      console.error('Verification email failed:', err)
+    )
     sendWelcomeEmail(user.email, businessName).catch(err =>
       console.error('Welcome email failed:', err)
     )

--- a/src/app/api/auth/verify-email/route.ts
+++ b/src/app/api/auth/verify-email/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { trackEmailVerified } from '@/lib/ga4'
+
+export async function GET(req: NextRequest) {
+  const token = req.nextUrl.searchParams.get('token')
+
+  if (!token) {
+    return NextResponse.redirect(new URL('/login?error=missing-token', req.url))
+  }
+
+  try {
+    const record = await prisma.emailVerificationToken.findUnique({
+      where: { token },
+    })
+
+    if (!record || record.expiresAt < new Date() || record.usedAt) {
+      return NextResponse.redirect(new URL('/login?error=invalid-token', req.url))
+    }
+
+    await prisma.$transaction([
+      prisma.user.update({
+        where: { id: record.userId },
+        data: { emailVerified: true },
+      }),
+      prisma.emailVerificationToken.update({
+        where: { id: record.id },
+        data: { usedAt: new Date() },
+      }),
+    ])
+
+    // Wire: fires once, on the success path only
+    trackEmailVerified(record.userId)
+
+    return NextResponse.redirect(new URL('/login?verified=true', req.url))
+  } catch (error) {
+    console.error('Email verification error:', error)
+    return NextResponse.redirect(new URL('/login?error=verification-failed', req.url))
+  }
+}

--- a/src/lib/email/verify-email.ts
+++ b/src/lib/email/verify-email.ts
@@ -1,0 +1,105 @@
+/**
+ * Email verification email template.
+ *
+ * Sent when a new user completes signup. Contains a one-time link that
+ * marks their email address as verified and unlocks full app access.
+ */
+
+import { FROM_EMAIL, getResend } from './resend'
+
+const BRAND = {
+  primary: '#22c55e',
+  bg: '#fafaf9',
+  text: '#292524',
+  textMuted: '#78716c',
+  border: '#e7e5e4',
+  white: '#ffffff',
+}
+
+function emailWrapper(body: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Verify Your Email — GroomGrid</title>
+</head>
+<body style="margin:0;padding:0;background-color:${BRAND.bg};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,sans-serif;color:${BRAND.text};">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:${BRAND.bg};padding:40px 20px;">
+    <tr>
+      <td align="center">
+        <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background-color:${BRAND.white};border-radius:12px;border:1px solid ${BRAND.border};overflow:hidden;">
+          <tr>
+            <td style="background-color:${BRAND.primary};padding:24px 32px;">
+              <p style="margin:0;font-size:22px;font-weight:700;color:${BRAND.white};letter-spacing:-0.5px;">Verify Your Email Address</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:32px;">
+              ${body}
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px 32px;border-top:1px solid ${BRAND.border};background-color:${BRAND.bg};">
+              <p style="margin:0;font-size:13px;color:${BRAND.textMuted};text-align:center;">
+                Powered by GroomGrid
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
+/**
+ * Send an email verification link to a newly registered user.
+ *
+ * @param to - User's email address
+ * @param verifyUrl - The verification link URL (includes one-time token)
+ */
+export async function sendVerificationEmail(to: string, verifyUrl: string): Promise<void> {
+  const html = emailWrapper(`
+    <h1 style="margin:0 0 16px 0;font-size:24px;font-weight:700;color:${BRAND.text};line-height:1.3;">
+      One quick step!
+    </h1>
+    <p style="margin:0 0 20px 0;font-size:15px;line-height:1.6;color:${BRAND.text};">
+      Thanks for signing up for GroomGrid. Please verify your email address to activate your account.
+    </p>
+    <p style="margin:0 0 24px 0;font-size:15px;line-height:1.6;color:${BRAND.text};">
+      This link will expire in 24 hours. If you didn't create an account, you can safely ignore this email.
+    </p>
+    <table cellpadding="0" cellspacing="0" style="width:100%;margin:20px 0;">
+      <tr>
+        <td align="center">
+          <a href="${verifyUrl}" style="display:inline-block;background-color:${BRAND.primary};color:${BRAND.white};font-weight:600;font-size:16px;padding:16px 32px;border-radius:8px;text-decoration:none;">
+            Verify My Email
+          </a>
+        </td>
+      </tr>
+    </table>
+    <p style="margin:0 0 14px 0;font-size:14px;line-height:1.6;color:${BRAND.textMuted};">
+      If the button doesn't work, copy and paste this link:<br/>
+      <span style="color:${BRAND.primary};word-break:break-all;">${verifyUrl}</span>
+    </p>
+  `);
+
+  const text = `Verify Your Email Address
+
+Thanks for signing up for GroomGrid. Please verify your email address to activate your account.
+
+Click the link below to verify:
+${verifyUrl}
+
+This link will expire in 24 hours. If you didn't create an account, you can safely ignore this email.`;
+
+  await getResend().emails.send({
+    from: FROM_EMAIL,
+    to,
+    subject: 'Verify your GroomGrid email address',
+    html,
+    text,
+  });
+}


### PR DESCRIPTION
## Summary

- **`prisma/schema.prisma`** — Added `PasswordResetToken` (was used in code but missing from schema) and `EmailVerificationToken` models; added both relations to `User`
- **`prisma/migrations/20260417000002_add_token_models/`** — Idempotent SQL migration with `IF NOT EXISTS` guards for both token tables
- **`src/lib/email/verify-email.ts`** — Verification email template following the existing `password-reset.ts` pattern
- **`src/app/api/auth/signup/route.ts`** — After user creation: generate + store verification token, send verification email alongside welcome email
- **`src/app/api/auth/verify-email/route.ts`** — `GET` handler: validates token, runs `$transaction` to set `user.emailVerified=true` and mark token used, then calls `trackEmailVerified(userId)` on the success path only
- **`src/app/api/auth/__tests__/verify-email.test.ts`** — 7 unit tests: missing token, not-found/expired/used token, DB error, success path (trackEmailVerified call verified)

## Test plan

- [x] `npm test -- --testPathPatterns="verify-email"` → 7/7 pass
- [x] `npm test -- --testPathPatterns="ga4"` → 247/247 pass (no regressions)
- [x] `trackEmailVerified(userId)` called exactly once on success path, never on failure paths (tested)
- [x] Token validated: not null, not expired, not already used
- [x] DB transaction atomically sets `emailVerified=true` and stamps `usedAt`

## ⚠️ Merge blocker

**Do NOT merge until Mailgun PR #127 is confirmed live in production.** The verification email is sent via the same `getResend()` / Mailgun transport. If email delivery is broken, users will never receive the verification link and the feature is DOA.

## Context

This closes the final client-side gap in the GA4 funnel (`trackEmailVerified` was fully implemented with 100% test coverage but had no call site anywhere in the app — because the entire email verification feature was missing).

Related: Deploy end-to-end conversion tracking rock (83.3% → next checkpoint after Mailgun lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)