### PR TITLE
fix(tests): update sitemap entry count to 32

### DIFF
--- a/src/__tests__/sitemap.test.ts
+++ b/src/__tests__/sitemap.test.ts
@@ -123,7 +123,7 @@ describe('Sitemap Generation', () => {
   it('should have total entries matching all pages', () => {
     const result = sitemap();
 
-    // 4 static pages + 5 landing pages + 17 blog posts = 26 total
-    expect(result.length).toBe(26);
+    // 4 static pages + 7 landing pages + 21 blog posts = 32 total
+    expect(result.length).toBe(32);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the failing sitemap test that expects 26 entries but receives 32.

New pages have been added (2 additional landing pages + 4 new blog posts) since the test was last updated, bringing the total to:
- 4 static pages
- 7 landing pages (was 5, added `pawfinity-alternatives` and `daysmart-alternatives`)
- 21 blog posts (was 17)

## Test plan

- [x] `src/__tests__/sitemap.test.ts` passes locally (11/11 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)