### PR TITLE
fix(analytics): resolve signup funnel tracking — anon events + attribution

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,9 +5,6 @@ const nextConfig = {
       bodySizeLimit: '2mb',
     },
   },
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   // Don't fail builds on prerender errors — many pages use client-side routing
   // (useSearchParams, useRouter) and can't be statically prerendered.
   // They'll be server-rendered at request time instead.

--- a/prisma/migrations/20260423000000_add_attribution_data_to_profiles/migration.sql
+++ b/prisma/migrations/20260423000000_add_attribution_data_to_profiles/migration.sql
@@ -1,0 +1,4 @@
+-- Add attribution_data column to profiles table
+-- Stores UTM and referral attribution captured at signup time for funnel analysis
+
+ALTER TABLE "profiles" ADD COLUMN IF NOT EXISTS "attribution_data" JSONB;

--- a/prisma/migrations/20260423000001_make_analytics_user_id_optional/migration.sql
+++ b/prisma/migrations/20260423000001_make_analytics_user_id_optional/migration.sql
@@ -1,0 +1,13 @@
+-- Make analytics_events.user_id nullable to allow anonymous pre-signup event tracking
+-- Pre-signup funnel events (signup_viewed, signup_started) can now be stored without
+-- a user session, enabling full funnel visibility in the local analytics_events table.
+
+-- Drop NOT NULL constraint
+ALTER TABLE "analytics_events" ALTER COLUMN "user_id" DROP NOT NULL;
+
+-- Recreate FK constraint with SET NULL on delete (was CASCADE)
+-- NULL user_id values are exempt from referential integrity checks in PostgreSQL,
+-- so this correctly handles both anonymous events and user deletion.
+ALTER TABLE "analytics_events" DROP CONSTRAINT IF EXISTS "analytics_events_user_id_fkey";
+ALTER TABLE "analytics_events" ADD CONSTRAINT "analytics_events_user_id_fkey"
+  FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,7 @@ model Profile {
   welcomeShown         Boolean   @default(false) @map("welcome_shown")
   stripeCustomerId     String?   @map("stripe_customer_id")
   stripeSubscriptionId String?   @map("stripe_subscription_id")
+  attributionData      Json?     @map("attribution_data")
   createdAt            DateTime  @default(now()) @map("created_at")
   updatedAt            DateTime  @updatedAt @map("updated_at")
 
@@ -168,13 +169,15 @@ model Feedback {
 
 model AnalyticsEvent {
   id         String   @id @default(cuid())
-  userId     String   @map("user_id")
+  userId     String?  @map("user_id")
   eventName  String   @map("event_name")
   properties Json?
   sessionId  String?  @map("session_id")
   createdAt  DateTime @default(now()) @map("created_at")
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  // userId is optional — anonymous pre-signup events (signup_viewed, signup_started)
+  // are stored without a user session. If a user is deleted, their events are nulled.
+  user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
 
   @@map("analytics_events")
 }

--- a/src/app/api/__tests__/analytics-track.test.ts
+++ b/src/app/api/__tests__/analytics-track.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for POST /api/analytics/track
+ *
+ * Key behaviors:
+ * - Accepts requests with no auth session (anonymous pre-signup events)
+ * - Requires eventName in request body
+ * - Stores event with userId = null when unauthenticated
+ * - Stores event with userId when authenticated
+ * - Passes through sessionId and properties to the DB
+ */
+
+// ─── Mock declarations ─────────────────────────────────────────────────────
+
+const mockAnalyticsEventCreate = jest.fn()
+
+jest.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    analyticsEvent: {
+      create: mockAnalyticsEventCreate,
+    },
+  },
+}))
+
+const mockGetServerSession = jest.fn()
+jest.mock('next-auth', () => ({
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}))
+
+jest.mock('@/lib/next-auth-options', () => ({
+  authOptions: {},
+}))
+
+// ─── Imports ───────────────────────────────────────────────────────────────
+
+import { POST } from '../analytics/track/route'
+import { NextRequest } from 'next/server'
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function makeRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost/api/analytics/track', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockAnalyticsEventCreate.mockResolvedValue({ id: 'evt_test_123' })
+})
+
+describe('POST /api/analytics/track', () => {
+  describe('anonymous (pre-signup) tracking', () => {
+    it('stores event with userId = null when no session exists', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const req = makeRequest({
+        eventName: 'signup_viewed',
+        sessionId: 'sess_123_abc',
+        properties: { page: '/signup' },
+      })
+
+      const res = await POST(req)
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.success).toBe(true)
+      expect(mockAnalyticsEventCreate).toHaveBeenCalledWith({
+        data: {
+          userId: null,
+          eventName: 'signup_viewed',
+          properties: { page: '/signup' },
+          sessionId: 'sess_123_abc',
+        },
+      })
+    })
+
+    it('stores signup_started without a session (funnel entry)', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const req = makeRequest({ eventName: 'signup_started', sessionId: 'sess_456' })
+      const res = await POST(req)
+
+      expect(res.status).toBe(200)
+      expect(mockAnalyticsEventCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ userId: null, eventName: 'signup_started' }),
+        })
+      )
+    })
+  })
+
+  describe('authenticated tracking', () => {
+    it('stores event with userId when a session exists', async () => {
+      mockGetServerSession.mockResolvedValue({
+        user: { id: 'user_abc', email: 'groomer@example.com' },
+        expires: '',
+      })
+
+      const req = makeRequest({
+        eventName: 'appointment_created',
+        sessionId: 'sess_789',
+        properties: { appointmentId: 'appt_1' },
+      })
+
+      const res = await POST(req)
+      const body = await res.json()
+
+      expect(res.status).toBe(200)
+      expect(body.success).toBe(true)
+      expect(mockAnalyticsEventCreate).toHaveBeenCalledWith({
+        data: {
+          userId: 'user_abc',
+          eventName: 'appointment_created',
+          properties: { appointmentId: 'appt_1' },
+          sessionId: 'sess_789',
+        },
+      })
+    })
+  })
+
+  describe('validation', () => {
+    it('returns 400 when eventName is missing', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const req = makeRequest({ sessionId: 'sess_abc', properties: {} })
+      const res = await POST(req)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error).toBe('eventName is required')
+      expect(mockAnalyticsEventCreate).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 for malformed JSON body', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const req = new NextRequest('http://localhost/api/analytics/track', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'this-is-not-json{{{',
+      })
+
+      const res = await POST(req)
+      const body = await res.json()
+
+      expect(res.status).toBe(400)
+      expect(body.error).toBe('Invalid JSON body')
+    })
+
+    it('defaults properties to {} and sessionId to null when not provided', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+
+      const req = makeRequest({ eventName: 'page_viewed' })
+      await POST(req)
+
+      expect(mockAnalyticsEventCreate).toHaveBeenCalledWith({
+        data: {
+          userId: null,
+          eventName: 'page_viewed',
+          properties: {},
+          sessionId: null,
+        },
+      })
+    })
+  })
+
+  describe('error handling', () => {
+    it('returns 500 when Prisma throws', async () => {
+      mockGetServerSession.mockResolvedValue(null)
+      mockAnalyticsEventCreate.mockRejectedValue(new Error('DB connection failed'))
+
+      const req = makeRequest({ eventName: 'signup_viewed' })
+      const res = await POST(req)
+      const body = await res.json()
+
+      expect(res.status).toBe(500)
+      expect(body.error).toContain('DB connection failed')
+    })
+  })
+})

--- a/src/app/api/analytics/track/route.ts
+++ b/src/app/api/analytics/track/route.ts
@@ -23,16 +23,16 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'eventName is required' }, { status: 400 })
   }
 
-  // Auth required for analytics
+  // Auth is optional — anonymous pre-signup events (signup_viewed, signup_started)
+  // are stored with userId = null. This enables full funnel tracking in the local
+  // analytics_events table even before a user account exists.
   const session = await getServerSession(authOptions)
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
+  const userId = session?.user?.id ?? null
 
   try {
     await prisma.analyticsEvent.create({
       data: {
-        userId: session.user.id,
+        userId,
         eventName,
         properties: (properties ?? {}) as object,
         sessionId: sessionId ?? null,
@@ -40,9 +40,10 @@ export async function POST(req: NextRequest) {
     })
 
     return NextResponse.json({ success: true })
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
     return NextResponse.json(
-      { error: `Failed to track event: ${error.message}` },
+      { error: `Failed to track event: ${message}` },
       { status: 500 }
     )
   }

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -63,7 +63,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const { email, password, businessName } = await req.json()
+    const { email, password, businessName, attributionData } = await req.json()
 
     if (!email || !password || !businessName) {
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
@@ -92,6 +92,7 @@ export async function POST(req: NextRequest) {
             businessName,
             subscriptionStatus: 'trial',
             trialEndsAt,
+            ...(attributionData ? { attributionData } : {}),
           },
         },
       },

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -134,6 +134,19 @@ function SignupPageInner() {
 
     trackSignupStarted(formData.businessName);
 
+    // Retrieve UTM attribution captured on page load from sessionStorage
+    let attribution: Record<string, unknown> | null = null;
+    if (typeof window !== 'undefined') {
+      const stored = sessionStorage.getItem('gg_attribution');
+      if (stored) {
+        try {
+          attribution = JSON.parse(stored);
+        } catch {
+          // Ignore malformed attribution data
+        }
+      }
+    }
+
     try {
       const res = await fetch('/api/auth/signup', {
         method: 'POST',
@@ -142,6 +155,7 @@ function SignupPageInner() {
           email: formData.email,
           password: formData.password,
           businessName: formData.businessName,
+          attributionData: attribution,
         }),
       });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,10 @@
     ".next/dev/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "e2e",
+    "tests",
+    "playwright-report",
+    "test-results"
   ]
 }


### PR DESCRIPTION
## Summary

Fixes three root causes that produced 0 signups and an empty `analytics_events` table despite 15 `/signup` sessions (80% bounce):

- **`ignoreBuildErrors: true` removed** from `next.config.mjs` — was silently deploying broken code. `tsconfig.json` updated to exclude `e2e/`, `tests/`, `playwright-report/`, `test-results/` dirs so TypeScript checking stays focused on app code.
- **Analytics track route auth gate removed** — `/api/analytics/track` was returning 401 for unauthenticated requests. Pre-signup events (`signup_viewed`, `signup_started`) now stored with `userId = null`. Two migrations added: `attribution_data` column on `profiles`, and `user_id` made nullable in `analytics_events` with `ON DELETE SET NULL`.
- **UTM attribution wired end-to-end** — Signup page reads `gg_attribution` from sessionStorage on form submit and passes `attributionData` to `/api/auth/signup`, which persists it on the profile. Every new signup now tagged with source.

## Files changed

| File | Change |
|------|--------|
| `next.config.mjs` | Remove `typescript.ignoreBuildErrors: true` |
| `tsconfig.json` | Exclude test/e2e dirs from TS compilation |
| `prisma/schema.prisma` | `AnalyticsEvent.userId` → `String?`, `Profile.attributionData` added |
| `prisma/migrations/20260423000000_*` | Add `attribution_data` column to profiles |
| `prisma/migrations/20260423000001_*` | Make `analytics_events.user_id` nullable, update FK to SET NULL |
| `src/app/api/analytics/track/route.ts` | Optional auth — anonymous events stored with `userId: null` |
| `src/app/signup/page.tsx` | Read sessionStorage attribution + pass to API |
| `src/app/api/auth/signup/route.ts` | Accept + store `attributionData` on profile create |
| `src/app/api/__tests__/analytics-track.test.ts` | 7 new unit tests (anon, authed, validation, errors) |

## Test plan

- [x] 7 new unit tests for analytics track route — all pass
- [x] 980 total tests pass across 40 suites (0 regressions)
- [x] Signup route unit tests (16) still pass after attribution param addition
- [ ] Deploy and verify `/signup` bounce rate drops from 80%
- [ ] Verify `analytics_events` table populates on next session

🤖 Generated with [Claude Code](https://claude.com/claude-code)