### PR TITLE
feat: add 9 missing blog pages (404 recovery)

### DIFF
--- a/src/__tests__/sitemap.test.ts
+++ b/src/__tests__/sitemap.test.ts
@@ -123,7 +123,7 @@ describe('Sitemap Generation', () => {
   it('should have total entries matching all pages', () => {
     const result = sitemap();
 
-    // 4 static pages + 5 landing pages + 8 blog posts = 17 total
-    expect(result.length).toBe(17);
+    // 4 static pages + 5 landing pages + 17 blog posts = 26 total
+    expect(result.length).toBe(26);
   });
 });

--- a/src/app/blog/best-pet-grooming-software/page.tsx
+++ b/src/app/blog/best-pet-grooming-software/page.tsx
@@ -1,0 +1,342 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Script from 'next/script';
+
+export const metadata: Metadata = {
+  title: 'Best Pet Grooming Software in 2026: Top Picks for Professional Groomers | GroomGrid',
+  description:
+    'The best pet grooming software for 2026 — reviewed and compared. Find the right platform for solo groomers, mobile businesses, and small salons based on features, pricing, and ease of use.',
+  alternates: {
+    canonical: 'https://getgroomgrid.com/blog/best-pet-grooming-software',
+  },
+  openGraph: {
+    title: 'Best Pet Grooming Software in 2026: Top Picks for Professional Groomers',
+    description:
+      'The best pet grooming software for 2026 — reviewed and compared. Find the right platform for solo groomers, mobile businesses, and small salons based on features, pricing, and ease of use.',
+    url: 'https://getgroomgrid.com/blog/best-pet-grooming-software',
+    type: 'article',
+  },
+};
+
+const breadcrumbSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://getgroomgrid.com' },
+    { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://getgroomgrid.com/blog' },
+    {
+      '@type': 'ListItem',
+      position: 3,
+      name: 'Best Pet Grooming Software',
+      item: 'https://getgroomgrid.com/blog/best-pet-grooming-software',
+    },
+  ],
+};
+
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'Best Pet Grooming Software in 2026: Top Picks for Professional Groomers',
+  description:
+    'The best pet grooming software for 2026 — reviewed and compared. Find the right platform for solo groomers, mobile businesses, and small salons based on features, pricing, and ease of use.',
+  url: 'https://getgroomgrid.com/blog/best-pet-grooming-software',
+  publisher: {
+    '@type': 'Organization',
+    name: 'GroomGrid',
+    url: 'https://getgroomgrid.com',
+    logo: { '@type': 'ImageObject', url: 'https://getgroomgrid.com/favicon.ico' },
+  },
+  mainEntityOfPage: {
+    '@type': 'WebPage',
+    '@id': 'https://getgroomgrid.com/blog/best-pet-grooming-software',
+  },
+};
+
+export default function BestPetGroomingSoftwarePage() {
+  return (
+    <>
+      <Script
+        id="breadcrumb-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <Script
+        id="article-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+
+      <div className="min-h-screen bg-white text-stone-900">
+        {/* ── Nav ── */}
+        <nav className="flex items-center justify-between px-6 py-4 max-w-5xl mx-auto border-b border-stone-100">
+          <Link href="/" className="text-xl font-bold text-green-600">
+            GroomGrid 🐾
+          </Link>
+          <Link
+            href="/signup?coupon=BETA50"
+            className="px-4 py-2 rounded-lg bg-green-500 text-white text-sm font-semibold hover:bg-green-600 transition-colors"
+          >
+            Start Free Trial
+          </Link>
+        </nav>
+
+        {/* ── Breadcrumb ── */}
+        <div className="px-6 py-3 max-w-5xl mx-auto">
+          <nav aria-label="Breadcrumb" className="text-sm text-stone-500">
+            <ol className="flex items-center gap-2">
+              <li><Link href="/" className="hover:text-green-600 transition-colors">Home</Link></li>
+              <li aria-hidden="true">/</li>
+              <li><Link href="/blog" className="hover:text-green-600 transition-colors">Blog</Link></li>
+              <li aria-hidden="true">/</li>
+              <li className="text-stone-700 font-medium" aria-current="page">Best Pet Grooming Software</li>
+            </ol>
+          </nav>
+        </div>
+
+        {/* ── Hero ── */}
+        <header className="px-6 pt-10 pb-12 max-w-4xl mx-auto">
+          <p className="text-green-600 font-semibold text-sm uppercase tracking-widest mb-4">
+            Top Picks 2026
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-extrabold text-stone-900 leading-tight mb-6">
+            Best Pet Grooming Software in 2026:<br className="hidden sm:block" /> Ranked for Independent Groomers
+          </h1>
+          <p className="text-xl text-stone-600 leading-relaxed max-w-3xl">
+            There are more pet grooming software options than ever in 2026 — and not all of them are
+            worth your time or money. This guide cuts through the noise with honest assessments of the
+            top platforms, with specific recommendations based on your business type.
+          </p>
+        </header>
+
+        {/* ── What Makes Software &quot;Best&quot; ── */}
+        <section className="px-6 py-12 bg-green-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-2xl font-bold text-stone-800 mb-4">What Makes Grooming Software &ldquo;Best&rdquo;?</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              The best software isn&apos;t necessarily the one with the most features — it&apos;s the
+              one you&apos;ll actually use consistently. We evaluated platforms on five criteria:
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {[
+                ['Ease of setup', 'How fast can you go from signup to first booking?'],
+                ['Core features', 'Scheduling, reminders, client records, deposits, payments'],
+                ['Mobile experience', 'Can you manage your business from your phone?'],
+                ['Pricing transparency', 'What does it actually cost with all the features you need?'],
+                ['Support quality', 'When something breaks, can you get help quickly?'],
+              ].map(([label, desc]) => (
+                <div key={label} className="p-4 bg-white rounded-lg border border-stone-200">
+                  <p className="font-semibold text-stone-800 mb-1">{label}</p>
+                  <p className="text-sm text-stone-500">{desc}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Top Picks ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-8">Top Pet Grooming Software Platforms</h2>
+
+          {/* GroomGrid */}
+          <div className="mb-10 p-6 bg-green-50 rounded-xl border-2 border-green-300">
+            <div className="flex items-center gap-3 mb-3">
+              <span className="bg-green-600 text-white text-xs font-bold px-3 py-1 rounded-full">OUR PICK</span>
+              <h3 className="text-2xl font-bold text-stone-800">GroomGrid</h3>
+            </div>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              Built specifically for independent groomers and small teams. GroomGrid handles everything
+              from online booking to automated reminders to deposit collection in one straightforward
+              platform. Setup takes under 30 minutes, pricing is flat (no add-on fees), and the mobile
+              experience is genuinely designed for groomers who work from their phones.
+            </p>
+            <div className="grid grid-cols-2 gap-3 mb-4">
+              {[
+                ['Best for', 'Solo groomers, small salons, mobile operators'],
+                ['Standout feature', 'Automated rebooking reminders + easy deposit setup'],
+                ['Pricing', 'Simple flat rate, 50% off first month'],
+                ['Free trial', 'Yes'],
+              ].map(([label, val]) => (
+                <div key={label} className="text-sm">
+                  <span className="font-semibold text-stone-700">{label}: </span>
+                  <span className="text-stone-600">{val}</span>
+                </div>
+              ))}
+            </div>
+            <Link
+              href="/signup?coupon=BETA50"
+              className="inline-block px-5 py-2.5 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 transition-colors text-sm"
+            >
+              Try GroomGrid Free →
+            </Link>
+          </div>
+
+          {/* MoeGo */}
+          <div className="mb-10 p-6 bg-white rounded-xl border border-stone-200">
+            <h3 className="text-2xl font-bold text-stone-800 mb-3">MoeGo</h3>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              MoeGo is a feature-rich platform with a strong following in the grooming industry.
+              It&apos;s best suited for larger operations with multiple groomers, complex scheduling
+              needs, or dedicated admin staff to handle setup and configuration. The feature depth is
+              impressive but comes with a steeper learning curve and higher costs as you add features.
+            </p>
+            <div className="grid grid-cols-2 gap-3">
+              {[
+                ['Best for', 'Multi-groomer salons, enterprise operations'],
+                ['Standout feature', 'Deep customization options'],
+                ['Pricing', 'Tiered; costs increase with features/team size'],
+                ['Free trial', 'Limited free tier'],
+              ].map(([label, val]) => (
+                <div key={label} className="text-sm">
+                  <span className="font-semibold text-stone-700">{label}: </span>
+                  <span className="text-stone-600">{val}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Gingr */}
+          <div className="mb-10 p-6 bg-white rounded-xl border border-stone-200">
+            <h3 className="text-2xl font-bold text-stone-800 mb-3">Gingr</h3>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              Gingr is designed for full-service pet businesses — grooming, boarding, daycare, training —
+              all in one. If you only do grooming, you&apos;re paying for features you won&apos;t use.
+              For multi-service pet businesses, the integrated approach saves time. Pricing is on the
+              higher end and setup complexity reflects the broader scope.
+            </p>
+            <div className="grid grid-cols-2 gap-3">
+              {[
+                ['Best for', 'Multi-service pet businesses (boarding + grooming)'],
+                ['Standout feature', 'Integrated daycare and boarding management'],
+                ['Pricing', 'Higher; contact for quote'],
+                ['Free trial', 'Demo available'],
+              ].map(([label, val]) => (
+                <div key={label} className="text-sm">
+                  <span className="font-semibold text-stone-700">{label}: </span>
+                  <span className="text-stone-600">{val}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Decision Guide ── */}
+        <section className="px-6 py-14 bg-stone-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">Which One Should You Choose?</h2>
+            <div className="space-y-4">
+              {[
+                {
+                  scenario: "You're a solo groomer or running a small team",
+                  pick: 'GroomGrid — simple, fast setup, everything you need without paying for features you don\'t',
+                },
+                {
+                  scenario: "You're running a large salon with 10+ groomers",
+                  pick: 'MoeGo — the feature depth and customization suits complex multi-staff operations',
+                },
+                {
+                  scenario: "You offer boarding, daycare, AND grooming",
+                  pick: 'Gingr — the integrated multi-service approach will save you from juggling multiple tools',
+                },
+                {
+                  scenario: "You're just starting out and not sure",
+                  pick: 'GroomGrid — lowest barrier to entry, free trial, and you can switch later as your needs evolve',
+                },
+              ].map(({ scenario, pick }) => (
+                <div key={scenario} className="p-5 bg-white rounded-xl border border-stone-200">
+                  <p className="font-semibold text-stone-800 mb-1">If: {scenario}</p>
+                  <p className="text-stone-600 text-sm">Pick: {pick}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Conclusion ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">The Bottom Line</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            The best pet grooming software is the one that fits how your business actually works — not
+            the one with the longest feature list. For most independent groomers, that means something
+            that gets you operational quickly, prevents no-shows automatically, and doesn&apos;t require
+            a manual every time you want to change something.
+          </p>
+          <p className="text-stone-600 leading-relaxed">
+            You can also read our complete overview of{' '}
+            <Link
+              href="/blog/pet-grooming-software"
+              className="text-green-600 font-medium hover:text-green-700 underline underline-offset-2"
+            >
+              what pet grooming software is and how it works
+            </Link>
+            , or compare specific options in our{' '}
+            <Link
+              href="/blog/groomgrid-vs-moego"
+              className="text-green-600 font-medium hover:text-green-700 underline underline-offset-2"
+            >
+              GroomGrid vs MoeGo comparison
+            </Link>
+            .
+          </p>
+        </section>
+
+        {/* ── Signup CTA ── */}
+        <section className="px-6 py-16 bg-green-600 text-white">
+          <div className="max-w-3xl mx-auto text-center">
+            <h2 className="text-3xl font-extrabold mb-4">
+              Start with the best-rated option for independent groomers
+            </h2>
+            <p className="text-green-100 text-lg mb-8 leading-relaxed">
+              GroomGrid is built for groomers like you — solo operators and small teams who want
+              software that works without the complexity. Try it free with 50% off your first month.
+            </p>
+            <Link
+              href="/signup?coupon=BETA50"
+              className="px-8 py-4 rounded-xl bg-white text-green-700 font-bold text-lg hover:bg-green-50 transition-colors shadow-md inline-block"
+            >
+              Start Free Trial →
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Related Articles ── */}
+        <section className="px-6 py-12 max-w-5xl mx-auto">
+          <h2 className="text-xl font-bold text-stone-800 mb-6">Related Articles</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Link
+              href="/blog/groomgrid-vs-moego"
+              className="group p-5 border border-stone-200 rounded-xl hover:border-green-300 hover:shadow-md transition-all"
+            >
+              <p className="text-sm text-green-600 font-semibold mb-1">Comparison</p>
+              <h3 className="font-bold text-stone-800 group-hover:text-green-600 transition-colors">
+                GroomGrid vs MoeGo: An Honest Comparison
+              </h3>
+            </Link>
+            <Link
+              href="/blog/pet-grooming-software"
+              className="group p-5 border border-stone-200 rounded-xl hover:border-green-300 hover:shadow-md transition-all"
+            >
+              <p className="text-sm text-green-600 font-semibold mb-1">Software Guide</p>
+              <h3 className="font-bold text-stone-800 group-hover:text-green-600 transition-colors">
+                Pet Grooming Software: The Complete Beginner&apos;s Guide
+              </h3>
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Footer ── */}
+        <footer className="px-6 py-8 max-w-5xl mx-auto border-t border-stone-100 mt-0">
+          <div className="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-stone-400">
+            <Link href="/" className="font-bold text-green-600">GroomGrid 🐾</Link>
+            <div className="flex gap-6">
+              <Link href="/grooming-business-operations/" className="hover:text-stone-600 transition-colors">Operations Hub</Link>
+              <Link href="/mobile-grooming-business/" className="hover:text-stone-600 transition-colors">Mobile Grooming</Link>
+              <Link href="/plans" className="hover:text-stone-600 transition-colors">Pricing</Link>
+              <Link href="/signup?coupon=BETA50" className="hover:text-stone-600 transition-colors">Sign Up</Link>
+            </div>
+            <p>© {new Date().getFullYear()} GroomGrid. All rights reserved.</p>
+          </div>
+        </footer>
+      </div>
+    </>
+  );
+}

--- a/src/app/blog/dog-grooming-client-intake-form/page.tsx
+++ b/src/app/blog/dog-grooming-client-intake-form/page.tsx
@@ -1,0 +1,338 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Script from 'next/script';
+
+export const metadata: Metadata = {
+  title: 'Dog Grooming Client Intake Form: What to Ask Every New Client | GroomGrid',
+  description:
+    'A complete guide to dog grooming client intake forms — what questions to ask, what information protects your business, and how to collect it digitally without the paperwork.',
+  alternates: {
+    canonical: 'https://getgroomgrid.com/blog/dog-grooming-client-intake-form',
+  },
+  openGraph: {
+    title: 'Dog Grooming Client Intake Form: What to Ask Every New Client',
+    description:
+      'A complete guide to dog grooming client intake forms — what questions to ask, what information protects your business, and how to collect it digitally without the paperwork.',
+    url: 'https://getgroomgrid.com/blog/dog-grooming-client-intake-form',
+    type: 'article',
+  },
+};
+
+const breadcrumbSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://getgroomgrid.com' },
+    { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://getgroomgrid.com/blog' },
+    {
+      '@type': 'ListItem',
+      position: 3,
+      name: 'Dog Grooming Client Intake Form',
+      item: 'https://getgroomgrid.com/blog/dog-grooming-client-intake-form',
+    },
+  ],
+};
+
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'Dog Grooming Client Intake Form: What to Ask Every New Client',
+  description:
+    'A complete guide to dog grooming client intake forms — what questions to ask, what information protects your business, and how to collect it digitally without the paperwork.',
+  url: 'https://getgroomgrid.com/blog/dog-grooming-client-intake-form',
+  publisher: {
+    '@type': 'Organization',
+    name: 'GroomGrid',
+    url: 'https://getgroomgrid.com',
+    logo: { '@type': 'ImageObject', url: 'https://getgroomgrid.com/favicon.ico' },
+  },
+  mainEntityOfPage: {
+    '@type': 'WebPage',
+    '@id': 'https://getgroomgrid.com/blog/dog-grooming-client-intake-form',
+  },
+};
+
+export default function DogGroomingClientIntakeFormPage() {
+  return (
+    <>
+      <Script
+        id="breadcrumb-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <Script
+        id="article-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+
+      <div className="min-h-screen bg-white text-stone-900">
+        {/* ── Nav ── */}
+        <nav className="flex items-center justify-between px-6 py-4 max-w-5xl mx-auto border-b border-stone-100">
+          <Link href="/" className="text-xl font-bold text-green-600">
+            GroomGrid 🐾
+          </Link>
+          <Link
+            href="/signup?coupon=BETA50"
+            className="px-4 py-2 rounded-lg bg-green-500 text-white text-sm font-semibold hover:bg-green-600 transition-colors"
+          >
+            Start Free Trial
+          </Link>
+        </nav>
+
+        {/* ── Breadcrumb ── */}
+        <div className="px-6 py-3 max-w-5xl mx-auto">
+          <nav aria-label="Breadcrumb" className="text-sm text-stone-500">
+            <ol className="flex items-center gap-2">
+              <li><Link href="/" className="hover:text-green-600 transition-colors">Home</Link></li>
+              <li aria-hidden="true">/</li>
+              <li><Link href="/blog" className="hover:text-green-600 transition-colors">Blog</Link></li>
+              <li aria-hidden="true">/</li>
+              <li className="text-stone-700 font-medium" aria-current="page">Client Intake Form</li>
+            </ol>
+          </nav>
+        </div>
+
+        {/* ── Hero ── */}
+        <header className="px-6 pt-10 pb-12 max-w-4xl mx-auto">
+          <p className="text-green-600 font-semibold text-sm uppercase tracking-widest mb-4">
+            Templates & Forms
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-extrabold text-stone-900 leading-tight mb-6">
+            Dog Grooming Client Intake Form:<br className="hidden sm:block" /> Every Question You Should Be Asking
+          </h1>
+          <p className="text-xl text-stone-600 leading-relaxed max-w-3xl">
+            A thorough client intake form isn&apos;t just paperwork — it&apos;s how you protect the
+            dog, protect yourself, and give every client the personalized experience that keeps them
+            coming back. Here&apos;s exactly what to collect.
+          </p>
+        </header>
+
+        {/* ── Why It Matters ── */}
+        <section className="px-6 py-12 bg-green-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-2xl font-bold text-stone-800 mb-4">Why a Thorough Intake Form Matters</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              Groomers who skip intake forms work in the dark. They don&apos;t know the dog on heart
+              medication until they&apos;re already in a high-stress groom. They don&apos;t know the
+              owner&apos;s preferred cut until the dog is already trimmed. They don&apos;t have an
+              emergency contact when the dog has a reaction.
+            </p>
+            <p className="text-stone-600 leading-relaxed">
+              A good intake form collects everything you need to do the groom safely, deliver the
+              service the client actually wants, and protect your business if anything goes wrong.
+              Done right, it also signals professionalism — clients trust groomers who take the time
+              to ask the right questions.
+            </p>
+          </div>
+        </section>
+
+        {/* ── Section 1: Owner Info ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">Section 1: Owner Information</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Basic contact information plus the fields that matter most when something unexpected happens.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {[
+              'Full name',
+              'Phone number (primary)',
+              'Email address',
+              'Home address (required for mobile; helpful for salon)',
+              'Emergency contact name and phone',
+              'Preferred contact method (call/text/email)',
+              'How did you hear about us?',
+              'Any other pets in the household?',
+            ].map((field) => (
+              <div key={field} className="flex items-center gap-3 p-3 bg-stone-50 rounded-lg border border-stone-200">
+                <span className="text-green-500 font-bold">✓</span>
+                <span className="text-stone-700 text-sm">{field}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* ── Section 2: Pet Info ── */}
+        <section className="px-6 py-14 bg-stone-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">Section 2: Pet Profile</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              This is the heart of the intake form. The more you know about the dog before they arrive,
+              the better the groom — and the safer the experience.
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {[
+                'Pet name',
+                'Breed (or mix)',
+                'Age',
+                'Weight',
+                'Sex (neutered/spayed?)',
+                'Coat type and condition',
+                'Color and markings',
+                'Vaccination status (rabies, Bordetella)',
+                'Veterinarian name and phone',
+                'Last grooming date',
+                'Previous groomer (any notes?)',
+                'Microchip number (optional)',
+              ].map((field) => (
+                <div key={field} className="flex items-center gap-3 p-3 bg-white rounded-lg border border-stone-200">
+                  <span className="text-green-500 font-bold">✓</span>
+                  <span className="text-stone-700 text-sm">{field}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Section 3: Health ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">Section 3: Health and Medical History</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            This section protects the dog and protects you. Always get this information in writing —
+            especially for medications and known conditions.
+          </p>
+          <ul className="space-y-3">
+            {[
+              'Current medications (name, dosage, frequency)',
+              'Known allergies (shampoos, products, environmental)',
+              'Heart or respiratory conditions',
+              'Skin conditions, hot spots, or known sensitivities',
+              'Orthopedic issues (hip dysplasia, arthritis — affects table positioning)',
+              'Seizure history',
+              'Anxiety or stress triggers during grooming',
+              'Previous adverse reactions to grooming products',
+              'Recent surgery or injuries',
+              'Senior dog (8+ years) — noting additional risk factors',
+            ].map((item) => (
+              <li key={item} className="flex items-start gap-3 text-stone-600">
+                <span className="text-green-500 font-bold mt-0.5">✓</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* ── Section 4: Grooming Preferences ── */}
+        <section className="px-6 py-14 bg-green-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">Section 4: Grooming Preferences and Service Notes</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              This determines whether the client comes back — get it right the first time.
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {[
+                { q: 'What style or cut are you looking for?', note: 'Ask for a reference photo if possible' },
+                { q: 'Any areas to avoid or be extra gentle with?', note: 'Ears, paws, belly, face' },
+                { q: 'How does the dog handle nail trims?', note: 'Know before you reach for the clippers' },
+                { q: 'Any aggression or biting history?', note: 'Non-negotiable — must know upfront' },
+                { q: 'Add-ons wanted? (teeth brushing, deshedding, etc.)', note: 'Upsell opportunity, but only if wanted' },
+                { q: 'Drop-off and pickup preferences?', note: 'Time windows, who can pick up, callback instructions' },
+              ].map(({ q, note }) => (
+                <div key={q} className="p-4 bg-white rounded-lg border border-stone-200">
+                  <p className="font-semibold text-stone-800 mb-1">{q}</p>
+                  <p className="text-xs text-stone-500">{note}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Digital vs Paper ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">Digital Intake vs Paper Forms</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Paper forms get lost, misread, and never referenced again. Digital intake forms collected
+            at booking flow directly into the client&apos;s profile in your grooming software — so
+            every detail is at your fingertips when the dog walks in the door.
+          </p>
+          <div className="bg-stone-50 border border-stone-200 rounded-xl p-6">
+            <p className="font-semibold text-stone-800 mb-2">With digital intake:</p>
+            <ul className="space-y-2 text-stone-600 text-sm">
+              <li>✓ Information lives in the client profile permanently</li>
+              <li>✓ Accessible from your phone mid-groom</li>
+              <li>✓ Auto-attached to the appointment history</li>
+              <li>✓ Searchable — find all dogs on medication in seconds</li>
+              <li>✓ Clients fill it out at home before arriving — no front-desk wait</li>
+            </ul>
+          </div>
+          <p className="text-stone-600 leading-relaxed mt-4">
+            A solid client profile system is one of the core pillars of good{' '}
+            <Link
+              href="/blog/dog-grooming-business-management"
+              className="text-green-600 font-medium hover:text-green-700 underline underline-offset-2"
+            >
+              dog grooming business management
+            </Link>
+            . Pair it with a{' '}
+            <Link
+              href="/blog/dog-grooming-contract-template"
+              className="text-green-600 font-medium hover:text-green-700 underline underline-offset-2"
+            >
+              clear grooming contract
+            </Link>{' '}
+            and you have a professional, documented relationship with every client from day one.
+          </p>
+        </section>
+
+        {/* ── Signup CTA ── */}
+        <section className="px-6 py-16 bg-green-600 text-white">
+          <div className="max-w-3xl mx-auto text-center">
+            <h2 className="text-3xl font-extrabold mb-4">
+              Store all of this in one place — automatically
+            </h2>
+            <p className="text-green-100 text-lg mb-8 leading-relaxed">
+              GroomGrid captures client and pet details at booking and keeps them in a searchable
+              profile forever. No more digging through paper or guessing from memory.
+              Try it free with 50% off your first month.
+            </p>
+            <Link
+              href="/signup?coupon=BETA50"
+              className="px-8 py-4 rounded-xl bg-white text-green-700 font-bold text-lg hover:bg-green-50 transition-colors shadow-md inline-block"
+            >
+              Start Free Trial →
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Related Articles ── */}
+        <section className="px-6 py-12 max-w-5xl mx-auto">
+          <h2 className="text-xl font-bold text-stone-800 mb-6">Related Articles</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Link
+              href="/blog/dog-grooming-contract-template"
+              className="group p-5 border border-stone-200 rounded-xl hover:border-green-300 hover:shadow-md transition-all"
+            >
+              <p className="text-sm text-green-600 font-semibold mb-1">Templates</p>
+              <h3 className="font-bold text-stone-800 group-hover:text-green-600 transition-colors">
+                Dog Grooming Contract Template: What to Include and Why
+              </h3>
+            </Link>
+            <Link
+              href="/blog/dog-grooming-business-management"
+              className="group p-5 border border-stone-200 rounded-xl hover:border-green-300 hover:shadow-md transition-all"
+            >
+              <p className="text-sm text-green-600 font-semibold mb-1">Operations</p>
+              <h3 className="font-bold text-stone-800 group-hover:text-green-600 transition-colors">
+                Dog Grooming Business Management: The Complete Guide
+              </h3>
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Footer ── */}
+        <footer className="px-6 py-8 max-w-5xl mx-auto border-t border-stone-100 mt-0">
+          <div className="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-stone-400">
+            <Link href="/" className="font-bold text-green-600">GroomGrid 🐾</Link>
+            <div className="flex gap-6">
+              <Link href="/grooming-business-operations/" className="hover:text-stone-600 transition-colors">Operations Hub</Link>
+              <Link href="/mobile-grooming-business/" className="hover:text-stone-600 transition-colors">Mobile Grooming</Link>
+              <Link href="/plans" className="hover:text-stone-600 transition-colors">Pricing</Link>
+              <Link href="/signup?coupon=BETA50" className="hover:text-stone-600 transition-colors">Sign Up</Link>
+            </div>
+            <p>© {new Date().getFullYear()} GroomGrid. All rights reserved.</p>
+          </div>
+        </footer>
+      </div>
+    </>
+  );
+}

--- a/src/app/blog/dog-grooming-tools-equipment-list/page.tsx
+++ b/src/app/blog/dog-grooming-tools-equipment-list/page.tsx
@@ -1,0 +1,344 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Script from 'next/script';
+
+export const metadata: Metadata = {
+  title: 'Dog Grooming Tools & Equipment List: Everything You Need | GroomGrid',
+  description:
+    'Complete dog grooming tools and equipment list for professional groomers. Covers clippers, shears, dryers, tables, tubs, and estimated costs for mobile and salon setups.',
+  alternates: {
+    canonical: 'https://getgroomgrid.com/blog/dog-grooming-tools-equipment-list',
+  },
+  openGraph: {
+    title: 'Dog Grooming Tools & Equipment List: Everything You Need',
+    description:
+      'Complete dog grooming tools and equipment list for professional groomers. Covers clippers, shears, dryers, tables, tubs, and estimated costs for mobile and salon setups.',
+    url: 'https://getgroomgrid.com/blog/dog-grooming-tools-equipment-list',
+    type: 'article',
+  },
+};
+
+const breadcrumbSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://getgroomgrid.com' },
+    { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://getgroomgrid.com/blog' },
+    {
+      '@type': 'ListItem',
+      position: 3,
+      name: 'Dog Grooming Tools & Equipment List',
+      item: 'https://getgroomgrid.com/blog/dog-grooming-tools-equipment-list',
+    },
+  ],
+};
+
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'Dog Grooming Tools & Equipment List: Everything You Need',
+  description:
+    'Complete dog grooming tools and equipment list for professional groomers. Covers clippers, shears, dryers, tables, tubs, and estimated costs for mobile and salon setups.',
+  url: 'https://getgroomgrid.com/blog/dog-grooming-tools-equipment-list',
+  publisher: {
+    '@type': 'Organization',
+    name: 'GroomGrid',
+    url: 'https://getgroomgrid.com',
+    logo: { '@type': 'ImageObject', url: 'https://getgroomgrid.com/favicon.ico' },
+  },
+  mainEntityOfPage: {
+    '@type': 'WebPage',
+    '@id': 'https://getgroomgrid.com/blog/dog-grooming-tools-equipment-list',
+  },
+};
+
+export default function DogGroomingToolsEquipmentListPage() {
+  return (
+    <>
+      <Script
+        id="breadcrumb-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <Script
+        id="article-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+
+      <div className="min-h-screen bg-white text-stone-900">
+        {/* ── Nav ── */}
+        <nav className="flex items-center justify-between px-6 py-4 max-w-5xl mx-auto border-b border-stone-100">
+          <Link href="/" className="text-xl font-bold text-green-600">
+            GroomGrid 🐾
+          </Link>
+          <Link
+            href="/signup?coupon=BETA50"
+            className="px-4 py-2 rounded-lg bg-green-500 text-white text-sm font-semibold hover:bg-green-600 transition-colors"
+          >
+            Start Free Trial
+          </Link>
+        </nav>
+
+        {/* ── Breadcrumb ── */}
+        <div className="px-6 py-3 max-w-5xl mx-auto">
+          <nav aria-label="Breadcrumb" className="text-sm text-stone-500">
+            <ol className="flex items-center gap-2">
+              <li><Link href="/" className="hover:text-green-600 transition-colors">Home</Link></li>
+              <li aria-hidden="true">/</li>
+              <li><Link href="/blog" className="hover:text-green-600 transition-colors">Blog</Link></li>
+              <li aria-hidden="true">/</li>
+              <li className="text-stone-700 font-medium" aria-current="page">Tools & Equipment List</li>
+            </ol>
+          </nav>
+        </div>
+
+        {/* ── Hero ── */}
+        <header className="px-6 pt-10 pb-12 max-w-4xl mx-auto">
+          <p className="text-green-600 font-semibold text-sm uppercase tracking-widest mb-4">
+            Equipment & Setup
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-extrabold text-stone-900 leading-tight mb-6">
+            Dog Grooming Tools &amp; Equipment List:<br className="hidden sm:block" /> The Complete Professional Checklist
+          </h1>
+          <p className="text-xl text-stone-600 leading-relaxed max-w-3xl">
+            Whether you&apos;re starting your first grooming business or upgrading an existing setup,
+            knowing exactly what tools you need — and what they cost — prevents expensive mistakes. This
+            is the master list professional groomers actually use.
+          </p>
+        </header>
+
+        {/* ── Clippers & Blades ── */}
+        <section className="px-6 py-12 bg-green-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-2xl font-bold text-stone-800 mb-4">1. Clippers and Blades</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              Clippers are your most-used tool — and the wrong ones will cause fatigue, missed cuts, and
+              stressed dogs. For professional use, cordless models from Andis, Wahl, or Oster are the
+              industry standard.
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {[
+                { item: 'Heavy-duty rotary clipper', cost: '$150–$350', note: 'For thick, double-coated breeds' },
+                { item: 'Finishing clipper', cost: '$100–$200', note: 'Detail work and sensitive areas' },
+                { item: 'Clipper blade set (assorted)', cost: '$80–$200', note: '#3, #4, #5, #7, #10, #15, #30, #40' },
+                { item: 'Blade coolant spray', cost: '$10–$20', note: 'Keeps blades cool and clean mid-groom' },
+                { item: 'Blade wash solution', cost: '$15–$30', note: 'Daily cleaning between appointments' },
+                { item: 'Clipper oil', cost: '$8–$15', note: 'Extend blade life significantly' },
+              ].map(({ item, cost, note }) => (
+                <div key={item} className="p-4 bg-white rounded-lg border border-stone-200">
+                  <div className="flex justify-between items-start mb-1">
+                    <p className="font-semibold text-stone-800">{item}</p>
+                    <span className="text-green-600 font-medium text-sm">{cost}</span>
+                  </div>
+                  <p className="text-sm text-stone-500">{note}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Shears & Scissors ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">2. Shears and Scissors</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            A good shear set is a long-term investment. Professional-grade scissors stay sharper longer,
+            reduce hand fatigue, and give cleaner cuts. Budget options wear out quickly and cost more
+            over time through frequent replacement.
+          </p>
+          <ul className="space-y-3 mb-6">
+            {[
+              { item: 'Straight shears (7"–8.5")', cost: '$80–$300', use: 'Body work, straight lines' },
+              { item: 'Curved shears', cost: '$80–$250', use: 'Topknots, rounded finishes' },
+              { item: 'Thinning shears', cost: '$60–$200', use: 'Blending, removing bulk' },
+              { item: 'Chunkers / texturizing shears', cost: '$70–$200', use: 'Volume removal, natural finish' },
+              { item: 'Small detail shears (5"–6")', cost: '$50–$150', use: 'Face, ears, paws' },
+            ].map(({ item, cost, use }) => (
+              <li key={item} className="flex items-start gap-4 p-4 bg-stone-50 rounded-lg border border-stone-200">
+                <div className="flex-1">
+                  <div className="flex justify-between items-start">
+                    <p className="font-semibold text-stone-800">{item}</p>
+                    <span className="text-green-600 font-medium text-sm ml-4">{cost}</span>
+                  </div>
+                  <p className="text-sm text-stone-500 mt-1">{use}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* ── Bathing & Drying ── */}
+        <section className="px-6 py-14 bg-stone-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">3. Bathing and Drying Equipment</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              Efficient bathing and drying is where you win or lose time. A high-velocity dryer cuts
+              drying time by 50–70% compared to stand dryers — on a full day of grooms, that adds up to
+              hours.
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {[
+                { item: 'High-velocity dryer', cost: '$200–$500', note: 'Removes water fast, reduces coat matting' },
+                { item: 'Stand dryer', cost: '$150–$400', note: 'Hands-free finishing dryer' },
+                { item: 'Grooming tub / bathing station', cost: '$300–$1,500', note: 'Stainless or fiberglass; elevated for back health' },
+                { item: 'Handheld sprayer', cost: '$30–$80', note: 'Flexible rinse attachment' },
+                { item: 'Shampoo and conditioner (professional grade)', cost: '$40–$120/mo', note: 'Dilutable concentrates reduce per-dog cost' },
+                { item: 'Towels (microfiber, 12+ pack)', cost: '$50–$100', note: 'Fast-absorbing, machine-washable' },
+              ].map(({ item, cost, note }) => (
+                <div key={item} className="p-4 bg-white rounded-lg border border-stone-200">
+                  <div className="flex justify-between items-start mb-1">
+                    <p className="font-semibold text-stone-800">{item}</p>
+                    <span className="text-green-600 font-medium text-sm">{cost}</span>
+                  </div>
+                  <p className="text-sm text-stone-500">{note}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Tables & Restraints ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">4. Grooming Tables and Restraints</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Never groom on the floor. A proper grooming table protects your back, keeps the dog secure,
+            and makes every groom faster and safer. Hydraulic tables are the gold standard for full-time
+            groomers.
+          </p>
+          <ul className="space-y-3">
+            {[
+              'Hydraulic grooming table — $400–$1,200. Adjustable height prevents back strain across a full day.',
+              'Electric grooming table — $500–$1,500. Foot-pedal controlled, ideal for mobile vans.',
+              'Grooming arm with loop — $40–$100. Keeps dog steady hands-free.',
+              'Non-slip mat (table surface) — $20–$50. Critical for dog safety and comfort.',
+              'Grooming noose / safety harness — $15–$30. Extra security for anxious dogs.',
+            ].map((item) => (
+              <li key={item} className="flex items-start gap-3 text-stone-600">
+                <span className="text-green-500 font-bold mt-0.5">✓</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* ── Brushes & Combs ── */}
+        <section className="px-6 py-14 bg-green-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">5. Brushes, Combs, and Dematting Tools</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              You need tools for every coat type. A slicker brush that works on a Shih Tzu won&apos;t do
+              much for a Husky. Build a complete set and label it by coat type to save time during busy days.
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {[
+                { item: 'Slicker brush (sizes S, M, L)', cost: '$15–$50 each', note: 'Removes tangles and loose fur' },
+                { item: 'Pin brush', cost: '$10–$40', note: 'Long coats and silky breeds' },
+                { item: 'Undercoat rake', cost: '$15–$35', note: 'Double-coated breeds' },
+                { item: 'Greyhound-style comb (coarse/fine)', cost: '$10–$25', note: 'Finishing and mat detection' },
+                { item: 'Dematting comb', cost: '$15–$30', note: 'Breaks apart mats safely' },
+                { item: 'Furminator or deshedding tool', cost: '$30–$60', note: 'Reduces shedding appointments' },
+              ].map(({ item, cost, note }) => (
+                <div key={item} className="p-4 bg-white rounded-lg border border-stone-200">
+                  <div className="flex justify-between items-start mb-1">
+                    <p className="font-semibold text-stone-800">{item}</p>
+                    <span className="text-green-600 font-medium text-sm">{cost}</span>
+                  </div>
+                  <p className="text-sm text-stone-500">{note}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Startup Cost Summary ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">Estimated Startup Equipment Costs</h2>
+          <div className="bg-stone-50 rounded-xl border border-stone-200 p-6 mb-6">
+            <div className="space-y-3">
+              {[
+                ['Basic home/salon setup', '$1,500 – $3,000'],
+                ['Full salon setup', '$4,000 – $8,000'],
+                ['Mobile van (equipment only)', '$5,000 – $12,000'],
+                ['Mobile van (van + equipment)', '$25,000 – $60,000'],
+              ].map(([setup, cost]) => (
+                <div key={setup} className="flex justify-between items-center py-2 border-b border-stone-200 last:border-0">
+                  <span className="text-stone-700 font-medium">{setup}</span>
+                  <span className="text-green-600 font-bold">{cost}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+          <p className="text-stone-600 leading-relaxed">
+            Equipment is just the physical side of the business. You&apos;ll also need software to
+            manage bookings, reminders, and client records. Read our guide on{' '}
+            <Link
+              href="/blog/dog-grooming-business-management"
+              className="text-green-600 font-medium hover:text-green-700 underline underline-offset-2"
+            >
+              dog grooming business management
+            </Link>{' '}
+            to see how the operational side comes together.
+          </p>
+        </section>
+
+        {/* ── Signup CTA ── */}
+        <section className="px-6 py-16 bg-green-600 text-white">
+          <div className="max-w-3xl mx-auto text-center">
+            <h2 className="text-3xl font-extrabold mb-4">
+              Got your equipment? Now get your schedule sorted.
+            </h2>
+            <p className="text-green-100 text-lg mb-8 leading-relaxed">
+              GroomGrid handles booking, reminders, deposits, and client records so you can focus
+              on the grooms. Try it free — 50% off your first month with code BETA50.
+            </p>
+            <Link
+              href="/signup?coupon=BETA50"
+              className="px-8 py-4 rounded-xl bg-white text-green-700 font-bold text-lg hover:bg-green-50 transition-colors shadow-md inline-block"
+            >
+              Start Free Trial →
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Related Articles ── */}
+        <section className="px-6 py-12 max-w-5xl mx-auto">
+          <h2 className="text-xl font-bold text-stone-800 mb-6">Related Articles</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Link
+              href="/blog/how-much-to-start-dog-grooming-business"
+              className="group p-5 border border-stone-200 rounded-xl hover:border-green-300 hover:shadow-md transition-all"
+            >
+              <p className="text-sm text-green-600 font-semibold mb-1">Startup Costs</p>
+              <h3 className="font-bold text-stone-800 group-hover:text-green-600 transition-colors">
+                How Much Does It Cost to Start a Dog Grooming Business?
+              </h3>
+            </Link>
+            <Link
+              href="/blog/is-dog-grooming-a-profitable-business"
+              className="group p-5 border border-stone-200 rounded-xl hover:border-green-300 hover:shadow-md transition-all"
+            >
+              <p className="text-sm text-green-600 font-semibold mb-1">Business</p>
+              <h3 className="font-bold text-stone-800 group-hover:text-green-600 transition-colors">
+                Is Dog Grooming a Profitable Business? Real Numbers, Real Talk
+              </h3>
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Footer ── */}
+        <footer className="px-6 py-8 max-w-5xl mx-auto border-t border-stone-100 mt-0">
+          <div className="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-stone-400">
+            <Link href="/" className="font-bold text-green-600">GroomGrid 🐾</Link>
+            <div className="flex gap-6">
+              <Link href="/grooming-business-operations/" className="hover:text-stone-600 transition-colors">Operations Hub</Link>
+              <Link href="/mobile-grooming-business/" className="hover:text-stone-600 transition-colors">Mobile Grooming</Link>
+              <Link href="/plans" className="hover:text-stone-600 transition-colors">Pricing</Link>
+              <Link href="/signup?coupon=BETA50" className="hover:text-stone-600 transition-colors">Sign Up</Link>
+            </div>
+            <p>© {new Date().getFullYear()} GroomGrid. All rights reserved.</p>
+          </div>
+        </footer>
+      </div>
+    </>
+  );
+}

--- a/src/app/blog/groomgrid-vs-moego/page.tsx
+++ b/src/app/blog/groomgrid-vs-moego/page.tsx
@@ -1,0 +1,359 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Script from 'next/script';
+
+export const metadata: Metadata = {
+  title: 'GroomGrid vs MoeGo: Which Dog Grooming Software is Right for You? | GroomGrid',
+  description:
+    'Comparing GroomGrid vs MoeGo for dog grooming businesses? See how pricing, features, and ease of use stack up — and why independent groomers are switching.',
+  alternates: {
+    canonical: 'https://getgroomgrid.com/blog/groomgrid-vs-moego',
+  },
+  openGraph: {
+    title: 'GroomGrid vs MoeGo: Which Dog Grooming Software is Right for You?',
+    description:
+      'Comparing GroomGrid vs MoeGo for dog grooming businesses? See how pricing, features, and ease of use stack up — and why independent groomers are switching.',
+    url: 'https://getgroomgrid.com/blog/groomgrid-vs-moego',
+    type: 'article',
+  },
+};
+
+const breadcrumbSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://getgroomgrid.com' },
+    { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://getgroomgrid.com/blog' },
+    {
+      '@type': 'ListItem',
+      position: 3,
+      name: 'GroomGrid vs MoeGo',
+      item: 'https://getgroomgrid.com/blog/groomgrid-vs-moego',
+    },
+  ],
+};
+
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'GroomGrid vs MoeGo: Which Dog Grooming Software is Right for You?',
+  description:
+    'Comparing GroomGrid vs MoeGo for dog grooming businesses? See how pricing, features, and ease of use stack up — and why independent groomers are switching.',
+  url: 'https://getgroomgrid.com/blog/groomgrid-vs-moego',
+  publisher: {
+    '@type': 'Organization',
+    name: 'GroomGrid',
+    url: 'https://getgroomgrid.com',
+    logo: { '@type': 'ImageObject', url: 'https://getgroomgrid.com/favicon.ico' },
+  },
+  mainEntityOfPage: {
+    '@type': 'WebPage',
+    '@id': 'https://getgroomgrid.com/blog/groomgrid-vs-moego',
+  },
+};
+
+export default function GroomGridVsMoeGoPage() {
+  return (
+    <>
+      <Script
+        id="breadcrumb-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <Script
+        id="article-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+
+      <div className="min-h-screen bg-white text-stone-900">
+        {/* ── Nav ── */}
+        <nav className="flex items-center justify-between px-6 py-4 max-w-5xl mx-auto border-b border-stone-100">
+          <Link href="/" className="text-xl font-bold text-green-600">
+            GroomGrid 🐾
+          </Link>
+          <Link
+            href="/signup?coupon=BETA50"
+            className="px-4 py-2 rounded-lg bg-green-500 text-white text-sm font-semibold hover:bg-green-600 transition-colors"
+          >
+            Start Free Trial
+          </Link>
+        </nav>
+
+        {/* ── Breadcrumb ── */}
+        <div className="px-6 py-3 max-w-5xl mx-auto">
+          <nav aria-label="Breadcrumb" className="text-sm text-stone-500">
+            <ol className="flex items-center gap-2">
+              <li>
+                <Link href="/" className="hover:text-green-600 transition-colors">Home</Link>
+              </li>
+              <li aria-hidden="true">/</li>
+              <li>
+                <Link href="/blog" className="hover:text-green-600 transition-colors">Blog</Link>
+              </li>
+              <li aria-hidden="true">/</li>
+              <li className="text-stone-700 font-medium" aria-current="page">GroomGrid vs MoeGo</li>
+            </ol>
+          </nav>
+        </div>
+
+        {/* ── Hero ── */}
+        <header className="px-6 pt-10 pb-12 max-w-4xl mx-auto">
+          <p className="text-green-600 font-semibold text-sm uppercase tracking-widest mb-4">
+            Software Comparison
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-extrabold text-stone-900 leading-tight mb-6">
+            GroomGrid vs MoeGo:<br className="hidden sm:block" /> An Honest Comparison for Independent Groomers
+          </h1>
+          <p className="text-xl text-stone-600 leading-relaxed max-w-3xl">
+            MoeGo has been the default choice for many grooming businesses for years. But &ldquo;default&rdquo;
+            doesn&apos;t mean best. Here&apos;s a direct comparison so you can decide which platform
+            actually fits the way you run your business.
+          </p>
+        </header>
+
+        {/* ── Why This Comparison Matters ── */}
+        <section className="px-6 py-12 bg-green-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-2xl font-bold text-stone-800 mb-4">Why the Right Software Actually Matters</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              Your grooming software is the operating system of your business. It handles scheduling,
+              client communication, payments, and reminders. If it&apos;s clunky, expensive, or missing
+              key features, you feel that friction every single working day.
+            </p>
+            <p className="text-stone-600 leading-relaxed">
+              Both GroomGrid and MoeGo are purpose-built for pet grooming businesses. But they take
+              very different approaches to pricing, simplicity, and which type of groomer they serve
+              best. This comparison focuses on what matters to independent groomers and small salon owners.
+            </p>
+          </div>
+        </section>
+
+        {/* ── Feature Comparison ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">Feature-by-Feature Breakdown</h2>
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="bg-stone-100">
+                  <th className="text-left p-4 font-semibold text-stone-700 border border-stone-200">Feature</th>
+                  <th className="text-left p-4 font-semibold text-green-700 border border-stone-200">GroomGrid</th>
+                  <th className="text-left p-4 font-semibold text-stone-700 border border-stone-200">MoeGo</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  ['Online booking', 'Included', 'Included'],
+                  ['Automated reminders (SMS + email)', 'Included', 'Included'],
+                  ['Client & pet profiles', 'Included', 'Included'],
+                  ['Deposit collection', 'Included', 'Add-on'],
+                  ['Pricing', 'Simple flat rate', 'Tiered plans, add-ons'],
+                  ['Setup time', 'Under 30 minutes', 'Longer onboarding'],
+                  ['Mobile grooming route tools', 'Included', 'Limited'],
+                  ['No-show protection', 'Built-in', 'Manual setup required'],
+                  ['Free trial', 'Yes — 50% off first month', 'Limited free tier'],
+                ].map(([feature, gg, mg]) => (
+                  <tr key={feature} className="even:bg-stone-50">
+                    <td className="p-4 border border-stone-200 font-medium text-stone-700">{feature}</td>
+                    <td className="p-4 border border-stone-200 text-green-700 font-medium">{gg}</td>
+                    <td className="p-4 border border-stone-200 text-stone-600">{mg}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* ── Pricing Deep Dive ── */}
+        <section className="px-6 py-14 bg-stone-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">Pricing: What You Actually Pay</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              MoeGo uses a tiered pricing model where core features are gated behind higher plans. As
+              your business grows — more staff, more clients, more locations — the monthly cost climbs
+              significantly. Add-ons like payment processing integrations and advanced reporting can push
+              monthly spend well above $100 for a solo groomer or small team.
+            </p>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              GroomGrid takes a simpler approach: one flat rate that includes everything. No add-on
+              fees for reminders, deposits, or client management. The goal is predictable, affordable
+              software that doesn&apos;t penalize you for growing.
+            </p>
+            <div className="bg-green-50 border border-green-200 rounded-xl p-6">
+              <p className="font-semibold text-stone-800 mb-2">The real cost question:</p>
+              <p className="text-stone-600">
+                It&apos;s not just what you pay per month — it&apos;s what you save by preventing
+                no-shows and keeping clients rebooking automatically. A single prevented no-show per
+                week pays for most software subscriptions. The best tool is the one that actually gets
+                used and prevents revenue leaks.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Ease of Use ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">Ease of Use: Who Gets Started Fastest</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            MoeGo is a mature, feature-rich platform — and that comes with complexity. First-time
+            users often describe a steep learning curve, particularly around setting up service menus,
+            pricing rules, and notification workflows. For tech-savvy groomers who want granular
+            control, that depth is a feature. For busy solo groomers who just want to stop losing
+            appointments to text-tag chaos, it can feel like overkill.
+          </p>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            GroomGrid is designed for groomers who want to be operational in under 30 minutes. The
+            onboarding flow walks you through adding services, setting your hours, and sending your
+            first booking link — without needing to read a help center article.
+          </p>
+          <ul className="space-y-3">
+            {[
+              'Add your services and pricing in minutes',
+              'Clients can book from a link you share — no app download required',
+              'Reminders go out automatically once you flip the switch',
+              'Deposit policies are set once and applied consistently',
+            ].map((item) => (
+              <li key={item} className="flex items-start gap-3 text-stone-600">
+                <span className="text-green-500 font-bold mt-0.5">✓</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* ── Who Each is For ── */}
+        <section className="px-6 py-14 bg-stone-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">Who Each Platform is Built For</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+              <div className="p-6 bg-white rounded-xl border border-green-200">
+                <p className="text-green-600 font-bold text-lg mb-3">GroomGrid is best for:</p>
+                <ul className="space-y-2 text-stone-600 text-sm">
+                  {[
+                    'Solo groomers and small teams (1-5 groomers)',
+                    'Mobile groomers who need route-friendly booking',
+                    'Groomers switching from paper or generic tools',
+                    'Businesses that want fast setup and simple pricing',
+                    'Owners who want reminders and deposits without configuration headaches',
+                  ].map((item) => (
+                    <li key={item} className="flex items-start gap-2">
+                      <span className="text-green-500 font-bold">✓</span>
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div className="p-6 bg-white rounded-xl border border-stone-200">
+                <p className="text-stone-700 font-bold text-lg mb-3">MoeGo may suit you if:</p>
+                <ul className="space-y-2 text-stone-600 text-sm">
+                  {[
+                    'You run a large salon with 10+ groomers',
+                    'You need complex multi-location management',
+                    'You want deep customization of every workflow',
+                    'You have a dedicated office manager for setup',
+                    'Budget is less of a concern than feature depth',
+                  ].map((item) => (
+                    <li key={item} className="flex items-start gap-2">
+                      <span className="text-stone-400 font-bold">→</span>
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Bottom Line ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">The Bottom Line</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            MoeGo built a solid product, and for large grooming enterprises it might be the right fit.
+            But most grooming businesses are not enterprises — they&apos;re one to five talented
+            groomers trying to fill their books, reduce no-shows, and stop losing evenings to admin work.
+          </p>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            GroomGrid was designed specifically for that reality. Simpler, faster to set up, with the
+            features that actually move the needle for independent groomers: automated reminders, easy
+            deposit collection, and a booking experience that clients actually use.
+          </p>
+          <p className="text-stone-600 leading-relaxed">
+            Want to understand the full landscape of grooming software options? Read our guide to{' '}
+            <Link
+              href="/blog/dog-grooming-software"
+              className="text-green-600 font-medium hover:text-green-700 underline underline-offset-2"
+            >
+              dog grooming software in 2026
+            </Link>{' '}
+            or see how to{' '}
+            <Link
+              href="/blog/reduce-no-shows-dog-grooming"
+              className="text-green-600 font-medium hover:text-green-700 underline underline-offset-2"
+            >
+              reduce no-shows in your grooming business
+            </Link>
+            .
+          </p>
+        </section>
+
+        {/* ── Signup CTA ── */}
+        <section className="px-6 py-16 bg-green-600 text-white">
+          <div className="max-w-3xl mx-auto text-center">
+            <h2 className="text-3xl font-extrabold mb-4">
+              Try GroomGrid free — 50% off your first month
+            </h2>
+            <p className="text-green-100 text-lg mb-8 leading-relaxed">
+              See why groomers are switching. Full features, no credit card required to start.
+              Use code BETA50 at signup.
+            </p>
+            <Link
+              href="/signup?coupon=BETA50"
+              className="px-8 py-4 rounded-xl bg-white text-green-700 font-bold text-lg hover:bg-green-50 transition-colors shadow-md inline-block"
+            >
+              Start Free Trial →
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Related Articles ── */}
+        <section className="px-6 py-12 max-w-5xl mx-auto">
+          <h2 className="text-xl font-bold text-stone-800 mb-6">Related Articles</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Link
+              href="/blog/dog-grooming-software"
+              className="group p-5 border border-stone-200 rounded-xl hover:border-green-300 hover:shadow-md transition-all"
+            >
+              <p className="text-sm text-green-600 font-semibold mb-1">Software</p>
+              <h3 className="font-bold text-stone-800 group-hover:text-green-600 transition-colors">
+                Dog Grooming Software: The 2026 Buyer&apos;s Guide
+              </h3>
+            </Link>
+            <Link
+              href="/blog/reduce-no-shows-dog-grooming"
+              className="group p-5 border border-stone-200 rounded-xl hover:border-green-300 hover:shadow-md transition-all"
+            >
+              <p className="text-sm text-green-600 font-semibold mb-1">Operations</p>
+              <h3 className="font-bold text-stone-800 group-hover:text-green-600 transition-colors">
+                How to Reduce No-Shows in Your Dog Grooming Business
+              </h3>
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Footer ── */}
+        <footer className="px-6 py-8 max-w-5xl mx-auto border-t border-stone-100 mt-0">
+          <div className="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-stone-400">
+            <Link href="/" className="font-bold text-green-600">GroomGrid 🐾</Link>
+            <div className="flex gap-6">
+              <Link href="/grooming-business-operations/" className="hover:text-stone-600 transition-colors">Operations Hub</Link>
+              <Link href="/mobile-grooming-business/" className="hover:text-stone-600 transition-colors">Mobile Grooming</Link>
+              <Link href="/plans" className="hover:text-stone-600 transition-colors">Pricing</Link>
+              <Link href="/signup?coupon=BETA50" className="hover:text-stone-600 transition-colors">Sign Up</Link>
+            </div>
+            <p>© {new Date().getFullYear()} GroomGrid. All rights reserved.</p>
+          </div>
+        </footer>
+      </div>
+    </>
+  );
+}

--- a/src/app/blog/how-much-to-start-dog-grooming-business/page.tsx
+++ b/src/app/blog/how-much-to-start-dog-grooming-business/page.tsx
@@ -1,0 +1,322 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Script from 'next/script';
+
+export const metadata: Metadata = {
+  title: 'How Much Does It Cost to Start a Dog Grooming Business? | GroomGrid',
+  description:
+    'Detailed cost breakdown to start a dog grooming business in 2026 — equipment, licensing, insurance, marketing, and software. Includes home salon, mobile, and retail location estimates.',
+  alternates: {
+    canonical: 'https://getgroomgrid.com/blog/how-much-to-start-dog-grooming-business',
+  },
+  openGraph: {
+    title: 'How Much Does It Cost to Start a Dog Grooming Business?',
+    description:
+      'Detailed cost breakdown to start a dog grooming business in 2026 — equipment, licensing, insurance, marketing, and software. Includes home salon, mobile, and retail location estimates.',
+    url: 'https://getgroomgrid.com/blog/how-much-to-start-dog-grooming-business',
+    type: 'article',
+  },
+};
+
+const breadcrumbSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://getgroomgrid.com' },
+    { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://getgroomgrid.com/blog' },
+    {
+      '@type': 'ListItem',
+      position: 3,
+      name: 'How Much to Start a Dog Grooming Business',
+      item: 'https://getgroomgrid.com/blog/how-much-to-start-dog-grooming-business',
+    },
+  ],
+};
+
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'How Much Does It Cost to Start a Dog Grooming Business?',
+  description:
+    'Detailed cost breakdown to start a dog grooming business in 2026 — equipment, licensing, insurance, marketing, and software. Includes home salon, mobile, and retail location estimates.',
+  url: 'https://getgroomgrid.com/blog/how-much-to-start-dog-grooming-business',
+  publisher: {
+    '@type': 'Organization',
+    name: 'GroomGrid',
+    url: 'https://getgroomgrid.com',
+    logo: { '@type': 'ImageObject', url: 'https://getgroomgrid.com/favicon.ico' },
+  },
+  mainEntityOfPage: {
+    '@type': 'WebPage',
+    '@id': 'https://getgroomgrid.com/blog/how-much-to-start-dog-grooming-business',
+  },
+};
+
+export default function HowMuchToStartDogGroomingBusinessPage() {
+  return (
+    <>
+      <Script
+        id="breadcrumb-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <Script
+        id="article-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+
+      <div className="min-h-screen bg-white text-stone-900">
+        {/* ── Nav ── */}
+        <nav className="flex items-center justify-between px-6 py-4 max-w-5xl mx-auto border-b border-stone-100">
+          <Link href="/" className="text-xl font-bold text-green-600">
+            GroomGrid 🐾
+          </Link>
+          <Link
+            href="/signup?coupon=BETA50"
+            className="px-4 py-2 rounded-lg bg-green-500 text-white text-sm font-semibold hover:bg-green-600 transition-colors"
+          >
+            Start Free Trial
+          </Link>
+        </nav>
+
+        {/* ── Breadcrumb ── */}
+        <div className="px-6 py-3 max-w-5xl mx-auto">
+          <nav aria-label="Breadcrumb" className="text-sm text-stone-500">
+            <ol className="flex items-center gap-2">
+              <li><Link href="/" className="hover:text-green-600 transition-colors">Home</Link></li>
+              <li aria-hidden="true">/</li>
+              <li><Link href="/blog" className="hover:text-green-600 transition-colors">Blog</Link></li>
+              <li aria-hidden="true">/</li>
+              <li className="text-stone-700 font-medium" aria-current="page">Startup Costs</li>
+            </ol>
+          </nav>
+        </div>
+
+        {/* ── Hero ── */}
+        <header className="px-6 pt-10 pb-12 max-w-4xl mx-auto">
+          <p className="text-green-600 font-semibold text-sm uppercase tracking-widest mb-4">
+            Startup Costs
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-extrabold text-stone-900 leading-tight mb-6">
+            How Much Does It Cost to<br className="hidden sm:block" /> Start a Dog Grooming Business?
+          </h1>
+          <p className="text-xl text-stone-600 leading-relaxed max-w-3xl">
+            The honest answer: anywhere from $2,000 to $100,000+ depending on the model you choose.
+            Here&apos;s the complete breakdown — equipment, licensing, insurance, marketing — so you can
+            plan accurately and start without surprises.
+          </p>
+        </header>
+
+        {/* ── Three Models ── */}
+        <section className="px-6 py-12 bg-green-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-2xl font-bold text-stone-800 mb-4">The Three Grooming Business Models</h2>
+            <p className="text-stone-600 leading-relaxed mb-6">
+              Your startup costs depend almost entirely on which model you choose. Each has different
+              overhead, income potential, and scalability.
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+              {[
+                { model: 'Home Salon', range: '$2,000–$8,000', note: 'Lowest startup cost. Clients come to you. Limited by zoning, space, and local regulations.' },
+                { model: 'Mobile Van', range: '$15,000–$65,000', note: 'Higher startup, premium pricing. Travel to clients. Fuel and maintenance are ongoing costs.' },
+                { model: 'Retail Location', range: '$30,000–$150,000', note: 'Highest startup but maximum capacity. Lease, buildout, equipment, and staff costs.' },
+              ].map(({ model, range, note }) => (
+                <div key={model} className="p-5 bg-white rounded-xl border border-stone-200">
+                  <p className="font-bold text-stone-800 text-lg mb-1">{model}</p>
+                  <p className="text-green-600 font-bold text-xl mb-3">{range}</p>
+                  <p className="text-stone-500 text-sm">{note}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Equipment Costs ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">Equipment Costs (All Models)</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Equipment is your largest upfront cost. Quality matters — cheap clippers and dryers wear out
+            quickly and cost more over time. Invest in professional-grade tools from the start.
+          </p>
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="bg-stone-100">
+                  <th className="text-left p-3 font-semibold text-stone-700 border border-stone-200">Item</th>
+                  <th className="text-left p-3 font-semibold text-stone-700 border border-stone-200">Budget</th>
+                  <th className="text-left p-3 font-semibold text-stone-700 border border-stone-200">Professional</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  ['Clippers (2)', '$200–$400', '$500–$800'],
+                  ['Blade set (complete)', '$100–$200', '$200–$400'],
+                  ['Shear set (4–6 pairs)', '$300–$600', '$700–$1,500'],
+                  ['High-velocity dryer', '$200–$350', '$400–$600'],
+                  ['Stand dryer', '$150–$250', '$300–$500'],
+                  ['Grooming table (hydraulic)', '$400–$600', '$800–$1,500'],
+                  ['Bathing tub/station', '$200–$500', '$500–$1,500'],
+                  ['Brushes, combs, tools', '$100–$200', '$250–$500'],
+                  ['Shampoos & supplies (monthly)', '$50–$100', '$100–$200'],
+                ].map(([item, budget, pro]) => (
+                  <tr key={item} className="even:bg-stone-50">
+                    <td className="p-3 border border-stone-200 font-medium text-stone-700">{item}</td>
+                    <td className="p-3 border border-stone-200 text-stone-600">{budget}</td>
+                    <td className="p-3 border border-stone-200 text-green-700 font-medium">{pro}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* ── Licensing and Legal ── */}
+        <section className="px-6 py-14 bg-stone-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">Licensing, Legal, and Insurance</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              Costs vary significantly by state and city. Use these as planning estimates — verify
+              your specific requirements with your state licensing board.
+            </p>
+            <div className="space-y-3">
+              {[
+                { item: 'Business entity formation (LLC)', cost: '$50–$500', note: 'One-time state filing fee; legal protection worth it' },
+                { item: 'Business license', cost: '$50–$200/yr', note: 'Required in most municipalities' },
+                { item: 'State grooming license', cost: '$50–$200', note: 'Some states require formal certification' },
+                { item: 'General liability insurance', cost: '$500–$1,500/yr', note: 'Covers injuries, property damage claims' },
+                { item: 'Commercial auto insurance (mobile)', cost: '$1,200–$3,000/yr', note: 'Required if operating from a van' },
+                { item: 'Care, custody & control coverage', cost: '$200–$600/yr', note: 'Covers dogs in your care — often required by clients' },
+              ].map(({ item, cost, note }) => (
+                <div key={item} className="flex gap-4 items-start p-4 bg-white rounded-lg border border-stone-200">
+                  <div className="flex-1">
+                    <p className="font-semibold text-stone-800">{item}</p>
+                    <p className="text-xs text-stone-500 mt-0.5">{note}</p>
+                  </div>
+                  <span className="text-green-600 font-bold text-sm whitespace-nowrap">{cost}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Marketing ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">Marketing and Launch Costs</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+            {[
+              { item: 'Logo + branding (basic)', cost: '$200–$800' },
+              { item: 'Website (DIY vs agency)', cost: '$0–$3,000' },
+              { item: 'Google Business Profile', cost: 'Free' },
+              { item: 'Business cards (500)', cost: '$30–$80' },
+              { item: 'Social media setup', cost: 'Free' },
+              { item: 'Paid ads (first 3 months)', cost: '$300–$1,000' },
+            ].map(({ item, cost }) => (
+              <div key={item} className="flex justify-between p-4 bg-stone-50 rounded-lg border border-stone-200">
+                <span className="text-stone-700 font-medium">{item}</span>
+                <span className="text-green-600 font-bold text-sm">{cost}</span>
+              </div>
+            ))}
+          </div>
+          <p className="text-stone-600 leading-relaxed">
+            Most groomers underinvest in marketing at launch and then wonder why the first 3 months are
+            slow. Allocate at least $500–$1,000 for your launch push — it compounds into word-of-mouth
+            referrals faster than organic growth alone.
+          </p>
+        </section>
+
+        {/* ── Summary ── */}
+        <section className="px-6 py-14 bg-green-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">Total Startup Cost Summary</h2>
+            <div className="space-y-4">
+              {[
+                { model: 'Home Salon (lean)', total: '$2,000–$5,000', items: 'Basic equipment, license, liability insurance, simple marketing' },
+                { model: 'Home Salon (well-equipped)', total: '$5,000–$10,000', items: 'Professional equipment, LLC, full insurance, website, launch marketing' },
+                { model: 'Mobile Van (used van)', total: '$15,000–$35,000', items: 'Used van conversion, full equipment, commercial auto insurance, launch' },
+                { model: 'Mobile Van (new van)', total: '$45,000–$75,000', items: 'New custom van, professional equipment, full insurance and marketing budget' },
+                { model: 'Retail Location', total: '$50,000–$150,000+', items: 'Lease, buildout, full equipment, staff, insurance, marketing, working capital' },
+              ].map(({ model, total, items }) => (
+                <div key={model} className="p-5 bg-white rounded-xl border border-stone-200">
+                  <div className="flex justify-between items-start mb-2">
+                    <p className="font-bold text-stone-800">{model}</p>
+                    <span className="text-green-600 font-bold">{total}</span>
+                  </div>
+                  <p className="text-stone-500 text-sm">{items}</p>
+                </div>
+              ))}
+            </div>
+            <p className="text-stone-600 leading-relaxed mt-6">
+              To understand what you can earn once you&apos;re running, read our complete breakdown of{' '}
+              <Link
+                href="/blog/is-dog-grooming-a-profitable-business"
+                className="text-green-600 font-medium hover:text-green-700 underline underline-offset-2"
+              >
+                grooming business profitability
+              </Link>
+              .
+            </p>
+          </div>
+        </section>
+
+        {/* ── Signup CTA ── */}
+        <section className="px-6 py-16 bg-green-600 text-white">
+          <div className="max-w-3xl mx-auto text-center">
+            <h2 className="text-3xl font-extrabold mb-4">
+              One startup cost that pays for itself fast
+            </h2>
+            <p className="text-green-100 text-lg mb-8 leading-relaxed">
+              GroomGrid handles your bookings, reminders, deposits, and client records from day one.
+              Prevent a single no-show and it&apos;s paid for. Try it free with 50% off your first month.
+            </p>
+            <Link
+              href="/signup?coupon=BETA50"
+              className="px-8 py-4 rounded-xl bg-white text-green-700 font-bold text-lg hover:bg-green-50 transition-colors shadow-md inline-block"
+            >
+              Start Free Trial →
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Related Articles ── */}
+        <section className="px-6 py-12 max-w-5xl mx-auto">
+          <h2 className="text-xl font-bold text-stone-800 mb-6">Related Articles</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Link
+              href="/blog/is-dog-grooming-a-profitable-business"
+              className="group p-5 border border-stone-200 rounded-xl hover:border-green-300 hover:shadow-md transition-all"
+            >
+              <p className="text-sm text-green-600 font-semibold mb-1">Business</p>
+              <h3 className="font-bold text-stone-800 group-hover:text-green-600 transition-colors">
+                Is Dog Grooming a Profitable Business? Real Numbers, Real Talk
+              </h3>
+            </Link>
+            <Link
+              href="/blog/dog-grooming-tools-equipment-list"
+              className="group p-5 border border-stone-200 rounded-xl hover:border-green-300 hover:shadow-md transition-all"
+            >
+              <p className="text-sm text-green-600 font-semibold mb-1">Equipment</p>
+              <h3 className="font-bold text-stone-800 group-hover:text-green-600 transition-colors">
+                Dog Grooming Tools &amp; Equipment List: The Complete Professional Checklist
+              </h3>
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Footer ── */}
+        <footer className="px-6 py-8 max-w-5xl mx-auto border-t border-stone-100 mt-0">
+          <div className="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-stone-400">
+            <Link href="/" className="font-bold text-green-600">GroomGrid 🐾</Link>
+            <div className="flex gap-6">
+              <Link href="/grooming-business-operations/" className="hover:text-stone-600 transition-colors">Operations Hub</Link>
+              <Link href="/mobile-grooming-business/" className="hover:text-stone-600 transition-colors">Mobile Grooming</Link>
+              <Link href="/plans" className="hover:text-stone-600 transition-colors">Pricing</Link>
+              <Link href="/signup?coupon=BETA50" className="hover:text-stone-600 transition-colors">Sign Up</Link>
+            </div>
+            <p>© {new Date().getFullYear()} GroomGrid. All rights reserved.</p>
+          </div>
+        </footer>
+      </div>
+    </>
+  );
+}

--- a/src/app/blog/how-to-increase-sales-dog-grooming-business/page.tsx
+++ b/src/app/blog/how-to-increase-sales-dog-grooming-business/page.tsx
@@ -1,0 +1,352 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Script from 'next/script';
+
+export const metadata: Metadata = {
+  title: 'How to Increase Sales in Your Dog Grooming Business: 8 Proven Strategies | GroomGrid',
+  description:
+    'Increase revenue in your dog grooming business without adding more appointments. Learn upselling, service packages, rebooking strategies, and the operational changes that drive growth.',
+  alternates: {
+    canonical: 'https://getgroomgrid.com/blog/how-to-increase-sales-dog-grooming-business',
+  },
+  openGraph: {
+    title: 'How to Increase Sales in Your Dog Grooming Business: 8 Proven Strategies',
+    description:
+      'Increase revenue in your dog grooming business without adding more appointments. Learn upselling, service packages, rebooking strategies, and the operational changes that drive growth.',
+    url: 'https://getgroomgrid.com/blog/how-to-increase-sales-dog-grooming-business',
+    type: 'article',
+  },
+};
+
+const breadcrumbSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://getgroomgrid.com' },
+    { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://getgroomgrid.com/blog' },
+    {
+      '@type': 'ListItem',
+      position: 3,
+      name: 'How to Increase Sales in Your Dog Grooming Business',
+      item: 'https://getgroomgrid.com/blog/how-to-increase-sales-dog-grooming-business',
+    },
+  ],
+};
+
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'How to Increase Sales in Your Dog Grooming Business: 8 Proven Strategies',
+  description:
+    'Increase revenue in your dog grooming business without adding more appointments. Learn upselling, service packages, rebooking strategies, and the operational changes that drive growth.',
+  url: 'https://getgroomgrid.com/blog/how-to-increase-sales-dog-grooming-business',
+  publisher: {
+    '@type': 'Organization',
+    name: 'GroomGrid',
+    url: 'https://getgroomgrid.com',
+    logo: { '@type': 'ImageObject', url: 'https://getgroomgrid.com/favicon.ico' },
+  },
+  mainEntityOfPage: {
+    '@type': 'WebPage',
+    '@id': 'https://getgroomgrid.com/blog/how-to-increase-sales-dog-grooming-business',
+  },
+};
+
+export default function HowToIncreaseSalesDogGroomingPage() {
+  return (
+    <>
+      <Script
+        id="breadcrumb-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <Script
+        id="article-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+
+      <div className="min-h-screen bg-white text-stone-900">
+        {/* ── Nav ── */}
+        <nav className="flex items-center justify-between px-6 py-4 max-w-5xl mx-auto border-b border-stone-100">
+          <Link href="/" className="text-xl font-bold text-green-600">
+            GroomGrid 🐾
+          </Link>
+          <Link
+            href="/signup?coupon=BETA50"
+            className="px-4 py-2 rounded-lg bg-green-500 text-white text-sm font-semibold hover:bg-green-600 transition-colors"
+          >
+            Start Free Trial
+          </Link>
+        </nav>
+
+        {/* ── Breadcrumb ── */}
+        <div className="px-6 py-3 max-w-5xl mx-auto">
+          <nav aria-label="Breadcrumb" className="text-sm text-stone-500">
+            <ol className="flex items-center gap-2">
+              <li><Link href="/" className="hover:text-green-600 transition-colors">Home</Link></li>
+              <li aria-hidden="true">/</li>
+              <li><Link href="/blog" className="hover:text-green-600 transition-colors">Blog</Link></li>
+              <li aria-hidden="true">/</li>
+              <li className="text-stone-700 font-medium" aria-current="page">How to Increase Sales</li>
+            </ol>
+          </nav>
+        </div>
+
+        {/* ── Hero ── */}
+        <header className="px-6 pt-10 pb-12 max-w-4xl mx-auto">
+          <p className="text-green-600 font-semibold text-sm uppercase tracking-widest mb-4">
+            Business Growth
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-extrabold text-stone-900 leading-tight mb-6">
+            How to Increase Sales in Your<br className="hidden sm:block" /> Dog Grooming Business
+          </h1>
+          <p className="text-xl text-stone-600 leading-relaxed max-w-3xl">
+            Growing your grooming revenue doesn&apos;t always mean booking more appointments. Often the
+            fastest path to more income is getting more out of the clients and schedule you already have.
+            Here are 8 strategies that work.
+          </p>
+        </header>
+
+        {/* ── The Revenue Equation ── */}
+        <section className="px-6 py-12 bg-green-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-2xl font-bold text-stone-800 mb-4">The Grooming Revenue Equation</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              Revenue = (number of appointments) × (average revenue per appointment). Most groomers
+              focus entirely on the first variable — getting more bookings. But increasing average
+              revenue per appointment is often faster, easier, and more profitable.
+            </p>
+            <p className="text-stone-600 leading-relaxed">
+              If you currently do 20 appointments per week at $60 average, that&apos;s $1,200/week.
+              Raise average revenue by $15 through add-ons and better pricing, and you&apos;re at
+              $1,500/week without seeing one extra dog. That&apos;s $15,600 more per year.
+            </p>
+          </div>
+        </section>
+
+        {/* ── Strategy 1: Add-Ons ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">1. Introduce High-Margin Add-On Services</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Add-ons take minimal extra time but command a meaningful price premium. The best add-ons
+            solve a real problem for the pet or provide noticeable value owners can see.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {[
+              { service: 'Teeth brushing', price: '$10–$20', time: '5 min' },
+              { service: 'Nail grinding (after clipping)', price: '$10–$15', time: '5 min' },
+              { service: 'Blueberry facial / eye treatment', price: '$10–$20', time: '5 min' },
+              { service: 'Conditioning treatment (deep)', price: '$15–$30', time: '10 min' },
+              { service: 'Ear cleaning', price: '$10–$15', time: '5 min' },
+              { service: 'Paw balm application', price: '$8–$15', time: '3 min' },
+              { service: 'Deshedding treatment', price: '$20–$50', time: '15-30 min' },
+              { service: 'Bandana / bow', price: '$5–$10', time: '2 min' },
+            ].map(({ service, price, time }) => (
+              <div key={service} className="flex justify-between items-center p-4 bg-stone-50 rounded-lg border border-stone-200">
+                <div>
+                  <p className="font-semibold text-stone-800">{service}</p>
+                  <p className="text-xs text-stone-500">{time}</p>
+                </div>
+                <span className="text-green-600 font-bold text-sm">{price}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* ── Strategy 2: Packages ── */}
+        <section className="px-6 py-14 bg-stone-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">2. Bundle Services into Packages</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              Packages increase average ticket size and give clients a sense of value. Instead of selling
+              individual services, create tiered packages that make a clear premium option obvious.
+            </p>
+            <div className="space-y-4">
+              {[
+                {
+                  name: 'Basic Groom',
+                  price: '$55–$80',
+                  includes: 'Bath, blow dry, brush, nail clip, ear clean',
+                },
+                {
+                  name: 'Full Groom',
+                  price: '$75–$110',
+                  includes: 'Basic groom + haircut/trim, teeth brushing, bandana',
+                },
+                {
+                  name: 'Spa Package',
+                  price: '$110–$160',
+                  includes: 'Full groom + conditioning treatment, paw balm, blueberry facial',
+                },
+              ].map(({ name, price, includes }) => (
+                <div key={name} className="p-5 bg-white rounded-xl border border-stone-200">
+                  <div className="flex justify-between items-start mb-2">
+                    <p className="font-bold text-stone-800 text-lg">{name}</p>
+                    <span className="text-green-600 font-bold">{price}</span>
+                  </div>
+                  <p className="text-stone-600 text-sm">{includes}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Strategy 3: Rebooking ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">3. Rebook at Checkout (Every Time)</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            The easiest new appointment to fill is the next one for a client you already have. When a
+            client picks up their dog, that&apos;s the highest-value moment to suggest the next visit.
+            Most clients will say yes — they just need the prompt.
+          </p>
+          <div className="bg-green-50 border border-green-200 rounded-xl p-6">
+            <p className="font-semibold text-stone-800 mb-2">Script that works:</p>
+            <p className="text-stone-600 italic">
+              &ldquo;For a Labradoodle like Max, I usually recommend coming back every 6–8 weeks to
+              keep the coat manageable. Want me to pencil in [specific date] now so you have a spot
+              locked in?&rdquo;
+            </p>
+          </div>
+          <p className="text-stone-600 leading-relaxed mt-4">
+            Groomers who rebook at checkout consistently run 20–30% higher utilization than those who
+            rely on clients to initiate. Combine this with{' '}
+            <Link
+              href="/blog/reduce-no-shows-dog-grooming"
+              className="text-green-600 font-medium hover:text-green-700 underline underline-offset-2"
+            >
+              automated reminders to reduce no-shows
+            </Link>{' '}
+            and you build a reliable, full schedule.
+          </p>
+        </section>
+
+        {/* ── More Strategies ── */}
+        <section className="px-6 py-14 bg-stone-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">4–8. More Proven Revenue Tactics</h2>
+            <div className="space-y-6">
+              {[
+                {
+                  num: '4',
+                  title: 'Raise your prices — selectively',
+                  body: 'Audit your service menu annually. If you haven\'t raised prices in 2 years, you\'re likely undercharging. Start by raising rates on your most time-intensive services (large breed full grooms, Doodle haircuts). Loyal clients will rarely leave over a $10–$15 increase.',
+                },
+                {
+                  num: '5',
+                  title: 'Charge appropriately for difficult dogs',
+                  body: 'A matted coat or anxious dog takes significantly more time. Implement a "condition surcharge" that adds $15–$50 for coats that require extra work. Communicate it clearly upfront — most clients understand and respect it.',
+                },
+                {
+                  num: '6',
+                  title: 'Sell retail products',
+                  body: 'Clients trust your product recommendations. A small retail section with shampoos, conditioners, brushes, and paw care products can add $50–$200 of passive revenue per week with zero additional labor. Stock what you personally use and recommend.',
+                },
+                {
+                  num: '7',
+                  title: 'Referral program',
+                  body: 'Your happiest clients are your best marketing channel. A simple "refer a friend, get $15 off your next groom" drives consistent new client acquisition at a much lower cost than advertising.',
+                },
+                {
+                  num: '8',
+                  title: 'Recurring appointment subscriptions',
+                  body: 'Offer a monthly or quarterly subscription plan that locks in a discount for pre-committed appointments. Clients pay slightly less per groom; you get predictable revenue and a guaranteed full schedule.',
+                },
+              ].map(({ num, title, body }) => (
+                <div key={num} className="flex gap-5 p-5 bg-white rounded-xl border border-stone-200">
+                  <div className="flex-shrink-0 w-10 h-10 rounded-full bg-green-100 text-green-700 font-bold flex items-center justify-center">
+                    {num}
+                  </div>
+                  <div>
+                    <p className="font-bold text-stone-800 mb-2">{title}</p>
+                    <p className="text-stone-600 text-sm leading-relaxed">{body}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Conclusion ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">Where to Start</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Don&apos;t try to implement all 8 strategies at once. Pick the one with the lowest friction
+            and highest expected return for your specific business. For most groomers, that&apos;s either
+            introducing 2-3 add-ons or implementing consistent rebooking at checkout.
+          </p>
+          <p className="text-stone-600 leading-relaxed">
+            For the financial picture of what a profitable grooming business looks like, read our deep
+            dive on{' '}
+            <Link
+              href="/blog/is-dog-grooming-a-profitable-business"
+              className="text-green-600 font-medium hover:text-green-700 underline underline-offset-2"
+            >
+              whether dog grooming is actually a profitable business
+            </Link>
+            .
+          </p>
+        </section>
+
+        {/* ── Signup CTA ── */}
+        <section className="px-6 py-16 bg-green-600 text-white">
+          <div className="max-w-3xl mx-auto text-center">
+            <h2 className="text-3xl font-extrabold mb-4">
+              The right software makes every strategy easier
+            </h2>
+            <p className="text-green-100 text-lg mb-8 leading-relaxed">
+              GroomGrid automates rebooking reminders, tracks client preferences, and makes
+              collecting deposits effortless — so more of your revenue strategies actually happen.
+              Try it free with 50% off your first month.
+            </p>
+            <Link
+              href="/signup?coupon=BETA50"
+              className="px-8 py-4 rounded-xl bg-white text-green-700 font-bold text-lg hover:bg-green-50 transition-colors shadow-md inline-block"
+            >
+              Start Free Trial →
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Related Articles ── */}
+        <section className="px-6 py-12 max-w-5xl mx-auto">
+          <h2 className="text-xl font-bold text-stone-800 mb-6">Related Articles</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Link
+              href="/blog/is-dog-grooming-a-profitable-business"
+              className="group p-5 border border-stone-200 rounded-xl hover:border-green-300 hover:shadow-md transition-all"
+            >
+              <p className="text-sm text-green-600 font-semibold mb-1">Business</p>
+              <h3 className="font-bold text-stone-800 group-hover:text-green-600 transition-colors">
+                Is Dog Grooming a Profitable Business? Real Numbers, Real Talk
+              </h3>
+            </Link>
+            <Link
+              href="/blog/reduce-no-shows-dog-grooming"
+              className="group p-5 border border-stone-200 rounded-xl hover:border-green-300 hover:shadow-md transition-all"
+            >
+              <p className="text-sm text-green-600 font-semibold mb-1">Operations</p>
+              <h3 className="font-bold text-stone-800 group-hover:text-green-600 transition-colors">
+                How to Reduce No-Shows in Your Dog Grooming Business
+              </h3>
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Footer ── */}
+        <footer className="px-6 py-8 max-w-5xl mx-auto border-t border-stone-100 mt-0">
+          <div className="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-stone-400">
+            <Link href="/" className="font-bold text-green-600">GroomGrid 🐾</Link>
+            <div className="flex gap-6">
+              <Link href="/grooming-business-operations/" className="hover:text-stone-600 transition-colors">Operations Hub</Link>
+              <Link href="/mobile-grooming-business/" className="hover:text-stone-600 transition-colors">Mobile Grooming</Link>
+              <Link href="/plans" className="hover:text-stone-600 transition-colors">Pricing</Link>
+              <Link href="/signup?coupon=BETA50" className="hover:text-stone-600 transition-colors">Sign Up</Link>
+            </div>
+            <p>© {new Date().getFullYear()} GroomGrid. All rights reserved.</p>
+          </div>
+        </footer>
+      </div>
+    </>
+  );
+}

--- a/src/app/blog/how-to-start-a-mobile-dog-grooming-business/page.tsx
+++ b/src/app/blog/how-to-start-a-mobile-dog-grooming-business/page.tsx
@@ -1,0 +1,346 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Script from 'next/script';
+
+export const metadata: Metadata = {
+  title: 'How to Start a Mobile Dog Grooming Business: The Complete Guide | GroomGrid',
+  description:
+    'Everything you need to start a mobile dog grooming business — van setup, licensing, pricing, finding first clients, and the tools to manage it all from day one.',
+  alternates: {
+    canonical: 'https://getgroomgrid.com/blog/how-to-start-a-mobile-dog-grooming-business',
+  },
+  openGraph: {
+    title: 'How to Start a Mobile Dog Grooming Business: The Complete Guide',
+    description:
+      'Everything you need to start a mobile dog grooming business — van setup, licensing, pricing, finding first clients, and the tools to manage it all from day one.',
+    url: 'https://getgroomgrid.com/blog/how-to-start-a-mobile-dog-grooming-business',
+    type: 'article',
+  },
+};
+
+const breadcrumbSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://getgroomgrid.com' },
+    { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://getgroomgrid.com/blog' },
+    {
+      '@type': 'ListItem',
+      position: 3,
+      name: 'How to Start a Mobile Dog Grooming Business',
+      item: 'https://getgroomgrid.com/blog/how-to-start-a-mobile-dog-grooming-business',
+    },
+  ],
+};
+
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'How to Start a Mobile Dog Grooming Business: The Complete Guide',
+  description:
+    'Everything you need to start a mobile dog grooming business — van setup, licensing, pricing, finding first clients, and the tools to manage it all from day one.',
+  url: 'https://getgroomgrid.com/blog/how-to-start-a-mobile-dog-grooming-business',
+  publisher: {
+    '@type': 'Organization',
+    name: 'GroomGrid',
+    url: 'https://getgroomgrid.com',
+    logo: { '@type': 'ImageObject', url: 'https://getgroomgrid.com/favicon.ico' },
+  },
+  mainEntityOfPage: {
+    '@type': 'WebPage',
+    '@id': 'https://getgroomgrid.com/blog/how-to-start-a-mobile-dog-grooming-business',
+  },
+};
+
+export default function HowToStartMobileDogGroomingBusinessPage() {
+  return (
+    <>
+      <Script
+        id="breadcrumb-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <Script
+        id="article-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+
+      <div className="min-h-screen bg-white text-stone-900">
+        {/* ── Nav ── */}
+        <nav className="flex items-center justify-between px-6 py-4 max-w-5xl mx-auto border-b border-stone-100">
+          <Link href="/" className="text-xl font-bold text-green-600">
+            GroomGrid 🐾
+          </Link>
+          <Link
+            href="/signup?coupon=BETA50"
+            className="px-4 py-2 rounded-lg bg-green-500 text-white text-sm font-semibold hover:bg-green-600 transition-colors"
+          >
+            Start Free Trial
+          </Link>
+        </nav>
+
+        {/* ── Breadcrumb ── */}
+        <div className="px-6 py-3 max-w-5xl mx-auto">
+          <nav aria-label="Breadcrumb" className="text-sm text-stone-500">
+            <ol className="flex items-center gap-2">
+              <li><Link href="/" className="hover:text-green-600 transition-colors">Home</Link></li>
+              <li aria-hidden="true">/</li>
+              <li><Link href="/blog" className="hover:text-green-600 transition-colors">Blog</Link></li>
+              <li aria-hidden="true">/</li>
+              <li className="text-stone-700 font-medium" aria-current="page">Start a Mobile Grooming Business</li>
+            </ol>
+          </nav>
+        </div>
+
+        {/* ── Hero ── */}
+        <header className="px-6 pt-10 pb-12 max-w-4xl mx-auto">
+          <p className="text-green-600 font-semibold text-sm uppercase tracking-widest mb-4">
+            Starting Out
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-extrabold text-stone-900 leading-tight mb-6">
+            How to Start a Mobile Dog<br className="hidden sm:block" /> Grooming Business
+          </h1>
+          <p className="text-xl text-stone-600 leading-relaxed max-w-3xl">
+            Mobile dog grooming is one of the most profitable models in the pet industry — low overhead,
+            premium pricing, and clients who are loyal because you make their lives easier. Here&apos;s
+            the complete roadmap to launch yours.
+          </p>
+        </header>
+
+        {/* ── Why Mobile ── */}
+        <section className="px-6 py-12 bg-green-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-2xl font-bold text-stone-800 mb-4">Why Mobile Grooming Is a Smart Business Model</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              Mobile grooming solves a real problem for dog owners: they don&apos;t want to drive to a
+              salon, wait around for hours, and deal with a stressed dog who&apos;s been around other
+              animals all day. You come to them. That convenience commands a premium — typically 20–35%
+              above local salon rates.
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {[
+                { pro: 'No lease costs', detail: 'Your van is your salon — no monthly rent on top of equipment' },
+                { pro: 'Premium pricing', detail: 'Clients pay more for the convenience of door-to-door service' },
+                { pro: 'Flexible schedule', detail: 'Set your own routes, hours, and service zones' },
+                { pro: 'Lower startup than salon', detail: 'A used van + equipment can get you operational for $20–$40K' },
+                { pro: 'One-on-one attention', detail: 'Dogs are calmer alone — your grooms can be faster and higher quality' },
+                { pro: 'Loyal client base', detail: 'Mobile clients tend to be highly loyal once they find a groomer they trust' },
+              ].map(({ pro, detail }) => (
+                <div key={pro} className="p-4 bg-white rounded-lg border border-stone-200">
+                  <p className="font-semibold text-stone-800 mb-1">{pro}</p>
+                  <p className="text-sm text-stone-500">{detail}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Step 1: Licensing ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">Step 1: Licensing and Legal Requirements</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Requirements vary by state and city. Most states don&apos;t require a specific grooming
+            license, but you&apos;ll need a business license, the right insurance, and potentially
+            a pet care facility permit depending on local ordinances.
+          </p>
+          <ul className="space-y-3 mb-4">
+            {[
+              'Register your business (LLC is recommended for liability protection) — $50–$500 filing fee',
+              'Obtain a local business license — typically $50–$200/year',
+              'Check state grooming certification requirements — varies widely',
+              'Get general liability insurance AND commercial auto insurance — see Step 5',
+              'Check local zoning — some areas restrict home-based van businesses',
+            ].map((item) => (
+              <li key={item} className="flex items-start gap-3 text-stone-600">
+                <span className="text-green-500 font-bold mt-0.5">✓</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* ── Step 2: Van ── */}
+        <section className="px-6 py-14 bg-stone-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">Step 2: Choosing and Setting Up Your Van</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              Your van is your most important investment. You have three main options:
+            </p>
+            <div className="space-y-4 mb-6">
+              {[
+                {
+                  option: 'Buy a pre-converted grooming van',
+                  cost: '$25,000–$70,000',
+                  pros: 'Ready to operate quickly, professional layout already done',
+                  cons: 'Higher upfront cost, limited customization',
+                },
+                {
+                  option: 'Buy a used cargo van + convert it',
+                  cost: '$8,000–$25,000 total',
+                  pros: 'More affordable, customize to your workflow',
+                  cons: 'Conversion takes time, plumbing and electrical work required',
+                },
+                {
+                  option: 'Lease or finance a new grooming van',
+                  cost: '$500–$1,200/month',
+                  pros: 'Newest equipment, less upfront cash',
+                  cons: 'Ongoing fixed cost, ownership complications',
+                },
+              ].map(({ option, cost, pros, cons }) => (
+                <div key={option} className="p-5 bg-white rounded-xl border border-stone-200">
+                  <div className="flex justify-between items-start mb-2">
+                    <p className="font-bold text-stone-800">{option}</p>
+                    <span className="text-green-600 font-bold text-sm">{cost}</span>
+                  </div>
+                  <p className="text-stone-600 text-sm"><strong>Pros:</strong> {pros}</p>
+                  <p className="text-stone-600 text-sm"><strong>Cons:</strong> {cons}</p>
+                </div>
+              ))}
+            </div>
+            <p className="text-stone-600 leading-relaxed">
+              For the full equipment list you&apos;ll need to outfit your van, see our{' '}
+              <Link
+                href="/blog/dog-grooming-tools-equipment-list"
+                className="text-green-600 font-medium hover:text-green-700 underline underline-offset-2"
+              >
+                dog grooming tools and equipment list
+              </Link>
+              .
+            </p>
+          </div>
+        </section>
+
+        {/* ── Step 3: Pricing ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">Step 3: Setting Your Prices</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Mobile pricing should reflect the premium service you offer. Research local salon rates and
+            add 20–35%. Most mobile groomers charge $75–$150+ for a full groom depending on breed,
+            size, and coat condition.
+          </p>
+          <div className="bg-green-50 border border-green-200 rounded-xl p-6">
+            <p className="font-semibold text-stone-800 mb-3">Sample mobile pricing ranges:</p>
+            <div className="space-y-2 text-stone-700">
+              <div className="flex justify-between"><span>Small breed full groom</span><span className="font-bold">$75–$100</span></div>
+              <div className="flex justify-between"><span>Medium breed full groom</span><span className="font-bold">$90–$130</span></div>
+              <div className="flex justify-between"><span>Large breed full groom</span><span className="font-bold">$120–$175</span></div>
+              <div className="flex justify-between"><span>Nail trim only</span><span className="font-bold">$25–$40</span></div>
+              <div className="flex justify-between"><span>Bath + brush only</span><span className="font-bold">$55–$85</span></div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Step 4: First Clients ── */}
+        <section className="px-6 py-14 bg-stone-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">Step 4: Getting Your First Clients</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              The first 10–20 clients are the hardest. After that, referrals do most of the work.
+            </p>
+            <ul className="space-y-3">
+              {[
+                'Set up Google Business Profile immediately — local search drives most new mobile grooming clients',
+                'Post in neighborhood Facebook groups and Nextdoor — introduce yourself, offer a launch discount',
+                'Partner with local vets and pet stores — leave business cards, offer referral discounts',
+                'Ask every early client for a Google review — 5 reviews gets you into map results',
+                'Instagram before/after photos — shows your work, builds trust, reaches local pet owners',
+                'Offer a friends & family discount for your first 10 clients to build reviews fast',
+              ].map((item) => (
+                <li key={item} className="flex items-start gap-3 text-stone-600">
+                  <span className="text-green-500 font-bold mt-0.5">✓</span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        {/* ── Step 5: Insurance & Tools ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">Step 5: Insurance and Business Software</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            <strong>Insurance:</strong> You need commercial auto insurance (your personal policy won&apos;t
+            cover a grooming van), general liability, and care/custody/control coverage. Budget $1,500–$4,000
+            per year combined.
+          </p>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            <strong>Business software:</strong> From your first client, use software to manage bookings,
+            send reminders, collect deposits, and store pet profiles. Managing 20+ active clients via text
+            and paper is chaos waiting to happen — and no-shows become very expensive when you&apos;ve
+            already driven to the location.
+          </p>
+          <p className="text-stone-600 leading-relaxed">
+            For a detailed financial plan with revenue projections, see our{' '}
+            <Link
+              href="/blog/mobile-dog-grooming-business-plan"
+              className="text-green-600 font-medium hover:text-green-700 underline underline-offset-2"
+            >
+              mobile dog grooming business plan template
+            </Link>
+            .
+          </p>
+        </section>
+
+        {/* ── Signup CTA ── */}
+        <section className="px-6 py-16 bg-green-600 text-white">
+          <div className="max-w-3xl mx-auto text-center">
+            <h2 className="text-3xl font-extrabold mb-4">
+              Start your mobile business with the right software
+            </h2>
+            <p className="text-green-100 text-lg mb-8 leading-relaxed">
+              GroomGrid is built for mobile groomers — manage your bookings, deposits, reminders, and
+              client records from your phone while you&apos;re on the road. Try it free with 50% off
+              your first month.
+            </p>
+            <Link
+              href="/signup?coupon=BETA50"
+              className="px-8 py-4 rounded-xl bg-white text-green-700 font-bold text-lg hover:bg-green-50 transition-colors shadow-md inline-block"
+            >
+              Start Free Trial →
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Related Articles ── */}
+        <section className="px-6 py-12 max-w-5xl mx-auto">
+          <h2 className="text-xl font-bold text-stone-800 mb-6">Related Articles</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Link
+              href="/blog/mobile-dog-grooming-business-plan"
+              className="group p-5 border border-stone-200 rounded-xl hover:border-green-300 hover:shadow-md transition-all"
+            >
+              <p className="text-sm text-green-600 font-semibold mb-1">Planning</p>
+              <h3 className="font-bold text-stone-800 group-hover:text-green-600 transition-colors">
+                Mobile Dog Grooming Business Plan: The Complete Template
+              </h3>
+            </Link>
+            <Link
+              href="/blog/how-much-to-start-dog-grooming-business"
+              className="group p-5 border border-stone-200 rounded-xl hover:border-green-300 hover:shadow-md transition-all"
+            >
+              <p className="text-sm text-green-600 font-semibold mb-1">Startup Costs</p>
+              <h3 className="font-bold text-stone-800 group-hover:text-green-600 transition-colors">
+                How Much Does It Cost to Start a Dog Grooming Business?
+              </h3>
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Footer ── */}
+        <footer className="px-6 py-8 max-w-5xl mx-auto border-t border-stone-100 mt-0">
+          <div className="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-stone-400">
+            <Link href="/" className="font-bold text-green-600">GroomGrid 🐾</Link>
+            <div className="flex gap-6">
+              <Link href="/grooming-business-operations/" className="hover:text-stone-600 transition-colors">Operations Hub</Link>
+              <Link href="/mobile-grooming-business/" className="hover:text-stone-600 transition-colors">Mobile Grooming</Link>
+              <Link href="/plans" className="hover:text-stone-600 transition-colors">Pricing</Link>
+              <Link href="/signup?coupon=BETA50" className="hover:text-stone-600 transition-colors">Sign Up</Link>
+            </div>
+            <p>© {new Date().getFullYear()} GroomGrid. All rights reserved.</p>
+          </div>
+        </footer>
+      </div>
+    </>
+  );
+}

--- a/src/app/blog/mobile-dog-grooming-business-tips/page.tsx
+++ b/src/app/blog/mobile-dog-grooming-business-tips/page.tsx
@@ -1,0 +1,315 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Script from 'next/script';
+
+export const metadata: Metadata = {
+  title: 'Mobile Dog Grooming Business Tips: Run a Tighter, More Profitable Operation | GroomGrid',
+  description:
+    'Practical mobile dog grooming business tips from experienced operators — route optimization, van organization, client communication, pricing, and the tools that keep mobile businesses running smoothly.',
+  alternates: {
+    canonical: 'https://getgroomgrid.com/blog/mobile-dog-grooming-business-tips',
+  },
+  openGraph: {
+    title: 'Mobile Dog Grooming Business Tips: Run a Tighter, More Profitable Operation',
+    description:
+      'Practical mobile dog grooming business tips from experienced operators — route optimization, van organization, client communication, pricing, and the tools that keep mobile businesses running smoothly.',
+    url: 'https://getgroomgrid.com/blog/mobile-dog-grooming-business-tips',
+    type: 'article',
+  },
+};
+
+const breadcrumbSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://getgroomgrid.com' },
+    { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://getgroomgrid.com/blog' },
+    {
+      '@type': 'ListItem',
+      position: 3,
+      name: 'Mobile Dog Grooming Business Tips',
+      item: 'https://getgroomgrid.com/blog/mobile-dog-grooming-business-tips',
+    },
+  ],
+};
+
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'Mobile Dog Grooming Business Tips: Run a Tighter, More Profitable Operation',
+  description:
+    'Practical mobile dog grooming business tips from experienced operators — route optimization, van organization, client communication, pricing, and the tools that keep mobile businesses running smoothly.',
+  url: 'https://getgroomgrid.com/blog/mobile-dog-grooming-business-tips',
+  publisher: {
+    '@type': 'Organization',
+    name: 'GroomGrid',
+    url: 'https://getgroomgrid.com',
+    logo: { '@type': 'ImageObject', url: 'https://getgroomgrid.com/favicon.ico' },
+  },
+  mainEntityOfPage: {
+    '@type': 'WebPage',
+    '@id': 'https://getgroomgrid.com/blog/mobile-dog-grooming-business-tips',
+  },
+};
+
+export default function MobileDogGroomingBusinessTipsPage() {
+  return (
+    <>
+      <Script
+        id="breadcrumb-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <Script
+        id="article-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+
+      <div className="min-h-screen bg-white text-stone-900">
+        {/* ── Nav ── */}
+        <nav className="flex items-center justify-between px-6 py-4 max-w-5xl mx-auto border-b border-stone-100">
+          <Link href="/" className="text-xl font-bold text-green-600">
+            GroomGrid 🐾
+          </Link>
+          <Link
+            href="/signup?coupon=BETA50"
+            className="px-4 py-2 rounded-lg bg-green-500 text-white text-sm font-semibold hover:bg-green-600 transition-colors"
+          >
+            Start Free Trial
+          </Link>
+        </nav>
+
+        {/* ── Breadcrumb ── */}
+        <div className="px-6 py-3 max-w-5xl mx-auto">
+          <nav aria-label="Breadcrumb" className="text-sm text-stone-500">
+            <ol className="flex items-center gap-2">
+              <li><Link href="/" className="hover:text-green-600 transition-colors">Home</Link></li>
+              <li aria-hidden="true">/</li>
+              <li><Link href="/blog" className="hover:text-green-600 transition-colors">Blog</Link></li>
+              <li aria-hidden="true">/</li>
+              <li className="text-stone-700 font-medium" aria-current="page">Mobile Grooming Tips</li>
+            </ol>
+          </nav>
+        </div>
+
+        {/* ── Hero ── */}
+        <header className="px-6 pt-10 pb-12 max-w-4xl mx-auto">
+          <p className="text-green-600 font-semibold text-sm uppercase tracking-widest mb-4">
+            Mobile Grooming
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-extrabold text-stone-900 leading-tight mb-6">
+            Mobile Dog Grooming Business Tips:<br className="hidden sm:block" /> Run Smarter, Earn More
+          </h1>
+          <p className="text-xl text-stone-600 leading-relaxed max-w-3xl">
+            Mobile grooming offers freedom and premium pricing — but it also comes with unique
+            operational challenges that salon groomers never face. These tips come from operators who
+            run tight, profitable mobile businesses day in and day out.
+          </p>
+        </header>
+
+        {/* ── Route Optimization ── */}
+        <section className="px-6 py-12 bg-green-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-2xl font-bold text-stone-800 mb-4">1. Optimize Your Routes — It Adds Up Fast</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              A mobile groomer driving 30 extra minutes between appointments loses 30 minutes of
+              productive time — and money on fuel. Over a 5-day week, that&apos;s 2.5 hours and
+              roughly $20–$40 in fuel. Over a year: $1,000–$2,000 and 130 hours gone.
+            </p>
+            <ul className="space-y-3">
+              {[
+                'Group bookings geographically — never bounce across town between stops',
+                'Set service zones and only accept bookings within them (your booking software can enforce this)',
+                'Schedule the farthest client first or last — not in the middle of the day',
+                'Block out "dead time" between clients in outlying areas — fill it or don\'t go there',
+                'Use a route planner (Google Maps multi-stop, Routific) on heavy booking days',
+              ].map((item) => (
+                <li key={item} className="flex items-start gap-3 text-stone-600">
+                  <span className="text-green-500 font-bold mt-0.5">✓</span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        {/* ── Van Organization ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">2. Keep Your Van Like a Professional Kitchen</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            In a mobile van, everything has a place — and everything in its place. Time spent searching
+            for tools is time you&apos;re not grooming. A well-organized van also creates a better
+            experience for clients who see inside.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {[
+              { tip: 'Labeled storage zones', detail: 'Clippers, shears, shampoos, and tools each in a dedicated spot' },
+              { tip: 'Pre-packed kit per service type', detail: 'Keep a small kit ready for nail-only or bath-only quick jobs' },
+              { tip: 'Daily van check', detail: '5 minutes each morning to verify supplies, water level, and equipment status' },
+              { tip: 'Weekly deep clean', detail: 'Prevents odor buildup and keeps the space professional' },
+              { tip: 'Spare blade set always on van', detail: 'A dull blade mid-groom kills your schedule' },
+              { tip: 'Secure everything', detail: 'Tools that shift during driving cause accidents — use magnetic strips, velcro, and bins' },
+            ].map(({ tip, detail }) => (
+              <div key={tip} className="p-4 bg-stone-50 rounded-lg border border-stone-200">
+                <p className="font-semibold text-stone-800 mb-1">{tip}</p>
+                <p className="text-sm text-stone-500">{detail}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* ── Client Communication ── */}
+        <section className="px-6 py-14 bg-stone-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">3. Client Communication is Your #1 Retention Tool</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              Mobile grooming clients chose you partly for the convenience — which means they expect
+              communication that matches. They need to know when you&apos;re coming, when you&apos;re
+              done, and when they should book again.
+            </p>
+            <div className="space-y-4">
+              {[
+                {
+                  timing: 'Day before',
+                  message: 'Appointment reminder with your arrival window (not just the appointment time)',
+                },
+                {
+                  timing: 'Morning of',
+                  message: '"On my way" text when you\'re 15-20 minutes out so they\'re ready',
+                },
+                {
+                  timing: 'After groom',
+                  message: 'Quick note or photo of the completed groom (clients love seeing their clean dog)',
+                },
+                {
+                  timing: '5–6 weeks later',
+                  message: 'Rebooking reminder so they don\'t wait until the coat is out of control',
+                },
+              ].map(({ timing, message }) => (
+                <div key={timing} className="flex gap-4 p-4 bg-white rounded-lg border border-stone-200">
+                  <div className="flex-shrink-0 w-28 text-sm font-semibold text-green-600">{timing}</div>
+                  <p className="text-stone-600">{message}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Pricing for Mobile ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">4. Price Correctly for the Mobile Model</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Mobile grooming commands a premium over salon prices — and it should. You&apos;re providing
+            door-to-door service, a stress-free experience for the dog, and eliminating the owner&apos;s
+            drive. Most markets support a 20–35% premium over local salon rates.
+          </p>
+          <div className="bg-green-50 border border-green-200 rounded-xl p-6 mb-4">
+            <p className="font-semibold text-stone-800 mb-3">Mobile pricing considerations:</p>
+            <ul className="space-y-2 text-stone-700">
+              <li><strong>Travel surcharge:</strong> $5–$20 for clients outside your primary zone</li>
+              <li><strong>Solo-owner premium:</strong> Your undivided attention has value — charge for it</li>
+              <li><strong>Convenience premium:</strong> 20–35% over local salon base rates</li>
+              <li><strong>Fuel adjustment:</strong> Build fuel costs into service pricing, not as a surprise fee</li>
+            </ul>
+          </div>
+          <p className="text-stone-600 leading-relaxed">
+            For a complete breakdown of mobile startup costs and revenue potential, see our{' '}
+            <Link
+              href="/blog/mobile-dog-grooming-business-plan"
+              className="text-green-600 font-medium hover:text-green-700 underline underline-offset-2"
+            >
+              mobile dog grooming business plan guide
+            </Link>
+            .
+          </p>
+        </section>
+
+        {/* ── No-Shows ── */}
+        <section className="px-6 py-14 bg-stone-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">5. No-Shows Hit Harder on Mobile — Protect Yourself</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              When a salon client no-shows, you&apos;ve lost an appointment slot. When a mobile client
+              no-shows, you&apos;ve also lost the drive time and fuel. Your protection mechanisms need
+              to be tighter as a result.
+            </p>
+            <ul className="space-y-3">
+              {[
+                'Require a deposit for all new clients (50% minimum)',
+                'Send reminder the day before AND a "heading your way" message the morning of',
+                'Have a same-day cancellation policy with deposit forfeiture clearly explained at booking',
+                'Keep a waitlist of nearby clients you can contact when a same-day slot opens',
+                'After 2 no-shows, require prepay in full for future bookings',
+              ].map((item) => (
+                <li key={item} className="flex items-start gap-3 text-stone-600">
+                  <span className="text-green-500 font-bold mt-0.5">✓</span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        {/* ── Signup CTA ── */}
+        <section className="px-6 py-16 bg-green-600 text-white">
+          <div className="max-w-3xl mx-auto text-center">
+            <h2 className="text-3xl font-extrabold mb-4">
+              Software built for mobile groomers
+            </h2>
+            <p className="text-green-100 text-lg mb-8 leading-relaxed">
+              GroomGrid handles bookings, deposits, reminders, and client records — all from your
+              phone. Perfect for mobile operators who manage everything on the go. 50% off your first
+              month with code BETA50.
+            </p>
+            <Link
+              href="/signup?coupon=BETA50"
+              className="px-8 py-4 rounded-xl bg-white text-green-700 font-bold text-lg hover:bg-green-50 transition-colors shadow-md inline-block"
+            >
+              Start Free Trial →
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Related Articles ── */}
+        <section className="px-6 py-12 max-w-5xl mx-auto">
+          <h2 className="text-xl font-bold text-stone-800 mb-6">Related Articles</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Link
+              href="/blog/mobile-dog-grooming-business-plan"
+              className="group p-5 border border-stone-200 rounded-xl hover:border-green-300 hover:shadow-md transition-all"
+            >
+              <p className="text-sm text-green-600 font-semibold mb-1">Planning</p>
+              <h3 className="font-bold text-stone-800 group-hover:text-green-600 transition-colors">
+                Mobile Dog Grooming Business Plan: The Complete Template
+              </h3>
+            </Link>
+            <Link
+              href="/blog/reduce-no-shows-dog-grooming"
+              className="group p-5 border border-stone-200 rounded-xl hover:border-green-300 hover:shadow-md transition-all"
+            >
+              <p className="text-sm text-green-600 font-semibold mb-1">Operations</p>
+              <h3 className="font-bold text-stone-800 group-hover:text-green-600 transition-colors">
+                How to Reduce No-Shows in Your Dog Grooming Business
+              </h3>
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Footer ── */}
+        <footer className="px-6 py-8 max-w-5xl mx-auto border-t border-stone-100 mt-0">
+          <div className="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-stone-400">
+            <Link href="/" className="font-bold text-green-600">GroomGrid 🐾</Link>
+            <div className="flex gap-6">
+              <Link href="/grooming-business-operations/" className="hover:text-stone-600 transition-colors">Operations Hub</Link>
+              <Link href="/mobile-grooming-business/" className="hover:text-stone-600 transition-colors">Mobile Grooming</Link>
+              <Link href="/plans" className="hover:text-stone-600 transition-colors">Pricing</Link>
+              <Link href="/signup?coupon=BETA50" className="hover:text-stone-600 transition-colors">Sign Up</Link>
+            </div>
+            <p>© {new Date().getFullYear()} GroomGrid. All rights reserved.</p>
+          </div>
+        </footer>
+      </div>
+    </>
+  );
+}

--- a/src/app/blog/pet-grooming-software/page.tsx
+++ b/src/app/blog/pet-grooming-software/page.tsx
@@ -1,0 +1,310 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Script from 'next/script';
+
+export const metadata: Metadata = {
+  title: 'Pet Grooming Software: What It Is and Why Your Business Needs It | GroomGrid',
+  description:
+    'Pet grooming software automates booking, reminders, payments, and client records. Learn what to look for, what to avoid, and how the right tool transforms your grooming business.',
+  alternates: {
+    canonical: 'https://getgroomgrid.com/blog/pet-grooming-software',
+  },
+  openGraph: {
+    title: 'Pet Grooming Software: What It Is and Why Your Business Needs It',
+    description:
+      'Pet grooming software automates booking, reminders, payments, and client records. Learn what to look for, what to avoid, and how the right tool transforms your grooming business.',
+    url: 'https://getgroomgrid.com/blog/pet-grooming-software',
+    type: 'article',
+  },
+};
+
+const breadcrumbSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://getgroomgrid.com' },
+    { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://getgroomgrid.com/blog' },
+    {
+      '@type': 'ListItem',
+      position: 3,
+      name: 'Pet Grooming Software',
+      item: 'https://getgroomgrid.com/blog/pet-grooming-software',
+    },
+  ],
+};
+
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'Pet Grooming Software: What It Is and Why Your Business Needs It',
+  description:
+    'Pet grooming software automates booking, reminders, payments, and client records. Learn what to look for, what to avoid, and how the right tool transforms your grooming business.',
+  url: 'https://getgroomgrid.com/blog/pet-grooming-software',
+  publisher: {
+    '@type': 'Organization',
+    name: 'GroomGrid',
+    url: 'https://getgroomgrid.com',
+    logo: { '@type': 'ImageObject', url: 'https://getgroomgrid.com/favicon.ico' },
+  },
+  mainEntityOfPage: {
+    '@type': 'WebPage',
+    '@id': 'https://getgroomgrid.com/blog/pet-grooming-software',
+  },
+};
+
+export default function PetGroomingSoftwarePage() {
+  return (
+    <>
+      <Script
+        id="breadcrumb-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <Script
+        id="article-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+
+      <div className="min-h-screen bg-white text-stone-900">
+        {/* ── Nav ── */}
+        <nav className="flex items-center justify-between px-6 py-4 max-w-5xl mx-auto border-b border-stone-100">
+          <Link href="/" className="text-xl font-bold text-green-600">
+            GroomGrid 🐾
+          </Link>
+          <Link
+            href="/signup?coupon=BETA50"
+            className="px-4 py-2 rounded-lg bg-green-500 text-white text-sm font-semibold hover:bg-green-600 transition-colors"
+          >
+            Start Free Trial
+          </Link>
+        </nav>
+
+        {/* ── Breadcrumb ── */}
+        <div className="px-6 py-3 max-w-5xl mx-auto">
+          <nav aria-label="Breadcrumb" className="text-sm text-stone-500">
+            <ol className="flex items-center gap-2">
+              <li><Link href="/" className="hover:text-green-600 transition-colors">Home</Link></li>
+              <li aria-hidden="true">/</li>
+              <li><Link href="/blog" className="hover:text-green-600 transition-colors">Blog</Link></li>
+              <li aria-hidden="true">/</li>
+              <li className="text-stone-700 font-medium" aria-current="page">Pet Grooming Software</li>
+            </ol>
+          </nav>
+        </div>
+
+        {/* ── Hero ── */}
+        <header className="px-6 pt-10 pb-12 max-w-4xl mx-auto">
+          <p className="text-green-600 font-semibold text-sm uppercase tracking-widest mb-4">
+            Software Guide
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-extrabold text-stone-900 leading-tight mb-6">
+            Pet Grooming Software:<br className="hidden sm:block" /> The Complete Beginner&apos;s Guide
+          </h1>
+          <p className="text-xl text-stone-600 leading-relaxed max-w-3xl">
+            If you&apos;re still managing your grooming business with a paper calendar, group texts, and
+            Venmo, you&apos;re working harder than you need to. Pet grooming software handles the
+            repetitive admin automatically — so you can focus on the dogs.
+          </p>
+        </header>
+
+        {/* ── What Is It ── */}
+        <section className="px-6 py-12 bg-green-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-2xl font-bold text-stone-800 mb-4">What Is Pet Grooming Software?</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              Pet grooming software is a purpose-built business management platform for professional
+              groomers. Unlike generic scheduling tools (Google Calendar, Calendly) or general
+              appointment apps, grooming software understands how grooming businesses actually work —
+              service durations by breed, deposit policies, recurring appointment cycles, and the
+              specific details you need for every pet.
+            </p>
+            <p className="text-stone-600 leading-relaxed">
+              At its core, good grooming software does three things: it fills your schedule efficiently,
+              it keeps clients informed and returning, and it gets you paid without friction.
+            </p>
+          </div>
+        </section>
+
+        {/* ── Core Features ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">Core Features to Expect</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+            {[
+              {
+                title: 'Online Booking',
+                desc: 'Clients book 24/7 from a link you share. No more back-and-forth texts to find open slots.',
+              },
+              {
+                title: 'Client & Pet Profiles',
+                desc: 'Store breed, coat type, health notes, service history, and owner preferences per dog.',
+              },
+              {
+                title: 'Automated Reminders',
+                desc: 'SMS and email reminders go out automatically before appointments — reducing no-shows by 40-60%.',
+              },
+              {
+                title: 'Deposit Collection',
+                desc: 'Require deposits at booking to protect your time. Applied automatically at checkout.',
+              },
+              {
+                title: 'Payment Processing',
+                desc: 'Accept cards, digital wallets, and online payments without a separate tool.',
+              },
+              {
+                title: 'Rebooking Reminders',
+                desc: 'Automatically prompt clients to rebook based on typical grooming cycles for their breed.',
+              },
+            ].map(({ title, desc }) => (
+              <div key={title} className="p-5 bg-stone-50 rounded-xl border border-stone-200">
+                <p className="font-bold text-stone-800 mb-2">{title}</p>
+                <p className="text-sm text-stone-600">{desc}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* ── Who Needs It ── */}
+        <section className="px-6 py-14 bg-stone-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">When Do You Actually Need Software?</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              Many groomers start without software and get by for a while. But there are clear signals
+              that manual systems are holding you back:
+            </p>
+            <ul className="space-y-3 mb-6">
+              {[
+                'You&apos;ve had at least one double-booking or missed appointment in the last 30 days',
+                'You spend more than 30 minutes per week chasing confirmations or sending reminders manually',
+                'You&apos;ve forgotten a client&apos;s service preferences or their dog&apos;s health notes',
+                'A client no-showed without warning and you lost that slot with no recourse',
+                'You&apos;re not sure which clients haven&apos;t rebooked in the last 8 weeks',
+              ].map((item) => (
+                <li key={item} className="flex items-start gap-3 text-stone-600">
+                  <span className="text-red-400 font-bold mt-0.5">→</span>
+                  <span dangerouslySetInnerHTML={{ __html: item }} />
+                </li>
+              ))}
+            </ul>
+            <p className="text-stone-600 leading-relaxed">
+              If any of those resonate, software will pay for itself within the first month — often in
+              the first week, by preventing a single no-show.
+            </p>
+          </div>
+        </section>
+
+        {/* ── Generic vs Grooming Software ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">Generic Scheduling Apps vs Grooming-Specific Software</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Tools like Calendly, Square Appointments, or Acuity Scheduling can handle basic booking —
+            but they weren&apos;t built for grooming. They don&apos;t know that a Poodle full groom
+            takes 3 hours but a nail trim takes 20 minutes. They don&apos;t store coat notes or track
+            grooming history per dog. They can&apos;t prompt clients to rebook based on breed cycle.
+          </p>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Grooming-specific software builds all of that in. It means less manual configuration,
+            fewer workarounds, and a client experience that feels tailored to the pet — because it is.
+          </p>
+          <div className="bg-green-50 border border-green-200 rounded-xl p-6">
+            <p className="font-semibold text-stone-800 mb-2">The right mental model:</p>
+            <p className="text-stone-600">
+              Generic tools are hammers. Grooming software is a scalpel. Both cut, but one is built for
+              the specific job. As your client list grows, you feel that difference every single day.
+            </p>
+          </div>
+        </section>
+
+        {/* ── What to Look For ── */}
+        <section className="px-6 py-14 bg-green-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">What to Look For When Choosing</h2>
+            <ul className="space-y-3">
+              {[
+                'Free trial with no credit card required — test it before you commit',
+                'Mobile-friendly for managing your schedule from anywhere',
+                'Built-in reminders that work without manual setup',
+                'Transparent pricing with no surprise add-on fees',
+                'Onboarding that gets you running in under an hour',
+                'Customer support you can actually reach when something goes wrong',
+              ].map((item) => (
+                <li key={item} className="flex items-start gap-3 text-stone-600">
+                  <span className="text-green-500 font-bold mt-0.5">✓</span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+            <p className="text-stone-600 leading-relaxed mt-6">
+              For a deeper comparison of the top platforms available, read our full{' '}
+              <Link
+                href="/blog/dog-grooming-software"
+                className="text-green-600 font-medium hover:text-green-700 underline underline-offset-2"
+              >
+                dog grooming software buyer&apos;s guide
+              </Link>
+              .
+            </p>
+          </div>
+        </section>
+
+        {/* ── Signup CTA ── */}
+        <section className="px-6 py-16 bg-green-600 text-white">
+          <div className="max-w-3xl mx-auto text-center">
+            <h2 className="text-3xl font-extrabold mb-4">
+              Ready to run your grooming business smarter?
+            </h2>
+            <p className="text-green-100 text-lg mb-8 leading-relaxed">
+              GroomGrid is pet grooming software built for independent groomers — simple, affordable,
+              and everything you need in one place. Try it free with 50% off your first month.
+            </p>
+            <Link
+              href="/signup?coupon=BETA50"
+              className="px-8 py-4 rounded-xl bg-white text-green-700 font-bold text-lg hover:bg-green-50 transition-colors shadow-md inline-block"
+            >
+              Start Free Trial →
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Related Articles ── */}
+        <section className="px-6 py-12 max-w-5xl mx-auto">
+          <h2 className="text-xl font-bold text-stone-800 mb-6">Related Articles</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Link
+              href="/blog/dog-grooming-software"
+              className="group p-5 border border-stone-200 rounded-xl hover:border-green-300 hover:shadow-md transition-all"
+            >
+              <p className="text-sm text-green-600 font-semibold mb-1">Software</p>
+              <h3 className="font-bold text-stone-800 group-hover:text-green-600 transition-colors">
+                Dog Grooming Software: The 2026 Buyer&apos;s Guide
+              </h3>
+            </Link>
+            <Link
+              href="/blog/dog-grooming-business-management"
+              className="group p-5 border border-stone-200 rounded-xl hover:border-green-300 hover:shadow-md transition-all"
+            >
+              <p className="text-sm text-green-600 font-semibold mb-1">Operations</p>
+              <h3 className="font-bold text-stone-800 group-hover:text-green-600 transition-colors">
+                Dog Grooming Business Management: The Complete Guide
+              </h3>
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Footer ── */}
+        <footer className="px-6 py-8 max-w-5xl mx-auto border-t border-stone-100 mt-0">
+          <div className="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-stone-400">
+            <Link href="/" className="font-bold text-green-600">GroomGrid 🐾</Link>
+            <div className="flex gap-6">
+              <Link href="/grooming-business-operations/" className="hover:text-stone-600 transition-colors">Operations Hub</Link>
+              <Link href="/mobile-grooming-business/" className="hover:text-stone-600 transition-colors">Mobile Grooming</Link>
+              <Link href="/plans" className="hover:text-stone-600 transition-colors">Pricing</Link>
+              <Link href="/signup?coupon=BETA50" className="hover:text-stone-600 transition-colors">Sign Up</Link>
+            </div>
+            <p>© {new Date().getFullYear()} GroomGrid. All rights reserved.</p>
+          </div>
+        </footer>
+      </div>
+    </>
+  );
+}

--- a/src/lib/blog-posts.ts
+++ b/src/lib/blog-posts.ts
@@ -54,4 +54,58 @@ export const blogPosts: BlogPost[] = [
     description: 'Cut grooming no-shows by 60% with automated reminders, deposit policies, and a multi-touch follow-up strategy. Real tactics groomers use every day.',
     publishedAt: '2026-04-06',
   },
+  {
+    slug: 'groomgrid-vs-moego',
+    title: 'GroomGrid vs MoeGo: Which Dog Grooming Software is Right for You?',
+    description: 'Comparing GroomGrid vs MoeGo for dog grooming businesses? See how pricing, features, and ease of use stack up — and why independent groomers are switching.',
+    publishedAt: '2026-04-20',
+  },
+  {
+    slug: 'dog-grooming-tools-equipment-list',
+    title: 'Dog Grooming Tools & Equipment List: The Complete Professional Checklist',
+    description: 'Complete dog grooming tools and equipment list for professional groomers. Covers clippers, shears, dryers, tables, tubs, and estimated costs for mobile and salon setups.',
+    publishedAt: '2026-04-21',
+  },
+  {
+    slug: 'pet-grooming-software',
+    title: 'Pet Grooming Software: What It Is and Why Your Business Needs It',
+    description: 'Pet grooming software automates booking, reminders, payments, and client records. Learn what to look for, what to avoid, and how the right tool transforms your grooming business.',
+    publishedAt: '2026-04-21',
+  },
+  {
+    slug: 'best-pet-grooming-software',
+    title: 'Best Pet Grooming Software in 2026: Top Picks for Professional Groomers',
+    description: 'The best pet grooming software for 2026 — reviewed and compared. Find the right platform for solo groomers, mobile businesses, and small salons based on features, pricing, and ease of use.',
+    publishedAt: '2026-04-22',
+  },
+  {
+    slug: 'how-to-increase-sales-dog-grooming-business',
+    title: 'How to Increase Sales in Your Dog Grooming Business: 8 Proven Strategies',
+    description: 'Increase revenue in your dog grooming business without adding more appointments. Learn upselling, service packages, rebooking strategies, and the operational changes that drive growth.',
+    publishedAt: '2026-04-22',
+  },
+  {
+    slug: 'mobile-dog-grooming-business-tips',
+    title: 'Mobile Dog Grooming Business Tips: Run a Tighter, More Profitable Operation',
+    description: 'Practical mobile dog grooming business tips from experienced operators — route optimization, van organization, client communication, pricing, and the tools that keep mobile businesses running smoothly.',
+    publishedAt: '2026-04-22',
+  },
+  {
+    slug: 'dog-grooming-client-intake-form',
+    title: 'Dog Grooming Client Intake Form: What to Ask Every New Client',
+    description: 'A complete guide to dog grooming client intake forms — what questions to ask, what information protects your business, and how to collect it digitally without the paperwork.',
+    publishedAt: '2026-04-23',
+  },
+  {
+    slug: 'how-much-to-start-dog-grooming-business',
+    title: 'How Much Does It Cost to Start a Dog Grooming Business?',
+    description: 'Detailed cost breakdown to start a dog grooming business in 2026 — equipment, licensing, insurance, marketing, and software. Includes home salon, mobile, and retail location estimates.',
+    publishedAt: '2026-04-23',
+  },
+  {
+    slug: 'how-to-start-a-mobile-dog-grooming-business',
+    title: 'How to Start a Mobile Dog Grooming Business: The Complete Guide',
+    description: 'Everything you need to start a mobile dog grooming business — van setup, licensing, pricing, finding first clients, and the tools to manage it all from day one.',
+    publishedAt: '2026-04-23',
+  },
 ].sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());


### PR DESCRIPTION
## Summary

- Creates 9 new blog pages that were returning 404 but have impressions in Google Search Console and Bing, recovering SEO value for indexed grooming keywords
- Each page follows the exact existing pattern: `Metadata` export, Schema.org Article + BreadcrumbList JSON-LD via `next/script`, 800-1200 words of original content, signup CTA linking to `/signup?coupon=BETA50`, and 2-3 internal links to related posts
- Updates `src/lib/blog-posts.ts` with 9 new `BlogPost` entries and adjusts the sitemap test total count from 17 to 26

**New pages:**
- `/blog/groomgrid-vs-moego` — GroomGrid vs MoeGo comparison with feature table
- `/blog/dog-grooming-tools-equipment-list` — Complete equipment list with costs
- `/blog/pet-grooming-software` — Beginner's guide to grooming software
- `/blog/best-pet-grooming-software` — 2026 top picks with platform reviews
- `/blog/how-to-increase-sales-dog-grooming-business` — 8 revenue strategies
- `/blog/mobile-dog-grooming-business-tips` — Operational tips for mobile groomers
- `/blog/dog-grooming-client-intake-form` — Complete intake form guide
- `/blog/how-much-to-start-dog-grooming-business` — Full startup cost breakdown
- `/blog/how-to-start-a-mobile-dog-grooming-business` — Step-by-step launch guide

## Test plan

- [x] Sitemap test passes: 11/11 tests green (26 total sitemap entries)
- [ ] Verify all 9 URLs return 200 after deploy
- [ ] Check pages appear in sitemap.xml post-deploy
- [ ] Confirm Google/Bing stop returning 404 for these URLs over time

🤖 Generated with [Claude Code](https://claude.com/claude-code)