### PR TITLE
feat(admin): add pipeline status page with GitHub PR integration

### DIFF
--- a/src/__tests__/app/admin/pipeline/page.test.tsx
+++ b/src/__tests__/app/admin/pipeline/page.test.tsx
@@ -1,0 +1,336 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for the Admin Pipeline page component.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PipelinePage from '@/app/admin/pipeline/page';
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+// Mock next/link
+jest.mock('next/link', () => {
+  return function MockLink({ children, href, ...props }: any) {
+    return <a href={href} {...props}>{children}</a>;
+  };
+});
+
+// Mock fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// Mock data
+const MOCK_PRS = [
+  {
+    number: 166,
+    title: 'feat(seo): add FAQPage schema',
+    html_url: 'https://github.com/mawsome-agency/groomgrid-app/pull/166',
+    state: 'open',
+    draft: false,
+    user: { login: 'jesse-korbin', avatar_url: 'https://github.com/avatar.png' },
+    head: { ref: 'feat/faq-schema', sha: 'abc123' },
+    created_at: '2026-04-20T12:00:00Z',
+    updated_at: '2026-04-20T12:30:00Z',
+  },
+  {
+    number: 165,
+    title: 'fix(tests): update sitemap count',
+    html_url: 'https://github.com/mawsome-agency/groomgrid-app/pull/165',
+    state: 'open',
+    draft: true,
+    user: { login: 'arjun-patel', avatar_url: 'https://github.com/avatar2.png' },
+    head: { ref: 'cortex/fix-sitemap-test', sha: 'def456' },
+    created_at: '2026-04-19T08:30:00Z',
+    updated_at: '2026-04-19T09:00:00Z',
+  },
+];
+
+const MOCK_RESPONSE = {
+  pullRequests: MOCK_PRS,
+  fetchedAt: '2026-04-23T18:00:00Z',
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function mockSuccessResponse(data = MOCK_RESPONSE) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => data,
+  });
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe('PipelinePage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    // Default: tab is visible
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('shows loading state initially', () => {
+    mockFetch.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<PipelinePage />);
+    expect(screen.getByText('Loading pipeline data...')).toBeInTheDocument();
+  });
+
+  it('renders PRs after successful fetch', async () => {
+    mockSuccessResponse();
+
+    render(<PipelinePage />);
+
+    await waitFor(() => {
+      // With default cortex/ filter, only #165 is visible
+      expect(screen.getByText('fix(tests): update sitemap count')).toBeInTheDocument();
+    });
+  });
+
+  it('shows Draft badge for draft PRs', async () => {
+    mockSuccessResponse();
+
+    render(<PipelinePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Draft')).toBeInTheDocument();
+    });
+  });
+
+  it('displays branch name and author', async () => {
+    mockSuccessResponse();
+
+    render(<PipelinePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('cortex/fix-sitemap-test')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('arjun-patel')).toBeInTheDocument();
+  });
+
+  it('shows View PR links', async () => {
+    mockSuccessResponse();
+
+    render(<PipelinePage />);
+
+    await waitFor(() => {
+      const links = screen.getAllByText('View PR');
+      // Only 1 link because default filter is cortex/ and only 1 PR matches
+      expect(links).toHaveLength(1);
+    });
+  });
+
+  it('displays empty state when no PRs exist', async () => {
+    mockSuccessResponse({ pullRequests: [] as any[], fetchedAt: '2026-04-23T18:00:00Z' });
+
+    render(<PipelinePage />);
+
+    await waitFor(() => {
+      // With default cortex/ filter and 0 PRs, shows "No open PRs matching cortex/"
+      expect(screen.getByText(/No open PRs matching/)).toBeInTheDocument();
+    });
+  });
+
+  it('displays filtered empty state when branch filter matches nothing', async () => {
+    mockSuccessResponse();
+
+    render(<PipelinePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('fix(tests): update sitemap count')).toBeInTheDocument();
+    });
+
+    // Change filter to something that doesn't match any PR
+    const input = screen.getByLabelText('Branch filter:');
+    await userEvent.setup({ advanceTimers: jest.advanceTimersByTime }).clear(input);
+    await userEvent.setup({ advanceTimers: jest.advanceTimersByTime }).type(input, 'nonexistent/');
+
+    expect(screen.getByText(/No open PRs matching "nonexistent\/"/)).toBeInTheDocument();
+  });
+
+  it('shows all PRs when filter is cleared', async () => {
+    mockSuccessResponse();
+
+    render(<PipelinePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('fix(tests): update sitemap count')).toBeInTheDocument();
+    });
+
+    // Clear the filter to see all PRs
+    const input = screen.getByLabelText('Branch filter:');
+    await userEvent.setup({ advanceTimers: jest.advanceTimersByTime }).clear(input);
+
+    // Both PRs should now be visible
+    expect(screen.getByText('feat(seo): add FAQPage schema')).toBeInTheDocument();
+    expect(screen.getByText('fix(tests): update sitemap count')).toBeInTheDocument();
+    expect(screen.getByText('Showing 2 of 2 open PRs')).toBeInTheDocument();
+  });
+
+  it('shows error message on failed fetch', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'GitHub API returned 500 — bad gateway' }),
+    });
+
+    render(<PipelinePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/bad gateway/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error message on network failure', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Failed to fetch'));
+
+    render(<PipelinePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to fetch')).toBeInTheDocument();
+    });
+  });
+
+  it('refreshes data when Refresh button is clicked', async () => {
+    mockSuccessResponse();
+    mockSuccessResponse(); // second call for refresh
+
+    render(<PipelinePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('fix(tests): update sitemap count')).toBeInTheDocument();
+    });
+
+    const refreshButton = screen.getByRole('button', { name: /refresh/i });
+    await userEvent.setup({ advanceTimers: jest.advanceTimersByTime }).click(refreshButton);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('filters PRs by branch prefix using default cortex/', async () => {
+    mockSuccessResponse();
+
+    render(<PipelinePage />);
+
+    await waitFor(() => {
+      // Only the cortex/fix-sitemap-test PR should be shown by default
+      expect(screen.getByText('Showing 1 of 2 open PRs')).toBeInTheDocument();
+    });
+  });
+
+  it('resets branch filter when clicking reset link', async () => {
+    mockSuccessResponse();
+
+    render(<PipelinePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Showing 1 of 2 open PRs')).toBeInTheDocument();
+    });
+
+    // Clear the filter to see all PRs
+    const input = screen.getByLabelText('Branch filter:');
+    await userEvent.setup({ advanceTimers: jest.advanceTimersByTime }).clear(input);
+
+    expect(screen.getByText('Showing 2 of 2 open PRs')).toBeInTheDocument();
+
+    // Type a different filter
+    await userEvent.setup({ advanceTimers: jest.advanceTimersByTime }).type(input, 'feat/');
+
+    // Reset link should appear
+    const resetLink = screen.getByText('Reset to default');
+    await userEvent.setup({ advanceTimers: jest.advanceTimersByTime }).click(resetLink);
+
+    // Should be back to default cortex/ filter
+    expect(screen.getByText('Showing 1 of 2 open PRs')).toBeInTheDocument();
+  });
+
+  it('shows count summary', async () => {
+    mockSuccessResponse();
+
+    render(<PipelinePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Showing 1 of 2 open PRs')).toBeInTheDocument();
+    });
+  });
+
+  it('polls for data every 30 seconds when tab is visible', async () => {
+    mockSuccessResponse();
+    mockSuccessResponse(); // second poll
+
+    render(<PipelinePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('fix(tests): update sitemap count')).toBeInTheDocument();
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Advance timer by 30 seconds
+    await act(async () => {
+      jest.advanceTimersByTime(30_000);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips polling when tab is hidden', async () => {
+    mockSuccessResponse();
+
+    render(<PipelinePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('fix(tests): update sitemap count')).toBeInTheDocument();
+    });
+
+    // Simulate hidden tab
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'hidden',
+      writable: true,
+      configurable: true,
+    });
+
+    // Advance timer by 30 seconds — should NOT trigger fetch
+    await act(async () => {
+      jest.advanceTimersByTime(30_000);
+    });
+
+    // Only the initial fetch, no polling fetch
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows "unknown" for PRs with null user', async () => {
+    const prsWithNullUser = [
+      {
+        number: 170,
+        title: 'chore: update deps',
+        html_url: 'https://github.com/mawsome-agency/groomgrid-app/pull/170',
+        state: 'open',
+        draft: false,
+        user: null,
+        head: { ref: 'cortex/update-deps', sha: 'xyz789' },
+        created_at: '2026-04-22T10:00:00Z',
+        updated_at: '2026-04-22T10:00:00Z',
+      },
+    ];
+
+    mockSuccessResponse({ pullRequests: prsWithNullUser as any[], fetchedAt: '2026-04-23T18:00:00Z' });
+
+    render(<PipelinePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('unknown')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/admin/pipeline/__tests__/page.unit.test.tsx
+++ b/src/app/admin/pipeline/__tests__/page.unit.test.tsx
@@ -1,0 +1,264 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Unit tests for the Pipeline admin page component.
+ *
+ * Tests rendering states (loading, error, empty, data), polling,
+ * branch filtering, and timeAgo formatting.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PipelinePage from '../page';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// Mock next/link to render as a plain <a>
+jest.mock('next/link', () => {
+  return function MockLink({ children, href, ...props }: any) {
+    return <a href={href} {...props}>{children}</a>;
+  };
+});
+
+// ─── Test data ────────────────────────────────────────────────────────────────
+
+// Both PRs use cortex/ branches so they show under the default filter
+const MOCK_PRS = [
+  {
+    number: 166,
+    title: 'feat(seo): add FAQPage schema',
+    html_url: 'https://github.com/mawsome-agency/groomgrid-app/pull/166',
+    state: 'open',
+    draft: false,
+    user: { login: 'jesse-korbin', avatar_url: 'https://github.com/avatar.png' },
+    head: { ref: 'cortex/faq-schema', sha: 'abc123' },
+    created_at: '2026-04-20T00:00:00Z',
+    updated_at: '2026-04-23T00:20:00Z',
+  },
+  {
+    number: 165,
+    title: 'fix(tests): update sitemap count',
+    html_url: 'https://github.com/mawsome-agency/groomgrid-app/pull/165',
+    state: 'open',
+    draft: true,
+    user: { login: 'atlas-reeves', avatar_url: 'https://github.com/avatar2.png' },
+    head: { ref: 'cortex/fix-sitemap', sha: 'def456' },
+    created_at: '2026-04-22T20:05:52Z',
+    updated_at: '2026-04-22T20:10:00Z',
+  },
+];
+
+// Extra PR with a non-cortex branch for filter testing
+const FEATURE_BRANCH_PR = {
+  number: 170,
+  title: 'feat(ui): new dashboard layout',
+  html_url: 'https://github.com/mawsome-agency/groomgrid-app/pull/170',
+  state: 'open',
+  draft: false,
+  user: { login: 'nadia-constantin', avatar_url: 'https://github.com/avatar3.png' },
+  head: { ref: 'feat/dashboard-v2', sha: 'ghi789' },
+  created_at: '2026-04-21T12:00:00Z',
+  updated_at: '2026-04-21T12:30:00Z',
+};
+
+function mockSuccessResponse(prs = MOCK_PRS) {
+  return {
+    ok: true,
+    status: 200,
+    json: jest.fn().mockResolvedValue({
+      pullRequests: prs,
+      fetchedAt: '2026-04-23T18:00:00.000Z',
+    }),
+  };
+}
+
+function mockErrorResponse(status: number, error: string) {
+  return {
+    ok: false,
+    status,
+    json: jest.fn().mockResolvedValue({ error }),
+  };
+}
+
+// ─── Suite ────────────────────────────────────────────────────────────────────
+
+describe('PipelinePage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── Loading state ────────────────────────────────────────────────────────────
+
+  it('shows loading state while fetching', () => {
+    // Keep fetch pending so loading state persists
+    mockFetch.mockReturnValue(new Promise(() => {}));
+
+    render(<PipelinePage />);
+
+    expect(screen.getByText('Loading pipeline data...')).toBeInTheDocument();
+  });
+
+  // ── Successful data display ─────────────────────────────────────────────────
+
+  it('renders PRs after successful fetch', async () => {
+    mockFetch.mockResolvedValue(mockSuccessResponse());
+
+    render(<PipelinePage />);
+
+    // Both PRs use cortex/ branches so they show under the default filter
+    await waitFor(() => {
+      expect(screen.getByText('feat(seo): add FAQPage schema')).toBeInTheDocument();
+    });
+    expect(screen.getByText('fix(tests): update sitemap count')).toBeInTheDocument();
+
+    // Draft badge on PR #165
+    expect(screen.getByText('Draft')).toBeInTheDocument();
+
+    // Branch names
+    expect(screen.getByText('cortex/faq-schema')).toBeInTheDocument();
+    expect(screen.getByText('cortex/fix-sitemap')).toBeInTheDocument();
+
+    // Authors
+    expect(screen.getByText('jesse-korbin')).toBeInTheDocument();
+    expect(screen.getByText('atlas-reeves')).toBeInTheDocument();
+
+    // View PR links
+    const links = screen.getAllByText('View PR');
+    expect(links).toHaveLength(2);
+    expect(links[0].closest('a')).toHaveAttribute(
+      'href',
+      'https://github.com/mawsome-agency/groomgrid-app/pull/166',
+    );
+  });
+
+  // ── Empty state ─────────────────────────────────────────────────────────────
+
+  it('shows empty state when no PRs exist', async () => {
+    mockFetch.mockResolvedValue(mockSuccessResponse([]));
+
+    render(<PipelinePage />);
+
+    // With 0 PRs and default cortex/ filter, shows "No open PRs matching"
+    await waitFor(() => {
+      expect(screen.getByText(/no open PRs matching/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows filtered empty state when no PRs match branch filter', async () => {
+    mockFetch.mockResolvedValue(mockSuccessResponse());
+
+    render(<PipelinePage />);
+
+    // Wait for data to load
+    await waitFor(() => {
+      expect(screen.getByText('feat(seo): add FAQPage schema')).toBeInTheDocument();
+    });
+
+    // Change filter to something that matches nothing
+    const input = screen.getByLabelText('Branch filter:');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'nonexistent/');
+
+    await waitFor(() => {
+      expect(screen.getByText(/no open PRs matching/i)).toBeInTheDocument();
+    });
+  });
+
+  // ── Error state ─────────────────────────────────────────────────────────────
+
+  it('shows error when fetch fails', async () => {
+    mockFetch.mockResolvedValue(
+      mockErrorResponse(503, 'GitHub API returned 403 — service unavailable')
+    );
+
+    render(<PipelinePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/service unavailable/i)).toBeInTheDocument();
+    });
+  });
+
+  // ── Branch filtering ────────────────────────────────────────────────────────
+
+  it('filters PRs by branch prefix', async () => {
+    // Include a PR with a non-cortex branch
+    const allPrs = [...MOCK_PRS, FEATURE_BRANCH_PR];
+    mockFetch.mockResolvedValue(mockSuccessResponse(allPrs));
+
+    render(<PipelinePage />);
+
+    // Default filter is "cortex/" — only cortex/ PRs should show
+    await waitFor(() => {
+      expect(screen.getByText('Showing 2 of 3 open PRs')).toBeInTheDocument();
+    });
+
+    // Change filter to "feat/"
+    const input = screen.getByLabelText('Branch filter:');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'feat/');
+
+    await waitFor(() => {
+      expect(screen.getByText('Showing 1 of 3 open PRs')).toBeInTheDocument();
+    });
+
+    // Clear filter to show all
+    await userEvent.clear(input);
+    await waitFor(() => {
+      expect(screen.getByText('Showing 3 of 3 open PRs')).toBeInTheDocument();
+    });
+  });
+
+  // ── Polling ─────────────────────────────────────────────────────────────────
+
+  it('calls fetch on mount and sets up polling', async () => {
+    mockFetch.mockResolvedValue(mockSuccessResponse());
+
+    render(<PipelinePage />);
+
+    // Initial fetch should have been called
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+    expect(mockFetch).toHaveBeenCalledWith('/api/admin/pipeline');
+  });
+
+  it('refreshes data when refresh button is clicked', async () => {
+    mockFetch.mockResolvedValue(mockSuccessResponse());
+
+    render(<PipelinePage />);
+
+    // Wait for initial fetch
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    // Click refresh button
+    const refreshButton = screen.getByText('Refresh');
+    await userEvent.click(refreshButton);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ── timeAgo formatting ─────────────────────────────────────────────────────
+
+  it('displays relative time for PR creation dates', async () => {
+    // Use a fixed "now" so timeAgo is deterministic
+    const recentPr = {
+      ...MOCK_PRS[0],
+      created_at: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(), // 3 hours ago
+    };
+    mockFetch.mockResolvedValue(mockSuccessResponse([recentPr]));
+
+    render(<PipelinePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/3h ago/)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/admin/pipeline/page.tsx
+++ b/src/app/admin/pipeline/page.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+/**
+ * Admin Pipeline Dashboard
+ *
+ * Shows current GitHub PR pipeline status for groomgrid-app.
+ * Auto-refreshes every 30 seconds (only when tab is visible).
+ * Follows the ab-tests page pattern.
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import type { PipelineItem, PipelineResponse } from '@/types/pipeline';
+
+const POLL_INTERVAL = 30_000; // 30 seconds
+const DEFAULT_BRANCH_FILTER = 'cortex/';
+
+function timeAgo(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffMs = now - then;
+  const diffMins = Math.floor(diffMs / 60_000);
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHrs = Math.floor(diffMins / 60);
+  if (diffHrs < 24) return `${diffHrs}h ago`;
+  const diffDays = Math.floor(diffHrs / 24);
+  if (diffDays < 30) return `${diffDays}d ago`;
+  return `${Math.floor(diffDays / 30)}mo ago`;
+}
+
+export default function PipelinePage() {
+  const [pullRequests, setPullRequests] = useState<PipelineItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [branchFilter, setBranchFilter] = useState(DEFAULT_BRANCH_FILTER);
+  const [lastFetched, setLastFetched] = useState<string>('');
+
+  const fetchPipeline = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await fetch('/api/admin/pipeline');
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
+        throw new Error(data.error || `Failed to fetch pipeline data (${res.status})`);
+      }
+      const data: PipelineResponse = await res.json();
+      setPullRequests(data.pullRequests);
+      setLastFetched(data.fetchedAt);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch pipeline data');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPipeline();
+    const interval = setInterval(() => {
+      // Only poll when tab is visible to avoid burning GitHub API rate limit
+      if (document.visibilityState === 'visible') {
+        fetchPipeline();
+      }
+    }, POLL_INTERVAL);
+    return () => clearInterval(interval);
+  }, [fetchPipeline]);
+
+  const filtered = branchFilter
+    ? pullRequests.filter((pr) =>
+        pr.head.ref.toLowerCase().startsWith(branchFilter.toLowerCase()),
+      )
+    : pullRequests;
+
+  return (
+    <div className="min-h-screen bg-stone-50 p-8">
+      <div className="mx-auto max-w-7xl">
+        {/* Header */}
+        <div className="mb-8 flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-stone-800">Pipeline</h1>
+            <p className="mt-1 text-sm text-stone-500">
+              Open pull requests for groomgrid-app
+            </p>
+          </div>
+          <div className="flex items-center gap-4">
+            {lastFetched && (
+              <span className="text-xs text-stone-400">
+                Updated {timeAgo(lastFetched)}
+              </span>
+            )}
+            <button
+              onClick={fetchPipeline}
+              disabled={loading}
+              className="rounded-lg bg-brand-600 px-4 py-2 font-semibold text-white hover:bg-brand-700 disabled:opacity-50"
+            >
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        {/* Branch filter */}
+        <div className="mb-4 flex items-center gap-3">
+          <label htmlFor="branch-filter" className="text-sm font-medium text-stone-700">
+            Branch filter:
+          </label>
+          <input
+            id="branch-filter"
+            type="text"
+            value={branchFilter}
+            onChange={(e) => setBranchFilter(e.target.value)}
+            placeholder="e.g. cortex/"
+            className="rounded-lg border border-stone-300 px-3 py-1.5 text-sm focus:border-brand-500 focus:outline-none"
+          />
+          {branchFilter !== DEFAULT_BRANCH_FILTER && (
+            <button
+              onClick={() => setBranchFilter(DEFAULT_BRANCH_FILTER)}
+              className="text-xs text-brand-600 hover:underline"
+            >
+              Reset to default
+            </button>
+          )}
+        </div>
+
+        {/* Error state */}
+        {error && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 p-4 text-red-800">
+            {error}
+          </div>
+        )}
+
+        {/* Loading state */}
+        {loading && pullRequests.length === 0 ? (
+          <div className="flex items-center justify-center py-12">
+            <div className="text-stone-500">Loading pipeline data...</div>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {filtered.length === 0 ? (
+              <div className="rounded-xl border border-stone-200 bg-white p-8 text-center">
+                <p className="text-stone-500">
+                  {branchFilter
+                    ? `No open PRs matching "${branchFilter}"`
+                    : 'No open pull requests'}
+                </p>
+                <p className="mt-2 text-sm text-stone-400">
+                  {branchFilter
+                    ? 'Try adjusting the branch filter'
+                    : 'All clear — no PRs in the pipeline'}
+                </p>
+              </div>
+            ) : (
+              filtered.map((pr) => (
+                <div
+                  key={pr.number}
+                  className="rounded-xl border border-stone-200 bg-white p-4 transition-shadow hover:shadow-sm"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0 flex-1">
+                      <div className="mb-1 flex items-center gap-2">
+                        <span className="text-sm font-medium text-stone-400">
+                          #{pr.number}
+                        </span>
+                        <h3 className="truncate text-base font-semibold text-stone-800">
+                          {pr.title}
+                        </h3>
+                        {pr.draft && (
+                          <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">
+                            Draft
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-3 text-sm text-stone-500">
+                        <span className="font-mono text-xs text-stone-600">
+                          {pr.head.ref}
+                        </span>
+                        <span>·</span>
+                        <span>
+                          {pr.user?.login ?? 'unknown'}
+                        </span>
+                        <span>·</span>
+                        <span>{timeAgo(pr.created_at)}</span>
+                      </div>
+                    </div>
+                    <Link
+                      href={pr.html_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="shrink-0 rounded-lg border border-stone-300 px-3 py-1.5 text-sm font-medium text-stone-700 hover:bg-stone-50"
+                    >
+                      View PR
+                    </Link>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        )}
+
+        {/* Count summary */}
+        {pullRequests.length > 0 && (
+          <div className="mt-4 text-center text-xs text-stone-400">
+            Showing {filtered.length} of {pullRequests.length} open PRs
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/pipeline/__tests__/route.test.ts
+++ b/src/app/api/admin/pipeline/__tests__/route.test.ts
@@ -1,0 +1,327 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for GET /api/admin/pipeline
+ *
+ * Tests auth guard, GitHub API proxy, timeout, error mapping, and response shape.
+ */
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+// Mock next-auth getServerSession
+const mockGetServerSession = jest.fn();
+jest.mock('next-auth', () => ({
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+
+// Mock next-auth-options (used by getServerSession)
+jest.mock('@/lib/next-auth-options', () => ({
+  authOptions: { providers: [] },
+}));
+
+// Mock global fetch to control GitHub API responses
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+const ORIGINAL_ENV = process.env;
+
+const GITHUB_PRS_RESPONSE = [
+  {
+    number: 166,
+    title: 'feat(seo): add FAQPage schema',
+    html_url: 'https://github.com/mawsome-agency/groomgrid-app/pull/166',
+    state: 'open',
+    draft: false,
+    user: { login: 'jesse-korbin', avatar_url: 'https://github.com/avatar.png' },
+    head: { ref: 'feat/faq-schema', sha: 'abc123' },
+    created_at: '2026-04-20T12:00:00Z',
+    updated_at: '2026-04-20T12:30:00Z',
+  },
+  {
+    number: 165,
+    title: 'fix(tests): update sitemap entry count',
+    html_url: 'https://github.com/mawsome-agency/groomgrid-app/pull/165',
+    state: 'open',
+    draft: true,
+    user: { login: 'arjun-patel', avatar_url: 'https://github.com/avatar2.png' },
+    head: { ref: 'cortex/fix-sitemap', sha: 'def456' },
+    created_at: '2026-04-19T08:30:00Z',
+    updated_at: '2026-04-19T09:00:00Z',
+  },
+];
+
+const AUTHENTICATED_SESSION = {
+  user: { id: 'user_123', email: 'admin@groomgrid.com', name: 'Admin' },
+  expires: '2026-12-31T23:59:59.000Z',
+};
+
+function mockGithubResponse(body: unknown, status = 200, ok = true): Response {
+  return {
+    ok,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+// ── Import after mocks ─────────────────────────────────────────────────
+
+import { GET } from '../route';
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe('GET /api/admin/pipeline', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...ORIGINAL_ENV, GITHUB_TOKEN: 'ghp_testtoken123' };
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  // ── Auth guard ────────────────────────────────────────────────────────
+
+  it('returns 401 when no session exists', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('Authentication required');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when session has no user.id', async () => {
+    mockGetServerSession.mockResolvedValue({ user: {} });
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('Authentication required');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // ── Missing GITHUB_TOKEN ──────────────────────────────────────────────
+
+  it('returns 503 when GITHUB_TOKEN is not configured', async () => {
+    mockGetServerSession.mockResolvedValue(AUTHENTICATED_SESSION);
+    delete process.env.GITHUB_TOKEN;
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(body.error).toContain('GITHUB_TOKEN');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // ── Successful fetch ──────────────────────────────────────────────────
+
+  it('returns pullRequests array on success', async () => {
+    mockGetServerSession.mockResolvedValue(AUTHENTICATED_SESSION);
+    mockFetch.mockResolvedValueOnce(mockGithubResponse(GITHUB_PRS_RESPONSE));
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.pullRequests).toHaveLength(2);
+    expect(body.pullRequests[0].number).toBe(166);
+    expect(body.pullRequests[0].title).toBe('feat(seo): add FAQPage schema');
+    expect(body.pullRequests[0].head.ref).toBe('feat/faq-schema');
+    expect(body.pullRequests[0].user.login).toBe('jesse-korbin');
+    expect(body.pullRequests[0].draft).toBe(false);
+    expect(body.pullRequests[1].draft).toBe(true);
+    expect(body.fetchedAt).toBeDefined();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends correct GitHub API URL, Bearer token, Accept, and User-Agent headers', async () => {
+    mockGetServerSession.mockResolvedValue(AUTHENTICATED_SESSION);
+    mockFetch.mockResolvedValueOnce(mockGithubResponse([]));
+
+    await GET();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.github.com/repos/mawsome-agency/groomgrid-app/pulls?state=open&per_page=50&sort=updated&direction=desc',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer ghp_testtoken123',
+          Accept: 'application/vnd.github+json',
+          'User-Agent': 'GroomGrid-Admin-Pipeline',
+        }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it('returns empty pullRequests array when GitHub returns empty', async () => {
+    mockGetServerSession.mockResolvedValue(AUTHENTICATED_SESSION);
+    mockFetch.mockResolvedValueOnce(mockGithubResponse([]));
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.pullRequests).toEqual([]);
+  });
+
+  // ── GitHub HTTP error mapping ─────────────────────────────────────────
+
+  it('maps 401 from GitHub to 503', async () => {
+    mockGetServerSession.mockResolvedValue(AUTHENTICATED_SESSION);
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: jest.fn().mockResolvedValue({ message: 'Bad credentials' }),
+    } as unknown as Response);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(body.error).toContain('401');
+  });
+
+  it('maps 403 from GitHub to 503', async () => {
+    mockGetServerSession.mockResolvedValue(AUTHENTICATED_SESSION);
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: jest.fn().mockResolvedValue({ message: 'Forbidden' }),
+    } as unknown as Response);
+
+    const res = await GET();
+    expect(res.status).toBe(503);
+  });
+
+  it('maps 404 from GitHub to 503', async () => {
+    mockGetServerSession.mockResolvedValue(AUTHENTICATED_SESSION);
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: jest.fn().mockResolvedValue({ message: 'Not Found' }),
+    } as unknown as Response);
+
+    const res = await GET();
+    expect(res.status).toBe(503);
+  });
+
+  it('maps 5xx from GitHub to 502', async () => {
+    mockGetServerSession.mockResolvedValue(AUTHENTICATED_SESSION);
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: jest.fn().mockResolvedValue({ message: 'Internal Server Error' }),
+    } as unknown as Response);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.error).toContain('500');
+  });
+
+  it('maps other unexpected 4xx from GitHub to 502', async () => {
+    mockGetServerSession.mockResolvedValue(AUTHENTICATED_SESSION);
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      json: jest.fn().mockResolvedValue({ message: 'Validation Failed' }),
+    } as unknown as Response);
+
+    const res = await GET();
+    expect(res.status).toBe(502);
+  });
+
+  // ── Timeout / network errors ───────────────────────────────────────────
+
+  it('returns 504 when GitHub request times out (AbortError)', async () => {
+    mockGetServerSession.mockResolvedValue(AUTHENTICATED_SESSION);
+    // In Node.js 18+, fetch abort throws Error with name='AbortError', not DOMException
+    const abortError = new Error('The operation was aborted');
+    abortError.name = 'AbortError';
+    mockFetch.mockRejectedValueOnce(abortError);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(504);
+    expect(body.error).toContain('timed out');
+  });
+
+  it('returns 500 for generic network fetch errors', async () => {
+    mockGetServerSession.mockResolvedValue(AUTHENTICATED_SESSION);
+    mockFetch.mockRejectedValueOnce(new TypeError('fetch failed'));
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('Failed to reach GitHub API');
+  });
+
+  it('returns 500 for unknown thrown errors', async () => {
+    mockGetServerSession.mockResolvedValue(AUTHENTICATED_SESSION);
+    mockFetch.mockRejectedValueOnce(new Error('Something unexpected'));
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('Failed to reach GitHub API');
+  });
+
+  it('handles non-Error thrown values', async () => {
+    mockGetServerSession.mockResolvedValue(AUTHENTICATED_SESSION);
+    mockFetch.mockRejectedValueOnce('string error');
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('Failed to reach GitHub API');
+  });
+
+  // ── Response parsing ─────────────────────────────────────────────────
+
+  it('handles PRs with null user gracefully', async () => {
+    mockGetServerSession.mockResolvedValue(AUTHENTICATED_SESSION);
+    mockFetch.mockResolvedValueOnce(mockGithubResponse([
+      {
+        number: 99,
+        title: 'Test PR',
+        html_url: 'https://github.com/mawsome-agency/groomgrid-app/pull/99',
+        state: 'open',
+        draft: false,
+        user: null,
+        head: { ref: 'main', sha: 'abc123' },
+        created_at: '2026-04-23T00:00:00Z',
+        updated_at: '2026-04-23T00:00:00Z',
+      },
+    ]));
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.pullRequests[0].user).toBeNull();
+    expect(body.pullRequests[0].number).toBe(99);
+  });
+
+  it('returns 500 when GitHub returns non-JSON', async () => {
+    mockGetServerSession.mockResolvedValue(AUTHENTICATED_SESSION);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: jest.fn().mockRejectedValue(new Error('Invalid JSON')),
+    } as unknown as Response);
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/admin/pipeline/route.ts
+++ b/src/app/api/admin/pipeline/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/next-auth-options';
+
+// No caching — always fetch fresh PR data
+export const dynamic = 'force-dynamic';
+
+const GITHUB_REPO = 'mawsome-agency/groomgrid-app';
+const GITHUB_API_URL = `https://api.github.com/repos/${GITHUB_REPO}/pulls?state=open&per_page=50&sort=updated&direction=desc`;
+const GITHUB_TIMEOUT_MS = 10_000;
+
+/**
+ * GET /api/admin/pipeline
+ *
+ * Proxies open GitHub PRs for the groomgrid-app repo.
+ * Requires authentication via next-auth session.
+ *
+ * Error mapping:
+ *   - 401/403/404 from GitHub → 503 (service unavailable)
+ *   - 5xx from GitHub → 502 (bad gateway)
+ *   - AbortError (timeout) → 504 (gateway timeout)
+ *   - Network/unknown errors → 500
+ */
+export async function GET() {
+  // ── Auth guard ──────────────────────────────────────────────────────
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json(
+      { error: 'Authentication required' },
+      { status: 401 },
+    );
+  }
+
+  // ── GitHub token check ──────────────────────────────────────────────
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    console.error('[Pipeline] GITHUB_TOKEN is not configured');
+    return NextResponse.json(
+      { error: 'Server configuration error — GITHUB_TOKEN missing' },
+      { status: 503 },
+    );
+  }
+
+  // ── GitHub proxy ─────────────────────────────────────────────────────
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), GITHUB_TIMEOUT_MS);
+
+  let ghRes: Response;
+
+  try {
+    ghRes = await fetch(GITHUB_API_URL, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'GroomGrid-Admin-Pipeline',
+      },
+      signal: controller.signal,
+    });
+  } catch (err: unknown) {
+    // Node.js 18+ fetch throws Error with name === 'AbortError' on abort,
+    // NOT DOMException. Must check error.name, not instanceof DOMException.
+    if (err instanceof Error && err.name === 'AbortError') {
+      return NextResponse.json(
+        { error: 'GitHub API request timed out after 10 seconds' },
+        { status: 504 },
+      );
+    }
+    console.error('[Pipeline] Network error fetching GitHub PRs:', err);
+    return NextResponse.json(
+      { error: 'Failed to reach GitHub API' },
+      { status: 500 },
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  // ── Error mapping ────────────────────────────────────────────────────
+  if (!ghRes.ok) {
+    const status = ghRes.status;
+    let mappedStatus: number;
+    let message: string;
+
+    if (status === 401 || status === 403 || status === 404) {
+      mappedStatus = 503;
+      message = `GitHub API returned ${status} — service unavailable`;
+    } else if (status >= 500) {
+      mappedStatus = 502;
+      message = `GitHub API returned ${status} — bad gateway`;
+    } else {
+      mappedStatus = 502;
+      message = `GitHub API returned unexpected status ${status}`;
+    }
+
+    console.error(`[Pipeline] GitHub API error: ${status}`);
+    return NextResponse.json({ error: message }, { status: mappedStatus });
+  }
+
+  let pullRequests;
+  try {
+    pullRequests = await ghRes.json();
+  } catch (jsonErr) {
+    console.error('[Pipeline] Failed to parse GitHub response:', jsonErr);
+    return NextResponse.json(
+      { error: 'Failed to parse GitHub response' },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    pullRequests,
+    fetchedAt: new Date().toISOString(),
+  });
+}

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -1,0 +1,30 @@
+/**
+ * Pipeline status page types
+ *
+ * These types mirror the GitHub PR API response shape
+ * that /api/admin/pipeline proxies.
+ */
+
+export interface PipelineItem {
+  number: number;
+  title: string;
+  html_url: string;
+  state: string;
+  draft: boolean;
+  user: {
+    login: string;
+    avatar_url: string;
+  } | null;
+  head: {
+    ref: string;
+    sha: string;
+  };
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PipelineResponse {
+  pullRequests: PipelineItem[];
+  fetchedAt: string;
+  error?: string;
+}


### PR DESCRIPTION
## Summary

Adds `/admin/pipeline` page showing current GitHub PR pipeline status for the team.

### What's Included

- **API Route** (`src/app/api/admin/pipeline/route.ts`): GET handler that proxies GitHub PRs
  - Auth guard: requires authenticated session
  - GitHub API proxy with correct error mapping (401/403→503, 404→503, 5xx→502, AbortError→504)
  - 10s timeout via AbortController
  - `cache: no-store`

- **Shared Types** (`src/types/pipeline.ts`): PipelineItem and PipelineResponse interfaces

- **Admin Page** (`src/app/admin/pipeline/page.tsx`):
  - Client-side rendering with useEffect (follows ab-tests page pattern)
  - 30s auto-refresh polling with cleanup
  - Branch filter (default: cortex/)
  - Loading/error/empty states
  - PR table: number, title, branch, author, age, draft badge, View PR link

- **Tests**: 43 total tests
  - Route tests: 17 cases (auth, error mapping, timeout, response parsing)
  - Page unit tests: 9 cases (rendering, polling, filtering)
  - Page integration tests: 17 cases (full mount scenarios)

## Test plan

- [x] All 43 pipeline tests pass locally
- [ ] CI passes
- [ ] `/admin/pipeline` renders correctly in staging
- [ ] Auth guard redirects unauthenticated users
- [ ] 30s polling refreshes data
- [ ] Branch filter works

🤖 Generated with [Claude Code](https://claude.com/claude-code)