### PR TITLE
fix(tests): update sitemap entry count to 32

### DIFF
--- a/src/__tests__/sitemap.test.ts
+++ b/src/__tests__/sitemap.test.ts
@@ -123,7 +123,7 @@ describe('Sitemap Generation', () => {
   it('should have total entries matching all pages', () => {
     const result = sitemap();
 
-    // 4 static pages + 5 landing pages + 17 blog posts = 26 total
-    expect(result.length).toBe(26);
+    // 4 static pages + 7 landing pages + 21 blog posts = 32 total
+    expect(result.length).toBe(32);
   });
 });


### PR DESCRIPTION
## Summary
- Main CI is failing because `sitemap.test.ts` still expects 26 entries
- 5 new content pages were added via PRs #159 and #160: 2 landing pages (daysmart-alternatives, pawfinity-alternatives) + several new blog posts
- Actual sitemap count is now **32** (4 static + 7 landing + 21 blog)
- This is a 2-line fix to unblock main and let the pending PRs (#153, #158, #162) merge cleanly

## Test plan
- [ ] CI passes on this branch
- [ ] `expect(result.length).toBe(32)` matches actual sitemap output

🤖 Generated with [Claude Code](https://claude.com/claude-code)