### PR TITLE
fix: guard Stripe webhook against bot traffic (missing signature header)

### DIFF
--- a/src/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/src/app/api/stripe/webhook/__tests__/route.test.ts
@@ -91,6 +91,22 @@ describe('Stripe webhook route (test mode)', () => {
     expect(callArg.metadata.userId).toBe('test_user_id');
   });
 
+  it('should return 200 for requests missing stripe-signature header (bot traffic)', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.ENABLE_TEST_WEBHOOK_BYPASS = 'false';
+
+    const req = new Request('http://localhost/api/stripe/webhook', {
+      method: 'POST',
+      body: JSON.stringify({}),
+      // No stripe-signature header
+    });
+
+    const response = await POST(req);
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json).toEqual({ received: true });
+  });
+
   it('should verify Stripe signature in production mode', async () => {
     process.env.NODE_ENV = 'production';
     process.env.ENABLE_TEST_WEBHOOK_BYPASS = 'false';

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -26,7 +26,7 @@ export async function POST(req: Request) {
   }
 
   const body = await req.text();
-  const signature = headersList.get('stripe-signature')!;
+  const signature = headersList.get('stripe-signature');
 
   let event;
 
@@ -56,6 +56,14 @@ export async function POST(req: Request) {
     // Use mock event in test mode
     event = mockStripeWebhookEvent;
   } else {
+    // Guard: bots/scanners hit this endpoint without the stripe-signature header.
+    // Stripe always includes it — absent header = not a real webhook.
+    // Return 200 so bots don't retry; log at debug only to avoid masking real failures.
+    if (!signature) {
+      console.debug('[Webhook] Missing stripe-signature header — likely bot/scanner, ignoring');
+      return NextResponse.json({ received: true });
+    }
+
     // Production: always require valid Stripe signature
     try {
       event = stripe.webhooks.constructEvent(body, signature, webhookSecret);


### PR DESCRIPTION
## Summary
- **Root cause**: `route.ts` used a non-null assertion (`!`) on the `stripe-signature` header, so bot/scanner requests without that header passed `null` into `stripe.webhooks.constructEvent()`, causing `StripeSignatureVerificationError` noise in logs
- **Fix**: Remove the `!` assertion, add an early-return guard that checks for missing `stripe-signature` header — returns 200 OK with a debug-level log (bots don't retry, so no point returning 400)
- **Impact**: Real Stripe webhooks (which always include the header) are completely unaffected and still go through full `constructEvent` signature verification

## Pipeline Results
| Stage | Status | Notes |
|-------|--------|-------|
| Plan | ✅ pass | Diagnosis identified root cause + fix approach |
| Build | ✅ pass | 2 files changed (route.ts + test), no new files |
| Test | ✅ pass | New test case: missing header → 200 OK in production mode |
| Simplify | ✅ pass | 25 lines added, 1 removed — minimal change |
| Security | ✅ pass | No secrets, no forbidden files |
| Regression | ✅ pass | Existing tests pass, no behavioral change for valid webhooks |

## Changes
- `src/app/api/stripe/webhook/route.ts`: Removed `!` non-null assertion on `stripe-signature` header read; added null guard before `constructEvent` that returns `200 { received: true }` with debug log
- `src/app/api/stripe/webhook/__tests__/route.test.ts`: Added test case verifying 200 response for requests missing `stripe-signature` header in production mode

## Test Plan
- [x] All 13 existing webhook tests pass
- [x] New test case: missing `stripe-signature` header in production mode → returns 200 `{ received: true }`
- [x] Existing test: valid signature in production mode → 200 OK (unaffected)
- [x] Existing test: invalid signature in production mode → 400 (unaffected)
- [ ] Manual: `curl -X POST http://localhost:3000/api/stripe/webhook -d '{}'` → returns 200 (no error in logs)
- [ ] Manual: Stripe CLI webhook with valid signature → still processes normally

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>