### PR TITLE
fix(a11y): signup page WCAG non-text contrast fix

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -355,7 +355,7 @@ function SignupPageInner() {
                 Business Name
               </label>
               <div className="relative">
-                <Building className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-stone-400" />
+                <Building className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-stone-500" />
                 <input
                   id="businessName"
                   name="businessName"
@@ -384,7 +384,7 @@ function SignupPageInner() {
                 Email Address
               </label>
               <div className="relative">
-                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-stone-400" />
+                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-stone-500" />
                 <input
                   id="email"
                   type="email"
@@ -413,7 +413,7 @@ function SignupPageInner() {
                 Password
               </label>
               <div className="relative">
-                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-stone-400" />
+                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-stone-500" />
                 <input
                   id="password"
                   type={showPassword ? 'text' : 'password'}
@@ -432,7 +432,7 @@ function SignupPageInner() {
                 <button
                   type="button"
                   onClick={() => setShowPassword((v) => !v)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600 transition-colors"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-500 hover:text-stone-600 transition-colors"
                   aria-label={showPassword ? 'Hide password' : 'Show password'}
                   tabIndex={-1}
                 >


### PR DESCRIPTION
## Summary
- Fix WCAG 1.4.11 non-text contrast violation on password visibility toggle button
- Change `text-stone-400` (2.52:1 on white ❌) → `text-stone-500` (4.80:1 on white ✅)
- Also update decorative input icons for visual consistency

## Acceptance Criteria
- [x] Password toggle button meets WCAG 1.4.11 (3:1 minimum contrast on white)
- [x] Hover state retains adequate contrast (stone-600 on white = 6.85:1 ✅)
- [x] No new dependencies
- [x] All 14 existing signup page tests pass

## Technical Details
- **Interactive toggle (line 435):** `stone-400` → `stone-500` — required for WCAG compliance
- **Decorative icons (lines 358, 387, 416):** `stone-400` → `stone-500` — visual consistency (exempt per WCAG 1.4.11 decorative exception)

Resolves the WCAG contrast issue identified in the accessibility audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)