### PR TITLE
feat: Add UTM attribution tracking to signup flow and profiles

### DIFF
--- a/prisma/migrations/20260423000000_add_attribution_data_to_profiles/migration.sql
+++ b/prisma/migrations/20260423000000_add_attribution_data_to_profiles/migration.sql
@@ -1,0 +1,4 @@
+-- Add attribution_data JSONB column to profiles table for UTM tracking
+-- This enables attribution of signups to marketing channels (utm_source, etc.)
+-- Supports the "Get first 100 paying subscribers" rock by providing visibility into acquisition channels
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS attribution_data JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,7 @@ model Profile {
   welcomeShown         Boolean   @default(false) @map("welcome_shown")
   stripeCustomerId     String?   @map("stripe_customer_id")
   stripeSubscriptionId String?   @map("stripe_subscription_id")
+  attributionData      Json?     @map("attribution_data")
   createdAt            DateTime  @default(now()) @map("created_at")
   updatedAt            DateTime  @updatedAt @map("updated_at")
 

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -63,7 +63,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const { email, password, businessName } = await req.json()
+    const { email, password, businessName, attributionData } = await req.json()
 
     if (!email || !password || !businessName) {
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
@@ -92,6 +92,7 @@ export async function POST(req: NextRequest) {
             businessName,
             subscriptionStatus: 'trial',
             trialEndsAt,
+            ...(attributionData && { attributionData }),
           },
         },
       },

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -81,6 +81,29 @@ function SignupPageInner() {
     }
   }, []);
 
+  // Capture UTM parameters from URL and store in sessionStorage for attribution tracking
+  // This enables channel/source analysis for the "Get first 100 paying subscribers" rock
+  useEffect(() => {
+    const utmSource = searchParams.get('utm_source');
+    const utmMedium = searchParams.get('utm_medium');
+    const utmCampaign = searchParams.get('utm_campaign');
+    const utmContent = searchParams.get('utm_content');
+    const utmTerm = searchParams.get('utm_term');
+
+    if (utmSource || utmMedium || utmCampaign) {
+      const attribution = {
+        utm_source: utmSource,
+        utm_medium: utmMedium,
+        utm_campaign: utmCampaign,
+        utm_content: utmContent,
+        utm_term: utmTerm,
+        timestamp: new Date().toISOString(),
+        referrer: typeof document !== 'undefined' ? document.referrer : null,
+      };
+      sessionStorage.setItem('gg_attribution', JSON.stringify(attribution));
+    }
+  }, [searchParams]);
+
   // Show sticky mobile CTA when form scrolls out of view
   useEffect(() => {
     const el = formRef.current;
@@ -134,6 +157,15 @@ function SignupPageInner() {
 
     trackSignupStarted(formData.businessName);
 
+    // Retrieve UTM attribution from sessionStorage (set on page load by useEffect)
+    let attribution = null;
+    if (typeof window !== 'undefined') {
+      const stored = sessionStorage.getItem('gg_attribution');
+      if (stored) {
+        attribution = JSON.parse(stored);
+      }
+    }
+
     try {
       const res = await fetch('/api/auth/signup', {
         method: 'POST',
@@ -142,6 +174,7 @@ function SignupPageInner() {
           email: formData.email,
           password: formData.password,
           businessName: formData.businessName,
+          attributionData: attribution,
         }),
       });
 
@@ -159,8 +192,8 @@ function SignupPageInner() {
         return;
       }
 
-      trackSignupCompleted(data.userId);
-      trackAccountCreated(data.userId, formData.businessName);
+      trackSignupCompleted(data.userId, attribution);
+      trackAccountCreated(data.userId, formData.businessName, attribution);
 
       const result = await signIn('credentials', {
         email: formData.email,

--- a/src/lib/ga4.ts
+++ b/src/lib/ga4.ts
@@ -42,10 +42,14 @@ export function trackSignupViewed() {
 }
 
 // Fires on successful POST /api/auth/signup response
-export function trackSignupCompleted(userId: string) {
-  trackEvent('signup_completed', {
+export function trackSignupCompleted(userId: string, attribution?: Record<string, any>) {
+  const params: Record<string, any> = {
     user_id: userId,
-  });
+  };
+  if (attribution?.utm_source) params.utm_source = attribution.utm_source;
+  if (attribution?.utm_campaign) params.utm_campaign = attribution.utm_campaign;
+  if (attribution?.utm_medium) params.utm_medium = attribution.utm_medium;
+  trackEvent('signup_completed', params);
 }
 
 // Fires when user lands on /plans page (once per mount)
@@ -110,12 +114,16 @@ export function trackOnboardingSkipped(reason?: string) {
   });
 }
 
-export function trackAccountCreated(userId: string, businessName: string) {
-  trackEvent('account_created', {
+export function trackAccountCreated(userId: string, businessName: string, attribution?: Record<string, any>) {
+  const params: Record<string, any> = {
     user_id: userId,
     business_name: businessName,
     timestamp: new Date().toISOString(),
-  });
+  };
+  if (attribution?.utm_source) params.utm_source = attribution.utm_source;
+  if (attribution?.utm_campaign) params.utm_campaign = attribution.utm_campaign;
+  if (attribution?.utm_medium) params.utm_medium = attribution.utm_medium;
+  trackEvent('account_created', params);
 }
 
 export function trackSubscriptionStarted(


### PR DESCRIPTION
## Summary
- Capture UTM parameters (utm_source, utm_medium, utm_campaign, utm_content, utm_term) from signup page URL using `useSearchParams()`
- Store attribution data in `sessionStorage` as `gg_attribution` with timestamp + referrer
- Pass `attributionData` to `/api/auth/signup` POST and store as JSONB `attribution_data` on the Profile model
- Extend `trackSignupCompleted` and `trackAccountCreated` GA4 events to include utm_source, utm_campaign, utm_medium

## Changes
- `src/app/signup/page.tsx` — UTM capture useEffect + sessionStorage + handleSubmit integration
- `src/app/api/auth/signup/route.ts` — Accept optional `attributionData`, pass to Prisma create
- `src/lib/ga4.ts` — Forward UTM params to GA4 events for channel attribution
- `prisma/schema.prisma` — Add `attributionData Json?` to Profile model
- `prisma/migrations/20260423000000_add_attribution_data_to_profiles/migration.sql` — JSONB column

## Testing
- All 154 existing tests pass (no breaking changes — all params optional)

## Post-Merge Actions Required
- Run migration on production: `npx prisma migrate deploy`
- Add follow-up: unit tests for new UTM code paths (sessionStorage parsing, route attribution handling)

## Rocks Supported
- "Get first 100 paying subscribers" — enables channel attribution for signups
- "Deploy end-to-end conversion tracking" — adds attribution visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)