### PR TITLE
fix(a11y): WCAG AA contrast + ARIA live regions on admin pages

### DIFF
--- a/src/app/admin/ab-tests/page.tsx
+++ b/src/app/admin/ab-tests/page.tsx
@@ -179,7 +179,7 @@ export default function ABTestsPage() {
             {tests.length === 0 ? (
               <div className="rounded-xl border border-stone-200 bg-white p-8 text-center">
                 <p className="text-stone-500">No A/B tests found</p>
-                <p className="mt-2 text-sm text-stone-400">
+                <p className="mt-2 text-sm text-stone-500">
                   Create your first test to start experimenting
                 </p>
               </div>
@@ -384,7 +384,7 @@ function TestCard({
             </p>
           </div>
         </div>
-        <p className="text-stone-400">
+        <p className="text-stone-500">
           Created {new Date(test.createdAt).toLocaleDateString()}
         </p>
       </div>

--- a/src/app/admin/pipeline/page.tsx
+++ b/src/app/admin/pipeline/page.tsx
@@ -13,6 +13,7 @@ import Link from 'next/link';
 import type { PipelineItem, PipelineResponse } from '@/types/pipeline';
 
 const POLL_INTERVAL = 30_000; // 30 seconds
+// Default filters to "cortex/" since all Cortex-managed PR branches follow this prefix
 const DEFAULT_BRANCH_FILTER = 'cortex/';
 
 function timeAgo(dateStr: string): string {
@@ -85,7 +86,7 @@ export default function PipelinePage() {
           </div>
           <div className="flex items-center gap-4">
             {lastFetched && (
-              <span className="text-xs text-stone-400">
+              <span className="text-xs text-stone-500">
                 Updated {timeAgo(lastFetched)}
               </span>
             )}
@@ -124,18 +125,18 @@ export default function PipelinePage() {
 
         {/* Error state */}
         {error && (
-          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 p-4 text-red-800">
+          <div aria-live="polite" className="mb-4 rounded-lg border border-red-200 bg-red-50 p-4 text-red-800">
             {error}
           </div>
         )}
 
         {/* Loading state */}
         {loading && pullRequests.length === 0 ? (
-          <div className="flex items-center justify-center py-12">
+          <div role="status" className="flex items-center justify-center py-12">
             <div className="text-stone-500">Loading pipeline data...</div>
           </div>
         ) : (
-          <div className="space-y-3">
+          <div aria-live="polite" className="space-y-3">
             {filtered.length === 0 ? (
               <div className="rounded-xl border border-stone-200 bg-white p-8 text-center">
                 <p className="text-stone-500">
@@ -143,7 +144,7 @@ export default function PipelinePage() {
                     ? `No open PRs matching "${branchFilter}"`
                     : 'No open pull requests'}
                 </p>
-                <p className="mt-2 text-sm text-stone-400">
+                <p className="mt-2 text-sm text-stone-500">
                   {branchFilter
                     ? 'Try adjusting the branch filter'
                     : 'All clear — no PRs in the pipeline'}
@@ -158,7 +159,7 @@ export default function PipelinePage() {
                   <div className="flex items-start justify-between gap-4">
                     <div className="min-w-0 flex-1">
                       <div className="mb-1 flex items-center gap-2">
-                        <span className="text-sm font-medium text-stone-400">
+                        <span className="text-sm font-medium text-stone-600">
                           #{pr.number}
                         </span>
                         <h3 className="truncate text-base font-semibold text-stone-800">
@@ -199,7 +200,7 @@ export default function PipelinePage() {
 
         {/* Count summary */}
         {pullRequests.length > 0 && (
-          <div className="mt-4 text-center text-xs text-stone-400">
+          <div className="mt-4 text-center text-xs text-stone-500">
             Showing {filtered.length} of {pullRequests.length} open PRs
           </div>
         )}


### PR DESCRIPTION
## Summary
- **M1 — Contrast fixes (6 changes, 2 files):** All `text-stone-400` instances on light backgrounds swapped to `text-stone-500` or `text-stone-600`, bringing contrast ratios from 2.41:1 → 4.59–7.63:1 (WCAG AA requires 4.5:1)
- **M2 — ARIA live regions (3 additions, pipeline page only):** Added `aria-live="polite"` to error banner, `role="status"` to loading container, and `aria-live="polite"` to results list so screen readers are notified on state changes
- No logic changes, no new dependencies, no schema changes — admin-only pages only

## Files changed
- `src/app/admin/pipeline/page.tsx` — 7 changes (4 contrast, 3 ARIA)
- `src/app/admin/ab-tests/page.tsx` — 2 contrast changes

## Test plan
- [x] Ran `npm test --testPathPatterns="admin/pipeline"` → 43 tests pass, 0 failures
- [x] All assertions are on text content / href attributes — class-name swaps and ARIA additions are invisible to JSDOM queries, zero regressions
- [ ] Visual spot-check: muted secondary text visually shifts one stop darker (intentional, correct)
- [ ] Axe DevTools audit on `/admin/pipeline` and `/admin/ab-tests` should clear color-contrast and aria-live findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)