### PR TITLE
fix(migrations): add missing timezone column migration

### DIFF
--- a/prisma/migrations/20260417000002_add_timezone_to_users/migration.sql
+++ b/prisma/migrations/20260417000002_add_timezone_to_users/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable: add timezone column to users
+-- Context: column was manually added to production on 2026-04-17 after a live incident
+-- where missing column was blocking all signups. Migration file was never committed.
+-- IF NOT EXISTS guard makes this idempotent — safe to deploy on envs already patched manually.
+
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "timezone" TEXT NOT NULL DEFAULT 'America/New_York';


### PR DESCRIPTION
## Summary
- Adds the missing `prisma/migrations/20260417000002_add_timezone_to_users/migration.sql` that was never committed after production was manually patched during a live signup-blocking incident on 2026-04-17
- Uses `ALTER TABLE "users" ADD COLUMN IF NOT EXISTS` — idempotent, safe to run on prod (column already exists) and staging (column missing)
- `schema.prisma` already has the `timezone` field; this migration closes the schema/migration-history drift

## ⚠️ Important findings from diagnosis
1. **Staging DB is not patched** — the `_prisma_migrations` table doesn't exist on staging and the `timezone` column is absent. The mission doc said staging was manually patched but that's incorrect. Running `prisma migrate deploy` on staging will correctly add the column via this migration.
2. **Production `_prisma_migrations` gap** — prod has the column but it's not recorded in `_prisma_migrations` (only `20260415085356_init` and `20240414_add_payment_event_model` are tracked). The `IF NOT EXISTS` guard means `prisma migrate deploy` will succeed without error, but the column addition step will be a no-op. To record it cleanly: run `prisma migrate resolve --applied 20260417000002_add_timezone_to_users` on prod after merging.

## Test plan
- [ ] Merge PR → verify CI passes
- [ ] On prod: run `prisma migrate resolve --applied 20260417000002_add_timezone_to_users` to register the migration as applied without re-running it
- [ ] On staging: run `prisma migrate deploy` — should create `_prisma_migrations` table and apply all migrations including this one
- [ ] Verify `SELECT timezone FROM users LIMIT 1;` returns results on both envs

🤖 Generated with [Claude Code](https://claude.com/claude-code)