### PR TITLE
fix(mobile): Add keyboard-aware scroll handling on login and signup

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -19,6 +19,22 @@ function LoginForm() {
     if (urlError) setError(decodeURIComponent(urlError));
   }, [searchParams]);
 
+  // Mobile keyboard handling: scroll focused inputs into view
+  useEffect(() => {
+    const handleFocus = (e: FocusEvent) => {
+      const target = e.target as HTMLElement;
+      if (target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA') {
+        // Small delay so the keyboard has time to appear
+        setTimeout(() => {
+          target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }, 300);
+      }
+    };
+
+    document.addEventListener('focusin', handleFocus);
+    return () => document.removeEventListener('focusin', handleFocus);
+  }, []);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -93,6 +93,21 @@ function SignupPageInner() {
     return () => observer.disconnect();
   }, []);
 
+  // Mobile keyboard handling: scroll focused inputs into view on mobile
+  useEffect(() => {
+    const handleFocus = (e: FocusEvent) => {
+      const target = e.target as HTMLElement;
+      if (target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA') {
+        setTimeout(() => {
+          target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }, 300);
+      }
+    };
+
+    document.addEventListener('focusin', handleFocus);
+    return () => document.removeEventListener('focusin', handleFocus);
+  }, []);
+
   const handleFieldChange = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
     clearFieldError(field);


### PR DESCRIPTION
## Summary
- Adds `focusin` event listener on login and signup pages that scrolls the active input into view after a 300ms delay (to account for virtual keyboard animation)
- Critical UX fix for our mobile groomer ICP who use the app on phones in their vans — the mobile keyboard often covers the input field being typed into, making it impossible to see what you're entering
- Lightweight implementation: no dependencies, no layout shift, just smooth scrolling on focus

## Why This Matters
Our core ICP (Independent Mobile Groomer) uses GroomGrid on their phone while in the van. Mobile keyboards cover ~40% of the viewport, making form fields invisible. This is a top conversion killer on mobile.

## Test Plan
- [ ] On mobile browser: tap email field → field scrolls into view above keyboard
- [ ] On mobile browser: tap password field → field scrolls into view above keyboard
- [ ] On desktop: no visible change in behavior
- [ ] On signup page: same behavior for all form fields (email, password, business name)