### PR TITLE
fix(tests): update sitemap count to 32 after new blog/landing pages

### DIFF
--- a/src/__tests__/sitemap.test.ts
+++ b/src/__tests__/sitemap.test.ts
@@ -123,7 +123,7 @@ describe('Sitemap Generation', () => {
   it('should have total entries matching all pages', () => {
     const result = sitemap();
 
-    // 4 static pages + 5 landing pages + 17 blog posts = 26 total
-    expect(result.length).toBe(26);
+    // 4 static pages + 7 landing pages + 21 blog posts = 32 total
+    expect(result.length).toBe(32);
   });
 });


### PR DESCRIPTION
## Summary

- Fixes the one failing test in CI for PR #161 (Stripe env var config)
- `src/__tests__/sitemap.test.ts` had a hardcoded count of `26` that was stale
- Recent content commits added 2 landing pages (`daysmart-alternatives`, `pawfinity-alternatives`) and 4 new blog posts, bringing actual sitemap total to **32**
- Updated comment and assertion: `4 static + 7 landing + 21 blog = 32`

## Test Results

```
Test Suites: 41 passed, 41 total
Tests:       1008 passed, 1008 total
```

## Root Cause

The failing test was not related to the Stripe env var work — it was a pre-existing count mismatch from the content sprint (PRs #159, #160). The fix stage caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)