### PR TITLE
feat: BETA50 promo code and direct Stripe paid signup path

### DIFF
--- a/src/app/api/checkout/session/route.ts
+++ b/src/app/api/checkout/session/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
+import { requireEnvVar } from '@/lib/validation';
+
+const VALID_PLANS = ['solo', 'salon', 'enterprise'] as const;
+type PlanType = typeof VALID_PLANS[number];
+
+function getStripe(): Stripe {
+  return new Stripe(requireEnvVar('STRIPE_SECRET_KEY'), {
+    apiVersion: '2023-10-16',
+  });
+}
+
+function getPriceId(plan: PlanType): string {
+  const priceMap: Record<PlanType, string> = {
+    solo: requireEnvVar('STRIPE_PRICE_SOLO'),
+    salon: requireEnvVar('STRIPE_PRICE_SALON'),
+    enterprise: requireEnvVar('STRIPE_PRICE_ENTERPRISE'),
+  };
+  return priceMap[plan];
+}
+
+/**
+ * GET /api/checkout/session?plan=solo|salon|enterprise
+ *
+ * Creates a Stripe Checkout session with BETA50 coupon pre-applied and
+ * redirects (307) the user directly to the Stripe-hosted checkout page.
+ * No authentication required — this is an anonymous checkout entry point.
+ */
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const plan = searchParams.get('plan');
+
+  if (!plan) {
+    return NextResponse.json({ error: 'Missing plan parameter' }, { status: 400 });
+  }
+
+  if (!(VALID_PLANS as readonly string[]).includes(plan)) {
+    return NextResponse.json({ error: 'Invalid plan. Must be solo, salon, or enterprise.' }, { status: 400 });
+  }
+
+  const validPlan = plan as PlanType;
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://getgroomgrid.com';
+
+  try {
+    const stripe = getStripe();
+    const priceId = getPriceId(validPlan);
+
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      payment_method_types: ['card'],
+      line_items: [{ price: priceId, quantity: 1 }],
+      discounts: [{ coupon: 'BETA50' }],
+      allow_promotion_codes: false,
+      success_url: `${appUrl}/checkout/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${appUrl}/plans`,
+    });
+
+    if (!session.url) {
+      return NextResponse.json({ error: 'Failed to create checkout session' }, { status: 500 });
+    }
+
+    return NextResponse.redirect(session.url, 307);
+  } catch (error: any) {
+    console.error('[/api/checkout/session] Stripe error:', error?.message || error);
+    return NextResponse.json({ error: 'Failed to create checkout session' }, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -73,6 +73,14 @@ export default function HomePage() {
   return (
     <div className="min-h-screen bg-white text-stone-900">
 
+      {/* ── Promo Banner ── */}
+      <div className="bg-green-600 text-white text-center py-2.5 px-4 text-sm font-semibold">
+        🎉 Launch Special — <span className="font-bold underline">BETA50</span>: 50% off for first 100 subscribers. No waitlist.{' '}
+        <Link href="/plans" className="underline hover:text-green-100 transition-colors">
+          See plans →
+        </Link>
+      </div>
+
       {/* ── Nav ── */}
       <nav className="flex items-center justify-between px-6 py-4 max-w-5xl mx-auto border-b border-stone-100">
         <span className="text-xl font-bold text-green-600">GroomGrid 🐾</span>

--- a/src/app/plans/page.tsx
+++ b/src/app/plans/page.tsx
@@ -210,6 +210,13 @@ function PlansPageInner() {
         </div>
       </header>
 
+      {/* BETA50 Promo Banner */}
+      <div className="bg-green-600 text-white text-center py-3 px-4">
+        <p className="text-sm font-semibold">
+          🎉 Launch Special: Use code <span className="font-bold underline">BETA50</span> for 50% off your first month! Limited to first 100 users.
+        </p>
+      </div>
+
       <main className="max-w-7xl mx-auto px-4 py-12">
         {/* Schema.org OfferCatalog structured data for rich results */}
         <Script

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -174,7 +174,15 @@ function SignupPageInner() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 to-stone-50 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-green-50 to-stone-50 flex flex-col items-center justify-center p-4">
+      {/* BETA50 Promo Banner */}
+      <div className="w-full max-w-3xl mb-3 bg-green-600 text-white text-center py-2.5 px-4 rounded-xl text-sm font-semibold">
+        🎉 Launch Special — use code <span className="font-bold underline">BETA50</span> for 50% off your first month!{' '}
+        <Link href="/plans" className="underline hover:text-green-100 transition-colors">
+          View plans →
+        </Link>
+      </div>
+
       {/* Card — single column on mobile, two columns on md+ */}
       <div className="bg-white rounded-2xl shadow-xl w-full max-w-3xl signup-card overflow-hidden grid md:grid-cols-[1fr_1.1fr]">
 

--- a/src/tests/stripe/checkout-session-route.unit.test.ts
+++ b/src/tests/stripe/checkout-session-route.unit.test.ts
@@ -1,0 +1,290 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for GET /api/checkout/session
+ *
+ * This route creates a Stripe Checkout session with BETA50 pre-applied and
+ * redirects (307) to the Stripe-hosted checkout URL.
+ *
+ * Coverage:
+ *  - Valid plan param creates checkout session and redirects
+ *  - BETA50 coupon is always pre-applied (discounts param)
+ *  - allow_promotion_codes is false when coupon is pre-applied
+ *  - Invalid plan param → 400
+ *  - Missing plan param → 400
+ *  - Stripe error → 500
+ *  - Session without URL → 500
+ *  - All three valid plans (solo/salon/enterprise)
+ */
+
+// ── Mocks (hoisted above imports) ─────────────────────────────────────────────
+
+jest.mock('stripe', () => {
+  const mockCreate = jest.fn();
+  const MockStripe = jest.fn().mockImplementation(() => ({
+    checkout: {
+      sessions: {
+        create: mockCreate,
+      },
+    },
+  }));
+  (MockStripe as any).__mockCreate = mockCreate;
+  return { __esModule: true, default: MockStripe };
+});
+
+jest.mock('@/lib/validation', () => ({
+  __esModule: true,
+  requireEnvVar: jest.fn((name: string) => {
+    const vars: Record<string, string> = {
+      STRIPE_SECRET_KEY: 'sk_test_mock_key',
+      STRIPE_PRICE_SOLO: 'price_mock_solo',
+      STRIPE_PRICE_SALON: 'price_mock_salon',
+      STRIPE_PRICE_ENTERPRISE: 'price_mock_enterprise',
+    };
+    return vars[name] ?? `mock_${name}`;
+  }),
+}));
+
+// ── Imports ────────────────────────────────────────────────────────────────────
+
+import { NextRequest } from 'next/server';
+import { GET } from '@/app/api/checkout/session/route';
+import Stripe from 'stripe';
+
+// Access the mock create function via the mock
+function getMockCreate(): jest.MockedFunction<any> {
+  const MockStripe = Stripe as unknown as jest.MockedClass<any>;
+  return MockStripe.__mockCreate;
+}
+
+function makeRequest(url: string): NextRequest {
+  return new NextRequest(url);
+}
+
+const MOCK_CHECKOUT_URL = 'https://checkout.stripe.com/c/pay/cs_test_mock_abc';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Valid plan → redirect
+// ─────────────────────────────────────────────────────────────────────────────
+describe('GET /api/checkout/session — valid plans', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getMockCreate().mockResolvedValue({ id: 'cs_test_mock_abc', url: MOCK_CHECKOUT_URL });
+  });
+
+  it('redirects (307) to Stripe checkout URL for solo plan', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe(MOCK_CHECKOUT_URL);
+  });
+
+  it('redirects (307) to Stripe checkout URL for salon plan', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=salon');
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe(MOCK_CHECKOUT_URL);
+  });
+
+  it('redirects (307) to Stripe checkout URL for enterprise plan', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=enterprise');
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe(MOCK_CHECKOUT_URL);
+  });
+
+  it('calls stripe.checkout.sessions.create once per request', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    await GET(req);
+
+    expect(getMockCreate()).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BETA50 coupon pre-applied
+// ─────────────────────────────────────────────────────────────────────────────
+describe('GET /api/checkout/session — BETA50 coupon', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getMockCreate().mockResolvedValue({ id: 'cs_test_mock_abc', url: MOCK_CHECKOUT_URL });
+  });
+
+  it('passes BETA50 as a discount coupon in the Stripe session params', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    await GET(req);
+
+    const [params] = getMockCreate().mock.calls[0];
+    expect(params.discounts).toEqual([{ coupon: 'BETA50' }]);
+  });
+
+  it('sets allow_promotion_codes to false (coupon is pre-applied)', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    await GET(req);
+
+    const [params] = getMockCreate().mock.calls[0];
+    expect(params.allow_promotion_codes).toBe(false);
+  });
+
+  it('uses subscription mode', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    await GET(req);
+
+    const [params] = getMockCreate().mock.calls[0];
+    expect(params.mode).toBe('subscription');
+  });
+
+  it('includes correct price ID for solo plan', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    await GET(req);
+
+    const [params] = getMockCreate().mock.calls[0];
+    expect(params.line_items[0].price).toBe('price_mock_solo');
+    expect(params.line_items[0].quantity).toBe(1);
+  });
+
+  it('includes correct price ID for salon plan', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=salon');
+    await GET(req);
+
+    const [params] = getMockCreate().mock.calls[0];
+    expect(params.line_items[0].price).toBe('price_mock_salon');
+  });
+
+  it('includes correct price ID for enterprise plan', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=enterprise');
+    await GET(req);
+
+    const [params] = getMockCreate().mock.calls[0];
+    expect(params.line_items[0].price).toBe('price_mock_enterprise');
+  });
+
+  it('sets success_url with CHECKOUT_SESSION_ID placeholder', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    await GET(req);
+
+    const [params] = getMockCreate().mock.calls[0];
+    expect(params.success_url).toContain('{CHECKOUT_SESSION_ID}');
+    expect(params.success_url).toContain('/checkout/success');
+  });
+
+  it('sets cancel_url to /plans', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    await GET(req);
+
+    const [params] = getMockCreate().mock.calls[0];
+    expect(params.cancel_url).toContain('/plans');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Validation — missing or invalid plan param
+// ─────────────────────────────────────────────────────────────────────────────
+describe('GET /api/checkout/session — validation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getMockCreate().mockResolvedValue({ id: 'cs_test_mock', url: MOCK_CHECKOUT_URL });
+  });
+
+  it('returns 400 when plan param is missing', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session');
+    const res = await GET(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/missing plan/i);
+  });
+
+  it('does NOT call Stripe when plan param is missing', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session');
+    await GET(req);
+
+    expect(getMockCreate()).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid plan "premium"', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=premium');
+    const res = await GET(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid plan/i);
+  });
+
+  it('returns 400 for invalid plan "free"', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=free');
+    const res = await GET(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for uppercase plan (case-sensitive)', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=SOLO');
+    const res = await GET(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for empty plan param', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=');
+    const res = await GET(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('does NOT call Stripe for invalid plan', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=bogus');
+    await GET(req);
+
+    expect(getMockCreate()).not.toHaveBeenCalled();
+  });
+
+  it.each(['solo', 'salon', 'enterprise'])('accepts valid plan "%s" without error', async (plan) => {
+    const req = makeRequest(`http://localhost:3000/api/checkout/session?plan=${plan}`);
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error handling
+// ─────────────────────────────────────────────────────────────────────────────
+describe('GET /api/checkout/session — error handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 500 when Stripe throws an error', async () => {
+    getMockCreate().mockRejectedValueOnce(new Error('Stripe network error'));
+
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    const res = await GET(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBeDefined();
+  });
+
+  it('returns 500 when Stripe session has no URL', async () => {
+    getMockCreate().mockResolvedValueOnce({ id: 'cs_no_url', url: null });
+
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    const res = await GET(req);
+
+    expect(res.status).toBe(500);
+  });
+
+  it('returns JSON error body on Stripe failure', async () => {
+    getMockCreate().mockRejectedValueOnce(new Error('Connection timeout'));
+
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=salon');
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(body).toHaveProperty('error');
+  });
+});


### PR DESCRIPTION
## Summary
- Verifies BETA50 Stripe coupon exists (50% off, max 100 redemptions, applied once to first month)
- Adds `/api/checkout/session?plan=solo|salon|enterprise` GET route that creates a Stripe Checkout session with BETA50 pre-applied and redirects (307) to Stripe-hosted checkout — no auth required, direct conversion path
- Adds promo banners to homepage (above nav), plans page (below header), and signup page (above form card) all showing the BETA50 code with a link to /plans
- 25 unit tests for the new checkout session route covering valid plans, BETA50 coupon params, `allow_promotion_codes: false`, invalid/missing plan → 400, Stripe errors → 500, and session without URL → 500

## Test plan
- [ ] Visit `/plans` — see green BETA50 promo banner, click plan CTA → checkout flow with 50% discount pre-applied
- [ ] Visit homepage — see green promo banner above nav with BETA50 code and "See plans →" link
- [ ] Visit `/signup` — see green promo banner above the card with BETA50 code and "View plans →" link
- [ ] `GET /api/checkout/session?plan=solo` → 307 redirect to Stripe Checkout URL with BETA50 coupon
- [ ] `GET /api/checkout/session?plan=bogus` → 400 JSON error
- [ ] `GET /api/checkout/session` (no plan) → 400 JSON error
- [ ] 25 jest unit tests pass: `npm test -- checkout-session-route`

🤖 Generated with [Claude Code](https://claude.com/claude-code)