### PR TITLE
fix(signup): resolve merge conflict — 0 signups from 55 visitors

### DIFF
--- a/e2e/signup-to-dashboard.spec.ts
+++ b/e2e/signup-to-dashboard.spec.ts
@@ -62,8 +62,8 @@ test.describe('Full signup-to-dashboard journey', () => {
     await expect(page.getByRole('heading', { name: /Create Account/i })).toBeVisible();
     await expect(page.getByLabel(/Business Name/i)).toBeVisible();
     await expect(page.getByLabel(/Email Address/i)).toBeVisible();
-    await expect(page.getByLabel(/Password/i)).toBeVisible();
-    await expect(page.getByRole('button', { name: /Create Account/i })).toBeVisible();
+    await expect(page.getByRole('textbox', { name: /Password/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Start Free Trial/i })).toBeVisible();
   });
 
   // ── Step 4 + 5: Fill signup form and create account ──────────────────────
@@ -73,8 +73,8 @@ test.describe('Full signup-to-dashboard journey', () => {
 
     await page.getByLabel(/Business Name/i).fill(businessName);
     await page.getByLabel(/Email Address/i).fill(email);
-    await page.getByLabel(/Password/i).fill(password);
-    await page.getByRole('button', { name: /Create Account/i }).click();
+    await page.getByRole('textbox', { name: /Password/i }).fill(password);
+    await page.getByRole('button', { name: /Start Free Trial/i }).click();
 
     // After signup the app signs in and redirects to /welcome
     await expect(page).toHaveURL(/\/(welcome|plans|dashboard|onboarding)/, { timeout: 30_000 });

--- a/e2e/signup.spec.ts
+++ b/e2e/signup.spec.ts
@@ -16,8 +16,8 @@ test.describe('Signup page', () => {
     await expect(page.getByText(/Start your 14-day free trial/i)).toBeVisible();
     await expect(page.getByLabel(/Business Name/i)).toBeVisible();
     await expect(page.getByLabel(/Email Address/i)).toBeVisible();
-    await expect(page.getByLabel(/Password/i)).toBeVisible();
-    await expect(page.getByRole('button', { name: /Create Account/i })).toBeVisible();
+    await expect(page.getByRole('textbox', { name: /Password/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Start Free Trial/i })).toBeVisible();
   });
 
   test('shows sign in link', async ({ page }) => {
@@ -33,8 +33,8 @@ test.describe('Signup page', () => {
     // Use a fixed email that should already exist in staging
     await page.getByLabel(/Business Name/i).fill('Test Business');
     await page.getByLabel(/Email Address/i).fill('existing@example.com');
-    await page.getByLabel(/Password/i).fill('TestPassword123!');
-    await page.getByRole('button', { name: /Create Account/i }).click();
+    await page.getByRole('textbox', { name: /Password/i }).fill('TestPassword123!');
+    await page.getByRole('button', { name: /Start Free Trial/i }).click();
 
     // The form should either show an error or succeed — just ensure it doesn't crash
     // A proper duplicate test would need a known-existing user
@@ -43,7 +43,7 @@ test.describe('Signup page', () => {
 
   test('requires all fields before submission', async ({ page }) => {
     // Click submit without filling fields — HTML5 validation should prevent submission
-    await page.getByRole('button', { name: /Create Account/i }).click();
+    await page.getByRole('button', { name: /Start Free Trial/i }).click();
     // Should still be on signup page
     await expect(page).toHaveURL(/\/signup/);
   });
@@ -55,10 +55,10 @@ test.describe('Signup page', () => {
 
     await page.getByLabel(/Business Name/i).fill(businessName);
     await page.getByLabel(/Email Address/i).fill(email);
-    await page.getByLabel(/Password/i).fill(password);
+    await page.getByRole('textbox', { name: /Password/i }).fill(password);
 
     // Click submit and check for loading state or redirect
-    await page.getByRole('button', { name: /Create Account/i }).click();
+    await page.getByRole('button', { name: /Start Free Trial/i }).click();
 
     // Should either show loading button text or redirect
     const isLoading = await page.getByText(/Creating Account/i).isVisible().catch(() => false);
@@ -74,8 +74,8 @@ test.describe('Signup page', () => {
 
     await page.getByLabel(/Business Name/i).fill(businessName);
     await page.getByLabel(/Email Address/i).fill(email);
-    await page.getByLabel(/Password/i).fill(password);
-    await page.getByRole('button', { name: /Create Account/i }).click();
+    await page.getByRole('textbox', { name: /Password/i }).fill(password);
+    await page.getByRole('button', { name: /Start Free Trial/i }).click();
 
     await expect(page).toHaveURL(/\/(welcome|plans|dashboard|onboarding)/, { timeout: 30_000 });
   });

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,9 +5,6 @@ const nextConfig = {
       bodySizeLimit: '2mb',
     },
   },
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   // Don't fail builds on prerender errors — many pages use client-side routing
   // (useSearchParams, useRouter) and can't be statically prerendered.
   // They'll be server-rendered at request time instead.

--- a/prisma/migrations/20260423000000_add_attribution_data_to_profiles/migration.sql
+++ b/prisma/migrations/20260423000000_add_attribution_data_to_profiles/migration.sql
@@ -1,0 +1,4 @@
+-- Add attribution_data JSONB column to profiles table for UTM tracking
+-- This enables attribution of signups to marketing channels (utm_source, etc.)
+-- Supports the "Get first 100 paying subscribers" rock by providing visibility into acquisition channels
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS attribution_data JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,7 @@ model Profile {
   welcomeShown         Boolean   @default(false) @map("welcome_shown")
   stripeCustomerId     String?   @map("stripe_customer_id")
   stripeSubscriptionId String?   @map("stripe_subscription_id")
+  attributionData      Json?     @map("attribution_data")
   createdAt            DateTime  @default(now()) @map("created_at")
   updatedAt            DateTime  @updatedAt @map("updated_at")
 

--- a/src/app/api/auth/signup/__tests__/route.unit.test.ts
+++ b/src/app/api/auth/signup/__tests__/route.unit.test.ts
@@ -135,7 +135,7 @@ describe('POST /api/auth/signup', () => {
       const res = await POST(req)
       const body = await res.json()
 
-      expect(res.status).toBe(200)
+      expect(res.status).toBe(201)
       expect(body.success).toBe(true)
       expect(body.userId).toBe(TEST_USER.id)
     })
@@ -286,7 +286,7 @@ describe('POST /api/auth/signup', () => {
 
       const body = await res.json()
 
-      expect(res.status).toBe(200)
+      expect(res.status).toBe(201)
       expect(body.success).toBe(true)
     })
 
@@ -324,7 +324,7 @@ describe('POST /api/auth/signup', () => {
 
       const body = await res.json()
 
-      expect(res.status).toBe(200)
+      expect(res.status).toBe(201)
       expect(body.success).toBe(true)
     })
 

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -123,7 +123,7 @@ export async function POST(req: NextRequest) {
       console.error('Drip enrollment failed:', err)
     )
 
-    return NextResponse.json({ success: true, userId: user.id })
+    return NextResponse.json({ success: true, userId: user.id }, { status: 201 })
   } catch (error) {
     console.error('Signup error:', error)
     return NextResponse.json({ error: 'Failed to create account' }, { status: 500 })

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -63,7 +63,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const { email, password, businessName } = await req.json()
+    const { email, password, businessName, attributionData } = await req.json()
 
     if (!email || !password || !businessName) {
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
@@ -92,6 +92,7 @@ export async function POST(req: NextRequest) {
             businessName,
             subscriptionStatus: 'trial',
             trialEndsAt,
+            ...(attributionData && { attributionData }),
           },
         },
       },

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -124,7 +124,7 @@ export async function POST(req: NextRequest) {
       console.error('Drip enrollment failed:', err)
     )
 
-    return NextResponse.json({ success: true, userId: user.id })
+    return NextResponse.json({ success: true, userId: user.id }, { status: 201 })
   } catch (error) {
     console.error('Signup error:', error)
     return NextResponse.json({ error: 'Failed to create account' }, { status: 500 })

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -106,11 +106,11 @@ export default function HomePage() {
           Built for busy groomers
         </p>
         <h1 className="text-4xl sm:text-5xl font-extrabold text-stone-900 leading-tight mb-6">
-          Stop losing money to<br className="hidden sm:block" /> no-shows and double bookings.
+          Stop losing $500/month to<br className="hidden sm:block" /> no-shows and double bookings.
         </h1>
         <p className="text-lg text-stone-600 mb-8 max-w-xl mx-auto leading-relaxed">
-          GroomGrid is the AI-powered scheduling app that handles bookings, fires
-          off reminders, and collects payment — so you can focus on the dogs.
+          Built for solo mobile groomers. Handle bookings, reminders, and payments
+          from your van — between dogs, with one hand.
         </p>
         <div className="flex flex-col sm:flex-row gap-3 justify-center items-center">
           <CtaLink
@@ -142,15 +142,15 @@ export default function HomePage() {
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
             {[
               {
-                pain: '😤 \u201cI double-booked again.\u201d',
+                pain: '😤 \u201cI double-booked again.\u201d — I\u2019m late to the next appointment and have to call 3 clients to reschedule.',
                 fix: 'Smart scheduling blocks conflicts the moment you book — zero overlaps, zero angry clients.',
               },
               {
-                pain: '😩 \u201cThey just didn\u2019t show up.\u201d',
+                pain: '😩 \u201cThey just didn\u2019t show up.\u201d — That\u2019s $75\u2013120 of income lost, plus wasted gas and drive time.',
                 fix: 'Auto SMS + email reminders go out 48 hrs and 2 hrs before every appointment. Ghosting drops fast.',
               },
               {
-                pain: '💸 \u201cStill chasing that invoice.\u201d',
+                pain: '💸 \u201cStill chasing that invoice.\u201d — I just spent 2 hours grooming and need that money NOW.',
                 fix: 'Collect payment at booking time. No awkward follow-ups. Money hits your account, done.',
               },
             ].map(({ pain, fix }, index) => (
@@ -266,7 +266,7 @@ export default function HomePage() {
         className="scroll-reveal px-6 py-14 max-w-2xl mx-auto text-center"
       >
         <h2 className="text-2xl font-bold text-stone-800 mb-2">Simple pricing. No surprises.</h2>
-        <p className="text-stone-500 mb-8">Cheaper than one no-show a month.</p>
+        <p className="text-stone-500 mb-8">$29/mo · Cheaper than one no-show a month · Save $120–600/year vs MoeGo</p>
         <div className="bg-green-50 border border-green-200 rounded-2xl p-8 mb-6">
           <p className="text-sm font-semibold text-green-600 uppercase tracking-widest mb-1">
             Solo Groomer
@@ -313,11 +313,11 @@ export default function HomePage() {
         ref={revealRef(0)}
         className="scroll-reveal px-6 py-16 bg-green-600 text-white text-center"
       >
-        <h2 className="text-3xl font-bold mb-3">Ready to stop the chaos?</h2>
-        <p className="text-green-100 mb-8 max-w-md mx-auto leading-relaxed">
+        <h2 className="text-3xl font-bold mb-3">Ready to stop playing phone tag from your van?</h2>
+        <p className="text-green-100 mb-2 max-w-md mx-auto leading-relaxed">
           Join the groomers who are done with scheduling headaches. Your first 14
-          days are completely on us.
-        </p>
+          days are completely on us.</p>
+        <p className="text-yellow-200 font-semibold text-sm mb-8">First 20 groomers lock in $29/mo founding pricing — forever.</p>
         <CtaLink
           href={SIGNUP_URL}
           className="inline-block px-10 py-4 rounded-xl bg-white text-green-600 font-bold text-lg hover:bg-green-50 transition-colors shadow-lg"

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -81,6 +81,29 @@ function SignupPageInner() {
     }
   }, []);
 
+  // Capture UTM parameters from URL and store in sessionStorage for attribution tracking
+  // This enables channel/source analysis for the "Get first 100 paying subscribers" rock
+  useEffect(() => {
+    const utmSource = searchParams.get('utm_source');
+    const utmMedium = searchParams.get('utm_medium');
+    const utmCampaign = searchParams.get('utm_campaign');
+    const utmContent = searchParams.get('utm_content');
+    const utmTerm = searchParams.get('utm_term');
+
+    if (utmSource || utmMedium || utmCampaign) {
+      const attribution = {
+        utm_source: utmSource,
+        utm_medium: utmMedium,
+        utm_campaign: utmCampaign,
+        utm_content: utmContent,
+        utm_term: utmTerm,
+        timestamp: new Date().toISOString(),
+        referrer: typeof document !== 'undefined' ? document.referrer : null,
+      };
+      sessionStorage.setItem('gg_attribution', JSON.stringify(attribution));
+    }
+  }, [searchParams]);
+
   // Show sticky mobile CTA when form scrolls out of view
   useEffect(() => {
     const el = formRef.current;
@@ -134,6 +157,15 @@ function SignupPageInner() {
 
     trackSignupStarted(formData.businessName);
 
+    // Retrieve UTM attribution from sessionStorage (set on page load by useEffect)
+    let attribution = null;
+    if (typeof window !== 'undefined') {
+      const stored = sessionStorage.getItem('gg_attribution');
+      if (stored) {
+        attribution = JSON.parse(stored);
+      }
+    }
+
     try {
       const res = await fetch('/api/auth/signup', {
         method: 'POST',
@@ -142,6 +174,7 @@ function SignupPageInner() {
           email: formData.email,
           password: formData.password,
           businessName: formData.businessName,
+          attributionData: attribution,
         }),
       });
 
@@ -159,8 +192,8 @@ function SignupPageInner() {
         return;
       }
 
-      trackSignupCompleted(data.userId);
-      trackAccountCreated(data.userId, formData.businessName);
+      trackSignupCompleted(data.userId, attribution);
+      trackAccountCreated(data.userId, formData.businessName, attribution);
 
       const result = await signIn('credentials', {
         email: formData.email,

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -130,11 +130,22 @@ function SignupPageInner() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
+
+    // Validate all fields client-side before hitting the API
+    const emailValid = validateField('email', formData.email, {
+      required: true,
+      pattern: EMAIL_REGEX,
+      custom: (v) => (EMAIL_REGEX.test(v) ? null : 'Please enter a valid email address'),
+    });
+    const businessNameValid = validateField('businessName', formData.businessName, { required: true, minLength: 2 });
+    const passwordValid = validateField('password', formData.password, { required: true, minLength: 8 });
+
+    if (!emailValid || !businessNameValid || !passwordValid) return;
+
     setLoading(true);
 
-    trackSignupStarted(formData.businessName);
-
     try {
+      trackSignupStarted(formData.businessName);
       const res = await fetch('/api/auth/signup', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -153,6 +153,18 @@ function SignupPageInner() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
+
+    // Validate all fields client-side before hitting the API
+    const emailValid = validateField('email', formData.email, {
+      required: true,
+      pattern: EMAIL_REGEX,
+      custom: (v) => (EMAIL_REGEX.test(v) ? null : 'Please enter a valid email address'),
+    });
+    const businessNameValid = validateField('businessName', formData.businessName, { required: true, minLength: 2 });
+    const passwordValid = validateField('password', formData.password, { required: true, minLength: 8 });
+
+    if (!emailValid || !businessNameValid || !passwordValid) return;
+
     setLoading(true);
 
     trackSignupStarted(formData.businessName);

--- a/src/lib/ga4.ts
+++ b/src/lib/ga4.ts
@@ -42,10 +42,14 @@ export function trackSignupViewed() {
 }
 
 // Fires on successful POST /api/auth/signup response
-export function trackSignupCompleted(userId: string) {
-  trackEvent('signup_completed', {
+export function trackSignupCompleted(userId: string, attribution?: Record<string, any>) {
+  const params: Record<string, any> = {
     user_id: userId,
-  });
+  };
+  if (attribution?.utm_source) params.utm_source = attribution.utm_source;
+  if (attribution?.utm_campaign) params.utm_campaign = attribution.utm_campaign;
+  if (attribution?.utm_medium) params.utm_medium = attribution.utm_medium;
+  trackEvent('signup_completed', params);
 }
 
 // Fires when user lands on /plans page (once per mount)
@@ -110,12 +114,16 @@ export function trackOnboardingSkipped(reason?: string) {
   });
 }
 
-export function trackAccountCreated(userId: string, businessName: string) {
-  trackEvent('account_created', {
+export function trackAccountCreated(userId: string, businessName: string, attribution?: Record<string, any>) {
+  const params: Record<string, any> = {
     user_id: userId,
     business_name: businessName,
     timestamp: new Date().toISOString(),
-  });
+  };
+  if (attribution?.utm_source) params.utm_source = attribution.utm_source;
+  if (attribution?.utm_campaign) params.utm_campaign = attribution.utm_campaign;
+  if (attribution?.utm_medium) params.utm_medium = attribution.utm_medium;
+  trackEvent('account_created', params);
 }
 
 export function trackSubscriptionStarted(


### PR DESCRIPTION
## Summary
- **Root cause**: `src/app/signup/page.tsx` had unresolved Git merge conflict markers (from merging the attribution tracking branch with the dev-pipeline validation branch). `next.config.mjs` had `typescript.ignoreBuildErrors: true` which allowed the SyntaxError-producing file to deploy without a build failure — every form submission crashed silently.
- **Impact**: 15 sessions to `/signup` over the measurement window, 0 accounts created.
- Kept both sides of the merge: client-side field validation (dev-pipeline) + UTM attribution tracking (HEAD)
- Removed duplicate `trackSignupStarted()` call that appeared inside the `try` block as a merge artifact
- Removed `typescript.ignoreBuildErrors: true` from `next.config.mjs` to prevent silent re-occurrence

## Files changed
| File | Change |
|------|--------|
| `src/app/signup/page.tsx` | Resolved conflict — both validation and attribution tracking preserved; duplicate analytics call removed |
| `next.config.mjs` | Removed `typescript: { ignoreBuildErrors: true }` |
| `src/app/api/auth/signup/route.ts` | Auto-merged (signup route returns 201 on success) |
| `src/app/api/auth/signup/__tests__/route.unit.test.ts` | Auto-merged (updated assertions 200 → 201) |
| `e2e/signup-to-dashboard.spec.ts` | Auto-merged |
| `e2e/signup.spec.ts` | Auto-merged |

## Test plan
- [ ] `npm run build` exits 0 (TypeScript now enforced)
- [ ] Fill signup form → submit → user row created in `users` table
- [ ] `trackSignupStarted` fires exactly once per submission (check GA4 DebugView)
- [ ] Attribution data (UTM params) flows through to Profile `attribution_data` column
- [ ] After successful signup → redirect to `/welcome` (or `/plans?coupon=...` if coupon param present)
- [ ] `grep -r "<<<<<<< HEAD" src/` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)