### PR TITLE
fix: validate coupon codes before Stripe checkout

### DIFF
--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -45,11 +45,24 @@ export async function createCheckoutSession({
   const stripe = getStripe();
   const priceId = getPriceIds()[planType];
 
-  // When a coupon is provided, apply it directly (fixed discount) instead of
-  // allowing the user to enter a promo code at checkout.
-  const discountFields: Partial<Stripe.Checkout.SessionCreateParams> = couponCode
-    ? { discounts: [{ coupon: couponCode }] }
-    : { allow_promotion_codes: true };
+  // When a coupon is provided, validate it exists in Stripe before applying.
+  // Invalid coupons should fall back gracefully (allow promo codes) rather than
+  // crashing the checkout flow. This prevents "No such coupon" errors when
+  // users enter typoed or expired coupon codes.
+  let discountFields: Partial<Stripe.Checkout.SessionCreateParams>;
+
+  if (couponCode) {
+    try {
+      // Validate the coupon exists in Stripe before applying
+      await stripe.coupons.retrieve(couponCode);
+      discountFields = { discounts: [{ coupon: couponCode }] };
+    } catch {
+      console.warn(`[Checkout] Coupon code "${couponCode}" not found in Stripe, falling back to promo code entry`);
+      discountFields = { allow_promotion_codes: true };
+    }
+  } else {
+    discountFields = { allow_promotion_codes: true };
+  }
 
   const session = await stripe.checkout.sessions.create({
     customer_email: customerEmail,


### PR DESCRIPTION
## Summary
- Invalid coupon codes (e.g., `GROOMERFOUNDING`) were crashing the entire checkout flow with `No such coupon` Stripe errors
- Added coupon validation before passing to Stripe — if invalid, falls back to allowing promo code entry
- This was a production blocker: real users who entered wrong coupon codes couldn't complete checkout

## Test plan
- [x] All 149 existing tests pass
- [ ] Verify checkout works with valid coupon `BETA50`
- [ ] Verify checkout works with invalid coupon (should fall back gracefully)
- [ ] Verify checkout works with no coupon
- [ ] Deploy to production and verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)