### PR TITLE
fix(checkout): remove allow_promotion_codes when discounts is set

### DIFF
--- a/src/app/api/checkout/session/route.ts
+++ b/src/app/api/checkout/session/route.ts
@@ -50,8 +50,9 @@ export async function GET(req: NextRequest) {
       mode: 'subscription',
       payment_method_types: ['card'],
       line_items: [{ price: priceId, quantity: 1 }],
+      // Pre-apply BETA50 coupon. Note: allow_promotion_codes cannot be set when
+      // discounts is specified — Stripe enforces mutual exclusivity.
       discounts: [{ coupon: 'BETA50' }],
-      allow_promotion_codes: false,
       success_url: `${appUrl}/checkout/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${appUrl}/plans`,
     });

--- a/src/tests/stripe/checkout-session-route.unit.test.ts
+++ b/src/tests/stripe/checkout-session-route.unit.test.ts
@@ -9,7 +9,7 @@
  * Coverage:
  *  - Valid plan param creates checkout session and redirects
  *  - BETA50 coupon is always pre-applied (discounts param)
- *  - allow_promotion_codes is false when coupon is pre-applied
+ *  - allow_promotion_codes is omitted (Stripe mutual exclusivity with discounts)
  *  - Invalid plan param → 400
  *  - Missing plan param → 400
  *  - Stripe error → 500
@@ -121,12 +121,14 @@ describe('GET /api/checkout/session — BETA50 coupon', () => {
     expect(params.discounts).toEqual([{ coupon: 'BETA50' }]);
   });
 
-  it('sets allow_promotion_codes to false (coupon is pre-applied)', async () => {
+  it('does not set allow_promotion_codes when coupon is pre-applied (Stripe mutual exclusivity)', async () => {
     const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
     await GET(req);
 
     const [params] = getMockCreate().mock.calls[0];
-    expect(params.allow_promotion_codes).toBe(false);
+    // Stripe requires discounts and allow_promotion_codes to be mutually exclusive.
+    // When discounts is specified, allow_promotion_codes must be omitted entirely.
+    expect(params.allow_promotion_codes).toBeUndefined();
   });
 
   it('uses subscription mode', async () => {


### PR DESCRIPTION
## Summary
- Stripe throws `You may only specify one of these parameters: allow_promotion_codes, discounts` when both are passed simultaneously
- The `/api/checkout/session?plan=*` endpoint was returning 500 on every request because it set both `discounts: [{ coupon: 'BETA50' }]` and `allow_promotion_codes: false`
- Fix: remove `allow_promotion_codes` entirely — it's implicit (and prohibited) when `discounts` is specified

## Test plan
- [x] Test updated to assert `allow_promotion_codes` is `undefined` (not `false`)
- [x] `GET /api/checkout/session?plan=solo` → now correctly redirects to Stripe Checkout with BETA50 applied
- [x] `GET /api/checkout/session?plan=bogus` → still returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)