### PR TITLE
feat(seo): add FAQPage schema to 3 striking-distance blog pages

### DIFF
--- a/src/app/blog/dog-grooming-tools-equipment-list/page.tsx
+++ b/src/app/blog/dog-grooming-tools-equipment-list/page.tsx
@@ -52,6 +52,53 @@ const articleSchema = {
   },
 };
 
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'What equipment does a dog groomer need to start?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'A beginner groomer needs professional clippers ($150–400), a blade set (#10, #7F, #5F, #4F), straight and curved shears ($80–200 each), a slicker brush, steel comb, nail trimmers, styptic powder, shampoo and conditioner, towels, a grooming table ($150–500), and a grooming loop or noose. For mobile groomers, add a portable tub and a generator or battery system. Budget $1,500–3,000 for a starter kit.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'How much does dog grooming equipment cost?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'A basic home or starter setup costs $1,500–3,000 including clippers, shears, table, and basic tools. A fully equipped salon runs $10,000–25,000 adding hydraulic tables, professional tubs, cage dryers, and HVAC. A mobile grooming van conversion starts at $25,000–80,000 including the vehicle, water system, generator, and all grooming equipment.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'What is the best grooming table for a mobile groomer?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Mobile groomers need a compact, lightweight table that fits in a van. Folding hydraulic tables ($200–500) are popular because they adjust height and fold flat for storage. Look for models with a non-slip surface, adjustable grooming arm, and weight capacity of at least 150 lbs. Electric tables ($400–800) are quieter but require a reliable power source.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Do I need a grooming van to start a mobile grooming business?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Not necessarily. Many mobile groomers start with a converted trailer ($5,000–15,000) or even a house-call model using portable equipment transported in an SUV or van. A full grooming van conversion ($25,000–80,000) is a significant investment best made after validating your client base. Start small, build demand, then upgrade.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'What software should I use to manage my grooming business?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Professional grooming software like GroomGrid helps manage scheduling, client and pet profiles, automated reminders, and payments — all from one app. For mobile groomers, it eliminates the need to juggle paper calendars, text messages, and spreadsheets. GroomGrid starts at $29/month and includes AI-powered scheduling and breed-specific time estimates.',
+      },
+    },
+  ],
+};
+
 export default function DogGroomingToolsEquipmentListPage() {
   return (
     <>
@@ -64,6 +111,11 @@ export default function DogGroomingToolsEquipmentListPage() {
         id="article-schema"
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+      <Script
+        id="faq-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
       />
 
       <div className="min-h-screen bg-white text-stone-900">

--- a/src/app/blog/groomgrid-vs-moego/page.tsx
+++ b/src/app/blog/groomgrid-vs-moego/page.tsx
@@ -52,6 +52,53 @@ const articleSchema = {
   },
 };
 
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'Is GroomGrid cheaper than MoeGo?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'GroomGrid starts at $29/month for the Solo tier. MoeGo starts around $49/month. For independent and mobile groomers, GroomGrid is meaningfully cheaper while offering AI-powered scheduling that MoeGo lacks.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Does GroomGrid have all the features MoeGo has?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'GroomGrid covers the core features solo and small salon groomers need — scheduling, automated reminders, client/pet profiles, integrated payments, and online booking. MoeGo has more enterprise features like multi-location management, but these add complexity and cost most independent groomers do not need.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Can I import my MoeGo data into GroomGrid?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Yes. You can export your client list and pet records from MoeGo as a CSV and import them into GroomGrid. The process typically takes under an hour. GroomGrid support can assist with migration.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Is MoeGo or GroomGrid better for mobile groomers?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'GroomGrid is designed mobile-first from the ground up — it works on any device in the field, requires no desktop app, and includes route-friendly scheduling. MoeGo is mobile-accessible but was originally built for brick-and-mortar salons.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Does GroomGrid have AI features that MoeGo lacks?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Yes. GroomGrid includes AI-powered scheduling suggestions, AI breed detection from photos, and automated 3-touch reminder sequences. These are not available in MoeGo.',
+      },
+    },
+  ],
+};
+
 export default function GroomGridVsMoeGoPage() {
   return (
     <>
@@ -64,6 +111,11 @@ export default function GroomGridVsMoeGoPage() {
         id="article-schema"
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+      <Script
+        id="faq-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
       />
 
       <div className="min-h-screen bg-white text-stone-900">

--- a/src/app/blog/mobile-dog-grooming-business-tips/page.tsx
+++ b/src/app/blog/mobile-dog-grooming-business-tips/page.tsx
@@ -52,6 +52,53 @@ const articleSchema = {
   },
 };
 
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'How do I get clients for my mobile dog grooming business?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Start with your local community — post before-and-after photos on neighborhood Facebook groups and Nextdoor. Offer a first-time discount to build reviews. Partner with local vets, pet stores, and dog walkers for referrals. Claim your Google Business Profile and encourage happy clients to leave reviews. Most mobile groomers fill their books within 3–6 months through word of mouth alone.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'How much should I charge for mobile dog grooming?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Mobile grooming commands a premium over salon pricing due to convenience. Typical rates range from $60–150 per dog depending on size, breed, coat condition, and your local market. Small dogs average $60–80, medium dogs $75–100, and large breeds $100–150+. Factor in drive time, fuel, and vehicle costs when setting your base price. Most mobile groomers set a minimum service fee of $50–75 per stop.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'What is the best route planning for mobile groomers?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Group appointments by zip code or neighborhood to minimize drive time. Schedule 4–6 dogs per day with 15–30 minute buffers between stops for travel and cleanup. Avoid booking across town in the same day. Use a scheduling tool that supports geographic grouping — GroomGrid offers route-friendly scheduling that helps mobile groomers cluster appointments by area automatically.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'How do I prevent no-shows as a mobile groomer?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'No-shows are especially costly for mobile groomers because you lose both revenue and fuel. Require a deposit or credit card on file at booking. Send automated reminders 24 hours and 1 hour before the appointment. Implement a cancellation policy (24-hour notice required). GroomGrid users report 30–40% fewer no-shows with automated 3-touch reminder sequences and deposit requirements.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'What software helps run a mobile grooming business?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Mobile groomers need software that works on the road — scheduling, client and pet records, automated reminders, and payment processing in one app. GroomGrid is built mobile-first with features designed specifically for van-based groomers, including route-friendly scheduling, breed-specific time estimates, and automated reminder sequences that reduce no-shows.',
+      },
+    },
+  ],
+};
+
 export default function MobileDogGroomingBusinessTipsPage() {
   return (
     <>
@@ -64,6 +111,11 @@ export default function MobileDogGroomingBusinessTipsPage() {
         id="article-schema"
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+      <Script
+        id="faq-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
       />
 
       <div className="min-h-screen bg-white text-stone-900">


### PR DESCRIPTION
## Summary
- Adds FAQPage JSON-LD structured data to 3 blog pages in GSC striking distance (positions 4-10)
- Schema-only change — no visual/content modifications to any page
- Follows the existing `faqSchema` pattern used in other blog pages (e.g., free-dog-grooming-software)

### Pages updated:
1. **groomgrid-vs-moego** (pos 9.4, 17 impressions) — 5 competitive comparison FAQs
2. **dog-grooming-tools-equipment-list** (pos 6.4, 9 impressions) — 5 equipment/cost FAQs  
3. **mobile-dog-grooming-business-tips** (pos 4.7, 3 impressions) — 5 mobile business FAQs

### Technical details:
- Each page gets a `const faqSchema` with `@type: FAQPage` and 5 Question/Answer pairs
- Rendered via `<Script id="faq-schema" type="application/ld+json">` — no visual FAQ section added
- Last FAQ in each page naturally mentions grooming software/GroomGrid as internal link opportunity
- All schemas validated as correct JSON with proper Schema.org structure

## Test plan
- [x] All 3 FAQ schemas produce valid JSON (`JSON.parse` succeeds)
- [x] No TypeScript errors in modified files
- [x] No visual FAQ sections added (schema only)
- [x] No existing content or H2 headings modified
- [ ] Deploy and verify schema in Google Rich Results Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)