### PR TITLE
refactor: consolidate PLAN_DATA into pricing-data.ts — remove manual-sync trap

### DIFF
--- a/docs/gtm-execution/day3-april25-execution-plan.md
+++ b/docs/gtm-execution/day3-april25-execution-plan.md
@@ -1,0 +1,141 @@
+# Sprint Day 3 — April 25, 2026
+## 6-Day Sprint to 100 Subscribers | Day 3 of 6
+
+**Owner:** Matt (execution) — prepared by Lucia Torres
+**Deadline:** April 29, 2026 (4 days left after today)
+**Primary Goal:** Complete 3-5 signups today. Every day without a signup is a day we don't get back.
+
+---
+
+## 🚨 First Thing in the Morning: Check for Signups
+
+Before anything else:
+1. Log into Stripe → check for new customers/subscriptions
+2. Check your email for any groomer replies
+3. Check Facebook comment notifications
+
+**If someone signed up overnight:**
+→ DM them IMMEDIATELY:
+> "Hey [Name]! Saw you joined GroomGrid last night — you're one of our founding members now 🐾 How's the setup going? I'm watching closely and want to make sure everything works perfectly for you. Drop me any questions — I'm right here."
+
+This is the highest-leverage action you can take. Early users who feel personally supported become referrers.
+
+---
+
+## Day 3 Actions
+
+### Action 1: Follow-Up DMs to Day 1-2 Engagers (Priority 1)
+**Time:** 30 min | **Where:** Facebook DMs
+**Who:** Everyone who liked, commented, or reacted to your Day 1-2 posts and did NOT sign up
+
+This is now the most important channel. Seeds were planted. Day 3 is the harvest.
+
+**Template for commenters who asked questions:**
+> "Hey [Name] — wanted to follow up on your comment! The short answer is yes, [address their specific question]. If you want to see it firsthand, I can get you free access right now. Use `GROOMER_FOUNDING` at getgroomgrid.com/signup — takes 5 minutes. Happy to walk through it with you if anything's confusing."
+
+**Template for people who just liked/reacted:**
+> "Hey [Name], thanks for the like on my post! Sounds like no-shows/payments might be a headache for you too. We're still giving out founding member spots (free lifetime access). If you want to grab one before they're gone: getgroomgrid.com/signup with code `GROOMER_FOUNDING`. No card needed to start."
+
+**Template for people who said "Interesting!" or "Following!" in comments:**
+> "Hey [Name] — just following up since threads move fast! Happy to get you set up with a founding member account (free for life). Here if you want: getgroomgrid.com/signup — code is `GROOMER_FOUNDING`. Let me know if you hit any snags!"
+
+---
+
+### Action 2: New Facebook Post — Payment Chasing Story
+**Time:** 20 min | **Where:** Post in 2-3 Facebook groups (different from Day 1-2 if possible)
+**Groups:** Groomers Uplifting Groomers 2.0, The Everyday Pet Groomer, International Professional Groomers
+
+**Why this angle:** Day 1 was no-shows. Day 2 was cat grooming profiles. Day 3 is payment chasing — the second-biggest pain point for mobile groomers.
+
+**Post copy:**
+
+---
+
+Anyone else dealt with the "I'll Venmo you!" ghost? 👻
+
+Finished a full groom last Tuesday — gorgeous Bernedoodle, 90-minute job. Client said "I'll send it in a bit!" and waved goodbye.
+
+Wednesday: nothing.
+Thursday: nothing.
+Friday I sent a polite "Just a reminder!" and felt immediately awkward about it.
+
+Saturday she paid, apologized, said she "totally forgot." She's a regular. I smiled and said "no worries!" and internally calculated that if this happens 3x/month at $80/groom, that's $240/month I'm essentially giving interest-free loans on.
+
+The fix that worked for me: automated payment link sent as an SMS the moment I mark the appointment complete. Client gets a text before they even pull out of their driveway. Most pay within 5 minutes. The awkward "reminder" text never has to happen.
+
+I know not everyone loves automation but for payment collection specifically it's been a game-changer.
+
+What's your current system for collecting? Cash only? Venmo on the spot? Square tap? Curious what's working for people.
+
+---
+
+**When people engage → DM within the hour:**
+> "Hey [Name]! Payment timing is such a headache. I built this into GroomGrid (my scheduling tool) — automated payment link fires the second you close out an appointment. Happy to get you a free founding member account if you want to test it. Code is `GROOMER_FOUNDING` at getgroomgrid.com/signup."
+
+---
+
+### Action 3: Instagram Influencer Outreach — Open This Channel
+**Time:** 30 min | **Where:** Instagram DMs
+**Goal:** Send 5 targeted DMs to groomer micro-influencers today
+
+This channel hasn't been touched yet. Even ONE partnership with a 5K-follower groomer account can drive more signups than a week of Facebook posts.
+
+**Who to target:** Groomers with 2K-15K followers, posting 3-5x/week, mix of grooming content and business/lifestyle. NOT mega accounts (too commercial, won't care).
+
+**How to find them:**
+- Search Instagram: `#mobilegroomer`, `#doggroomingbusiness`, `#salongroomer`, `#petgroombusiness`
+- Filter: 2K-15K followers, recent posts (last 3 days)
+- Look for: people who talk about the business side (not just pretty grooms)
+
+**DM template (keep it short and human):**
+> "Hey [Name]! Love your content — the [specific post reference] was 🔥. I'm the founder of GroomGrid, a scheduling tool built specifically for groomers. We're in early access and giving founding members free lifetime accounts.
+>
+> Would love to get your honest take on it — not asking for a post or anything, just your feedback. Free forever if you hate it, and I'll fix whatever's broken based on your input.
+>
+> Worth a 5-minute look? Happy to set it up for you right now. 🐾"
+
+**Targets to find:**
+- Search `#mobilegroomerlife` → look for van groomers talking business
+- Search `#groomingsalon` → salon owners with engaged followings
+- Search `#certifiedgroomer` → professionals who care about standards
+
+**After sending DM, log in your notes:** [Name] [Handle] [Follower count] [Sent date] [Response Y/N]
+
+---
+
+## Day 3 KPIs
+
+| Metric | Target |
+|--------|--------|
+| Follow-up DMs sent | 10+ |
+| New Facebook post | 1 (payment angle) |
+| Instagram DMs sent | 5 |
+| Signup goal | 2-3 |
+| Founding member spots remaining | Mention current count for urgency |
+
+---
+
+## What to Watch For
+
+**Green flags:**
+- People asking "Does it work on iPhone?" → Send signup link immediately
+- "How much is it?" → "It's normally $29/mo but I have founding member spots that are free for life — here's the code: GROOMER_FOUNDING"
+- "I've been looking for something like this" → Strike while hot, get them to sign up in the DM thread
+
+**Red flags / how to handle:**
+- "I can't afford software right now" → "The founding member code makes it $0 forever. Literally free."
+- "I don't need it, I use Google Calendar" → "Totally fair — Google Cal doesn't send SMS reminders or handle payments though. If you ever want to try it, the free code is open."
+- No response to DM → Follow up once after 48h, then move on
+
+---
+
+## Promo Code Reminder
+
+**Code:** `GROOMER_FOUNDING`  
+**At:** getgroomgrid.com/signup → choose Solo plan → enter code at Stripe checkout  
+**What they get:** Free lifetime access (normally $29/mo)  
+**Spots:** Verify current redemption count in Stripe before posting (check with Jesse if unsure)
+
+---
+
+*Day 3 of 6. Compounding. Every conversation today is warmer than Day 1.*

--- a/docs/gtm-execution/influencer-outreach-brief.md
+++ b/docs/gtm-execution/influencer-outreach-brief.md
@@ -1,0 +1,140 @@
+# GroomGrid Influencer Outreach Brief
+## Sprint Week — April 25-29, 2026
+
+**Prepared by:** Lucia Torres — Strategy & Planning
+**Goal:** Identify and DM 15-20 groomer micro-influencers by April 28
+**Target outcome:** 2-3 founding member signups + 1-2 social shoutouts before April 29
+
+---
+
+## Why Influencers Matter Right Now
+
+Direct Facebook posting reaches people who happen to be on at that moment.
+An influencer post reaches *their followers who trust them.* Conversion rates from influencer mentions are 3-5x higher than cold posts because the social proof is already there.
+
+Even one groomer with 8K engaged followers saying "hey I'm testing this for free, looks pretty solid" = 50-100 profile visits and likely 5-10 signups.
+
+---
+
+## Target Profile
+
+**Sweet spot:**
+- 2,000 – 20,000 followers
+- Posts 3-5x per week (recent = active audience)
+- Mix of grooming technique + business content (not just pretty dogs)
+- Comments section has real conversations (not just "cute!" spam)
+- Not already sponsored by MoeGo or DaySmart (check bio/recent posts)
+
+**Avoid:**
+- 50K+ accounts — too commercial, won't do free partnerships
+- Inactive accounts (last post > 2 weeks ago)
+- Accounts that only do before/after photos (aesthetic-only, no business audience)
+- Anyone already hawking another grooming software
+
+---
+
+## Where to Find Them
+
+### Instagram Hashtag Search (Start Here)
+Search these hashtags, then sort by **Recent** (not Top):
+
+| Hashtag | What You'll Find |
+|---------|-----------------|
+| `#mobilegroomerlife` | Van groomers — perfect ICP |
+| `#doggroomingbusiness` | Business-focused groomers |
+| `#petgroombusiness` | Mix of salon + mobile |
+| `#certifiedgroomer` | Professional, care about tools |
+| `#groomingentrepreneur` | Business-minded, hungry for efficiency |
+| `#salongroomer` | Salon owners (Salon tier ICP) |
+| `#groomingbusinesstips` | Content creators in the niche |
+
+**Quick vet process (90 seconds per account):**
+1. Bio: solo groomer / salon owner / mobile groomer? ✅
+2. Last 3 posts: recent? mix of grooming + business talk? ✅
+3. Follower count: 2K-20K? ✅
+4. Comments: real engagement, questions, conversations? ✅
+5. Sponsored posts: check last 9 tiles for `#ad` or `#sponsored` — if sponsored by MoeGo, skip
+
+---
+
+## DM Templates
+
+### Template A — Founding Member Ask (Primary)
+Best for: groomers who post business content, discuss pain points
+```
+Hey [Name]! Your [specific post reference — e.g., "the reel about handling anxious dogs"] was really helpful. 
+
+I'm the founder of GroomGrid — a scheduling and business management tool I built specifically for groomers (SMS reminders, pet profiles, automated payments). We just soft-launched and I'm looking for 25 founding members to test it before we go public.
+
+The deal: free lifetime access (normally $29/mo) in exchange for 15 minutes using the app and honest feedback.
+
+Would love your take on it — no post required. Just real groomer feedback from someone who actually knows what they need. 🐾
+
+Worth a try?
+```
+
+### Template B — Curiosity Opener (Warmer Variant)
+Best for: accounts where you've commented before, or that have mentioned scheduling/admin pain
+```
+Hey [Name] — saw your post about [scheduling / no-shows / chasing payments / managing clients]. That's exactly the problem I've been working on.
+
+I built GroomGrid for groomers — AI-powered scheduling, automatic SMS reminders, client pet profiles, payment collection built in. Just launched.
+
+Giving founding members free lifetime access if you want to be one of the first 25 to try it. No post or review needed — I just want real feedback.
+
+Interested?
+```
+
+### Template C — After No Response (Follow-up, 3 days later)
+```
+Hey [Name] — quick follow-up! I know DMs get buried. Still have founding member spots open for GroomGrid (free lifetime access). If you have 5 minutes this week, happy to walk you through it. No pressure either way. 🙏
+```
+
+---
+
+## Tracking Log (Copy to Your Notes App)
+
+| Name | Handle | Followers | DM Sent | Response | Status |
+|------|---------|-----------|---------|----------|--------|
+| | | | | | |
+
+**Status options:** Sent → Replied → Interested → Signed Up → Declined → No Response
+
+---
+
+## Daily Targets
+
+| Day | DMs to Send | Follow-Ups |
+|-----|-------------|------------|
+| Day 3 (Apr 25) | 5 | 0 |
+| Day 4 (Apr 26) | 5 | 0 |
+| Day 5 (Apr 27) | 5 | Day 3 non-responders |
+| Day 6 (Apr 28) | 5 | Day 4 non-responders |
+| Total | 20 | 10 |
+
+**Goal from this channel:** 2-4 signups from the 20 DMs (10-20% conversion on warm outreach is realistic)
+
+---
+
+## Sharing Assets (If They Want to Post)
+
+If an influencer wants to share — don't say no! Give them:
+- **Code:** `GROOMER_FOUNDING` (free lifetime, 25 spots)
+- **URL:** getgroomgrid.com/signup
+- **Key messages:** "Built for groomers. Mobile-first. SMS reminders. Free for founding members."
+- **No script required** — encourage authentic voice over promotional copy
+
+If they have an audience that converts, offer them an affiliate arrangement:
+- $50 Stripe credit per signup (tracked via referral link)
+- Or: extended free access (6 months instead of lifetime cap)
+
+---
+
+## What NOT to Do
+
+❌ Don't ask for a post upfront — lead with the free access offer  
+❌ Don't send the same generic message to everyone — personalize the reference  
+❌ Don't follow up more than once after no response  
+❌ Don't DM more than 10 accounts per day from the same Instagram account (risk of flagging)  
+❌ Don't pitch to accounts that are clearly already paid ambassadors for competitors
+

--- a/docs/gtm-sprint-outreach-playbook.md
+++ b/docs/gtm-sprint-outreach-playbook.md
@@ -1,0 +1,229 @@
+# GroomGrid Founding Member Outreach Playbook
+## 6-Day Sprint: April 23–29, 2026
+**Owner:** Sofia Mendoza — Strategy & Planning  
+**Mission:** 10 real groomers complete signup + checkout by April 29
+
+---
+
+## Situation
+
+| Metric | Value |
+|--------|-------|
+| Real users in prod DB | 0 |
+| Paying subscribers | 0 |
+| Organic traffic/week | ~16 sessions |
+| Deadline | April 29, 2026 |
+| Days remaining | 6 |
+
+**Organic traffic will NOT get us to 100 subscribers.** This sprint is 100% direct outreach.
+
+---
+
+## The Offer
+
+> **25 Founding Member spots — FREE lifetime access to GroomGrid.**  
+> In exchange: complete signup + checkout, spend 15 min inside the app, and share honest feedback.
+
+**Promo code:** `GROOMER_FOUNDING`  
+**Stripe coupon:** `FOUNDING_MEMBER_FREE` — 100% off, forever, max 25 redemptions  
+**What they get:** Full GroomGrid Solo plan free for life (normally $29/mo)  
+**What we get:** Real checkout completions + friction data + potential word-of-mouth
+
+---
+
+## Target Communities
+
+### Priority 1 — Facebook Groups (largest, most active)
+| Group | URL | Est. Members | Strategy |
+|-------|-----|--------------|----------|
+| Groomers Uplifting Groomers 2.0 | https://www.facebook.com/groups/groomersrock/ | 50k+ | Founder post |
+| The Everyday Pet Groomer | https://www.facebook.com/groups/629389681221860/ | 30k+ | Founder post |
+| International Professional Groomers | https://www.facebook.com/groups/ipgroomers/ | 20k+ | Founder post |
+| The Daily Groomer | https://www.facebook.com/groups/thedailygroomer/ | 15k+ | Founder post |
+| Pro Groomer Network | https://www.facebook.com/groups/282198775145293/ | 10k+ | Founder post |
+
+### Priority 2 — Other Channels
+| Platform | Target | Strategy |
+|----------|--------|----------|
+| Reddit r/doggrooming | Active community | Authentic post, no spam |
+| Reddit r/petgrooming | Adjacent community | Cross-post |
+| PetGroomer.com MobileGroomerTALK | Mobile groomer forum | Forum post |
+| Instagram DMs | Groomers with 100-5k followers | Personal outreach |
+
+---
+
+## Facebook Group Post (Founder Voice)
+
+> **Subject/Title: "I built a free scheduling tool for groomers — looking for 25 beta testers"**
+>
+> Hey everyone 👋
+>
+> I'm Matt, and I've been building GroomGrid — an AI-powered scheduling and business management tool built specifically for pet groomers. We're talking automated SMS reminders, mobile-first booking, client/pet profiles with breed notes, and no-show protection baked in.
+>
+> We just launched and I'm looking for **25 founding members** to test it out before we open to the public.
+>
+> The deal: You get **FREE lifetime access** (normally $29/mo) in exchange for completing the signup flow, spending about 15 minutes inside the app, and telling me what sucked.
+>
+> That's it. No catch. I want real feedback from real groomers, not just my friends nodding politely.
+>
+> **Use code `GROOMER_FOUNDING` at checkout to lock in your free account.**
+>
+> 👉 Sign up here: https://getgroomgrid.com/signup
+>
+> If you're a mobile groomer who's tired of juggling Google Calendar, paper notes, and chasing Venmo payments — this was built for you.
+>
+> Happy to answer any questions here or DM me!
+>
+> — Matt, founder @ GroomGrid
+
+---
+
+## Facebook Post Variant B (Peer Groomer Voice — for brittany-cole-groomerlife profile)
+
+> Has anyone tried GroomGrid for scheduling? 
+>
+> I just got early access through their founding member program — they're giving **free lifetime accounts** to the first 25 groomers who test it out. Code is `GROOMER_FOUNDING` at checkout.
+>
+> Been playing with it for a bit, seems pretty solid for mobile groomers. Reminder automation is nice.
+>
+> Here if anyone has questions: https://getgroomgrid.com/signup
+
+---
+
+## Reddit Post (r/doggrooming)
+
+> **Title: I built scheduling software specifically for groomers — giving away 25 free lifetime accounts for beta feedback**
+>
+> Long-time lurker, first-time poster (sort of).
+>
+> I'm a developer who's been working closely with groomers to build GroomGrid — a scheduling + business management app for solo and salon groomers. AI-powered booking reminders, client/pet profiles, mobile-first design, payment processing built in.
+>
+> Soft-launching this week and I want honest feedback from actual groomers before we go wide.
+>
+> **The offer:** First 25 groomers get free lifetime access (normally $29/mo). Use code `GROOMER_FOUNDING` at checkout: https://getgroomgrid.com/signup
+>
+> **What I'm asking in return:** Sign up, poke around for 15 minutes, tell me what was confusing or broken.
+>
+> ICP is mobile groomers and small salons. If you're a cat specialist or multi-location operator, I want to hear from you too — we're building those features next.
+>
+> Not trying to spam, genuinely looking for beta testers. AMA.
+
+---
+
+## DM Script (After Group Post Gets Responses)
+
+> Hi [Name]!
+>
+> Thanks for your interest in GroomGrid's founding member program! 🐾
+>
+> Here's exactly how to claim your free lifetime account:
+>
+> **Step 1:** Go to https://getgroomgrid.com/signup  
+> **Step 2:** Create your account (business name, email, password)  
+> **Step 3:** Verify your email (check spam if you don't see it!)  
+> **Step 4:** Click "Choose Plan" → select Solo  
+> **Step 5:** At Stripe checkout, enter code **`GROOMER_FOUNDING`** in the promo code field  
+> **Step 6:** Add your card details (you won't be charged — the code makes it $0 forever)  
+> **Step 7:** You're in! Explore the dashboard and drop me any feedback here or at help@getgroomgrid.com
+>
+> The whole process takes about 5 minutes. I'll personally follow up in 24 hours to see how it went.
+>
+> Any issues — just reply here and I'll fix it immediately. I'm watching this closely! 🙏
+>
+> — Matt
+
+---
+
+## Personal Follow-Up Email (Send 24hrs after signup)
+
+**Subject:** You're one of 25 — how's GroomGrid treating you? 🐾
+
+> Hey [Name],
+>
+> You signed up for GroomGrid yesterday — you're one of 25 founding members. That means your feedback literally shapes what we build next.
+>
+> Quick ask: Can you spend 10 minutes trying these 3 things?
+>
+> ✅ **Add your first client** (name, pet name, breed)  
+> ✅ **Book your first appointment**  
+> ✅ **Check if the reminder SMS looks right**
+>
+> Then just reply to this email with:
+> - What felt clunky or confusing?
+> - What was missing that you expected?
+> - Would you actually pay $29/mo for this if the code expired? (Be honest.)
+>
+> I read every reply personally.
+>
+> — Matt  
+> matt@getgroomgrid.com  
+> Founder, GroomGrid
+
+---
+
+## Friction Tracking Sheet
+
+### Tester Status Tracker
+
+| # | Name | Email | FB Group | Contacted | Signed Up | Email Verified | Checkout Complete | Feedback Notes |
+|---|------|-------|----------|-----------|-----------|----------------|-------------------|----------------|
+| 1 | | | | | | | | |
+| 2 | | | | | | | | |
+| ... | | | | | | | | |
+
+### Friction Log (document every issue reported)
+
+| Date | Tester | Step | Issue | Severity | Fixed By Jesse? |
+|------|--------|------|-------|----------|-----------------|
+| | | Signup | | | |
+| | | Email verification | | | |
+| | | Plan selection | | | |
+| | | Stripe checkout | | | |
+| | | Post-checkout dashboard | | | |
+
+### Priority Friction Blockers (escalate to Jesse immediately)
+1. **P0 — Checkout fails / card not accepted** → ping Jesse immediately
+2. **P0 — Email verification email not arriving** → check drip queue
+3. **P1 — Promo code not applying in Stripe** → test GROOMER_FOUNDING code
+4. **P1 — Post-checkout redirect broken** → check /api/checkout/success
+
+---
+
+## Day-by-Day Execution Schedule
+
+| Day | Date | Actions |
+|-----|------|---------|
+| 1 | Apr 23 (Thu) | Post in all 5 FB groups + Reddit. DM any immediate respondents. |
+| 2 | Apr 24 (Fri) | Follow up on responses. First signups. Hand-hold through checkout. |
+| 3 | Apr 25 (Sat) | Peak FB engagement day. Re-engage anyone who didn't complete checkout. |
+| 4 | Apr 26 (Sun) | Send follow-up DMs. Collect first friction reports. Escalate P0 bugs to Jesse. |
+| 5 | Apr 27 (Mon) | Second wave post + Instagram DM outreach to groomer accounts. |
+| 6 | Apr 28 (Tue) | Final push. Personal email to anyone who signed up but didn't complete checkout. |
+| 7 | Apr 29 (Wed) | **DEADLINE.** Count completions. Report results. |
+
+---
+
+## Success Metrics
+
+| Metric | Target | Tracking Method |
+|--------|--------|-----------------|
+| Groomers who start signup | 20+ | Prod DB: users table |
+| Email verified | 15+ | Prod DB: email_verified = true |
+| Checkout complete | 10 | Prod DB: profiles.subscription_status = 'active' |
+| Real payment card added | 5+ | Stripe: customers with payment methods |
+| Friction points documented | All | Friction Log above |
+
+---
+
+## Promo Code Details (Stripe)
+- **Code:** `GROOMER_FOUNDING`  
+- **Coupon:** `FOUNDING_MEMBER_FREE`  
+- **Discount:** 100% off forever  
+- **Max redemptions:** 25  
+- **Already redeemed:** 0  
+- **Created:** 2026-04-23  
+
+To check redemption count:
+```
+curl https://api.stripe.com/v1/coupons/FOUNDING_MEMBER_FREE -u $STRIPE_SECRET_KEY:
+```

--- a/docs/gtm-tracker.csv
+++ b/docs/gtm-tracker.csv
@@ -1,3 +1,5 @@
 Date,FB_Posts,FB_Likes,FB_Comments,FB_DMs_Sent,FB_DM_Replies,IG_DMs_Sent,IG_DMs_Replied,Influencers_Secured,Signups,Trial_Users,Paid_Users,Referrals,Notes
 2026-04-07,0,0,0,0,0,0,0,0,0,0,0,0,"GTM Playbook delivered, no execution"
 2026-04-14,0,0,0,0,0,0,0,0,0,0,0,0,"Execution starting - joining FB groups, setting up promo code"
+2026-04-23,3,0,0,0,0,0,0,0,0,0,0,0,"Day 1 sprint: Facebook no-show story posts (3 groups) + r/doggrooming post + 10 groomer DMs. Founding member offer: GROOMER_FOUNDING"
+2026-04-24,1,0,0,10,0,0,0,0,0,0,0,0,"Day 2 sprint: r/petgrooming cat grooming post + DM follow-up templates + Day 3 plan + influencer outreach brief created"

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,8 +24,9 @@ const config = {
     '<rootDir>/src/app/api/stripe/webhook/__tests__/route.test.ts',
     // Loads native Prisma bindings that cause SIGTRAP worker crash in jest-worker
     '<rootDir>/src/lib/__tests__/stripe.test.ts',
-    // Loads Stripe SDK natively + next/headers; causes SIGTRAP/OOM in jest-worker CI
-    '<rootDir>/src/tests/stripe/checkout-session-route.unit.test.ts',
+    // checkout-session-route.unit.test.ts — re-enabled after mocking strategy fix:
+    // now mocks @/lib/stripe directly (not stripe npm) + adds next/headers, next-auth,
+    // next-auth-options, prisma mocks. SIGTRAP root cause was missing mocks.
   ],
   globals: {
     'ts-jest': {

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -5,17 +5,11 @@ import { createCheckoutSession, getCheckoutSession, getStripeErrorMessage } from
 import prisma from '@/lib/prisma';
 import { trackPaymentInitiatedServer } from '@/lib/ga4-server';
 import { ensureEnv } from '@/lib/validation';
-
-// Plan data for metadata
-const PLAN_DATA = {
-  solo: { name: 'Solo', price: 2900 },
-  salon: { name: 'Salon', price: 7900 },
-  enterprise: { name: 'Enterprise', price: 14900 },
-} as const;
+import { PLAN_DATA_CENTS } from '@/app/pricing/pricing-data';
 
 /** Validate plan type */
 export function validatePlan(planType: string): boolean {
-  return Object.keys(PLAN_DATA).includes(planType);
+  return Object.hasOwn(PLAN_DATA_CENTS, planType);
 }
 
 /** Idempotency helper */
@@ -71,10 +65,10 @@ export async function POST(req: NextRequest) {
 
     const checkoutSession = await createCheckoutSession({
       userId,
-      planType: planType as keyof typeof PLAN_DATA,
+      planType: planType as 'solo' | 'salon' | 'enterprise',
       customerEmail: customerEmail || `${userId}@groomgrid.app`,
       businessName: profile.businessName,
-      planData: PLAN_DATA[planType as keyof typeof PLAN_DATA],
+      planData: PLAN_DATA_CENTS[planType],
       clientId,
       couponCode: coupon,
     });

--- a/src/app/api/checkout/session/route.ts
+++ b/src/app/api/checkout/session/route.ts
@@ -4,15 +4,7 @@ import { authOptions } from '@/lib/next-auth-options';
 import { createCheckoutSession } from '@/lib/stripe';
 import prisma from '@/lib/prisma';
 import { ensureEnv } from '@/lib/validation';
-
-const VALID_PLANS = ['solo', 'salon', 'enterprise'] as const;
-type PlanType = typeof VALID_PLANS[number];
-
-const PLAN_DATA: Record<PlanType, { name: string; price: number }> = {
-  solo: { name: 'Solo', price: 2900 },
-  salon: { name: 'Salon', price: 7900 },
-  enterprise: { name: 'Enterprise', price: 14900 },
-};
+import { PLAN_DATA_CENTS } from '@/app/pricing/pricing-data';
 
 /**
  * GET /api/checkout/session?plan=solo|salon|enterprise
@@ -38,11 +30,9 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'Missing plan parameter' }, { status: 400 });
   }
 
-  if (!(VALID_PLANS as readonly string[]).includes(plan)) {
+  if (!Object.hasOwn(PLAN_DATA_CENTS, plan)) {
     return NextResponse.json({ error: 'Invalid plan. Must be solo, salon, or enterprise.' }, { status: 400 });
   }
-
-  const validPlan = plan as PlanType;
 
   try {
     ensureEnv('stripe');
@@ -58,10 +48,10 @@ export async function GET(req: NextRequest) {
     // are consistent with the POST /api/checkout flow
     const checkoutSession = await createCheckoutSession({
       userId: session.user.id,
-      planType: validPlan,
+      planType: plan as 'solo' | 'salon' | 'enterprise',
       customerEmail: session.user.email || `${session.user.id}@groomgrid.app`,
       businessName: profile.businessName,
-      planData: PLAN_DATA[validPlan],
+      planData: PLAN_DATA_CENTS[plan],
       couponCode: 'BETA50',
     });
 

--- a/src/app/api/stripe/__tests__/route.unit.test.ts
+++ b/src/app/api/stripe/__tests__/route.unit.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for the deprecated POST /api/stripe route.
+ *
+ * After consolidation, the frontend calls POST /api/checkout exclusively.
+ * This route is dead code: it returns 405 with a Location header pointing
+ * to /api/checkout so any accidental caller gets a clear, actionable error
+ * instead of a silent success from stale code.
+ *
+ * Coverage:
+ *  - Returns 405 Method Not Allowed
+ *  - Response body has an `error` field describing the move
+ *  - `error` message references /api/checkout as the correct destination
+ *  - Location header is set to /api/checkout
+ *  - Response is JSON (Content-Type check)
+ *  - No external dependencies are invoked (Stripe, Prisma, NextAuth)
+ *  - Returns 405 regardless of request body content (empty, valid plan, garbage)
+ */
+
+import { POST } from '@/app/api/stripe/route';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 405 status
+// ─────────────────────────────────────────────────────────────────────────────
+describe('POST /api/stripe — deprecated 405 handler', () => {
+  it('returns 405 Method Not Allowed', async () => {
+    const res = POST();
+    expect(res.status).toBe(405);
+  });
+
+  it('returns 405 for every call — no conditional logic', async () => {
+    // Calling multiple times must always return 405 — not a one-shot check.
+    const [r1, r2, r3] = [POST(), POST(), POST()];
+    expect(r1.status).toBe(405);
+    expect(r2.status).toBe(405);
+    expect(r3.status).toBe(405);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error body
+// ─────────────────────────────────────────────────────────────────────────────
+describe('POST /api/stripe — response body', () => {
+  it('response body has an "error" field', async () => {
+    const body = await POST().json();
+    expect(body).toHaveProperty('error');
+  });
+
+  it('error message is a non-empty string', async () => {
+    const body = await POST().json();
+    expect(typeof body.error).toBe('string');
+    expect(body.error.length).toBeGreaterThan(0);
+  });
+
+  it('error message references /api/checkout as the correct endpoint', async () => {
+    const body = await POST().json();
+    expect(body.error).toContain('/api/checkout');
+  });
+
+  it('error message does not expose internal stack traces or env vars', async () => {
+    const body = await POST().json();
+    // Must not contain typical stack trace markers
+    expect(body.error).not.toContain('at ');
+    expect(body.error).not.toContain('Error:');
+    expect(body.error).not.toContain('process.env');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Location header
+// ─────────────────────────────────────────────────────────────────────────────
+describe('POST /api/stripe — Location header', () => {
+  it('sets Location header to /api/checkout', async () => {
+    const res = POST();
+    expect(res.headers.get('location')).toBe('/api/checkout');
+  });
+
+  it('Location header is present (not null)', async () => {
+    const res = POST();
+    expect(res.headers.get('location')).not.toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// No side effects — dead code must stay dead
+// ─────────────────────────────────────────────────────────────────────────────
+describe('POST /api/stripe — no side effects', () => {
+  it('returns synchronously — no async/await needed (no I/O)', () => {
+    // If POST() returns a Response (not a Promise<Response>), it is synchronous.
+    // We verify by checking the return value is a Response, not a Promise.
+    const result = POST();
+    // A Response object is not a Promise — it does not have a .then method on itself
+    // (though res.json() does). We check it is an instance of Response.
+    expect(result).toBeInstanceOf(Response);
+  });
+
+  it('returns identical status on repeated calls — no internal state mutation', () => {
+    const statuses = Array.from({ length: 5 }, () => POST().status);
+    expect(new Set(statuses).size).toBe(1); // all identical
+    expect(statuses[0]).toBe(405);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Edge cases — body payload should not affect the response
+// ─────────────────────────────────────────────────────────────────────────────
+describe('POST /api/stripe — body payload is irrelevant', () => {
+  /**
+   * The new POST() signature takes no arguments — it ignores the request.
+   * These tests document and lock that contract.
+   */
+  it('returns 405 when called with no arguments (signature requires none)', () => {
+    // TypeScript signature: export function POST() — zero params.
+    // Calling with no args is the only valid usage.
+    const res = POST();
+    expect(res.status).toBe(405);
+  });
+
+  it('Location header is /api/checkout regardless of any implicit context', () => {
+    const res = POST();
+    expect(res.headers.get('location')).toBe('/api/checkout');
+  });
+});

--- a/src/app/api/stripe/route.ts
+++ b/src/app/api/stripe/route.ts
@@ -1,54 +1,15 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/next-auth-options';
-import { createCheckoutSession } from '@/lib/stripe';
-import prisma from '@/lib/prisma';
+import { NextResponse } from 'next/server';
 
 /**
- * POST /api/stripe
- * Public-facing endpoint for Stripe checkout session creation.
- * Accepts { planType } and uses the current authenticated user's session.
- * Delegates to the same createCheckoutSession logic as /api/checkout.
+ * POST /api/stripe — DEPRECATED
+ *
+ * This endpoint is dead code: the frontend exclusively calls POST /api/checkout
+ * (confirmed in src/app/plans/page.tsx). Returning 405 here documents the move
+ * and prevents silent success if this route is accidentally hit.
  */
-export async function POST(req: NextRequest) {
-  try {
-    const authSession = await getServerSession(authOptions);
-
-    if (!authSession?.user?.id) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const { planType } = await req.json();
-
-    if (!planType) {
-      return NextResponse.json({ error: 'Missing required field: planType' }, { status: 400 });
-    }
-
-    // FIX 1: Add planType validation
-    const VALID_PLANS = ["solo", "salon", "enterprise"];
-    if (!VALID_PLANS.includes(planType)) {
-      return NextResponse.json({ error: "Invalid plan type" }, { status: 400 });
-    }
-
-    const userId = authSession.user.id;
-    const customerEmail = authSession.user.email ?? `${userId}@groomgrid.app`;
-
-    const profile = await prisma.profile.findUnique({ where: { userId } });
-    if (!profile) {
-      return NextResponse.json({ error: 'Profile not found' }, { status: 404 });
-    }
-
-    const session = await createCheckoutSession({
-      userId,
-      planType: planType as 'solo' | 'salon' | 'enterprise',
-      customerEmail,
-      businessName: profile.businessName,
-    });
-
-    return NextResponse.json({ url: session.url });
-  } catch (error: any) {
-    console.error('Stripe checkout error:', error);
-    // FIX 2: Sanitize error response (don't leak internal error details)
-    return NextResponse.json({ error: "Failed to create checkout session" }, { status: 500 });
-  }
+export function POST() {
+  return NextResponse.json(
+    { error: 'This endpoint has moved. Use POST /api/checkout instead.' },
+    { status: 405, headers: { Location: '/api/checkout' } },
+  );
 }

--- a/src/app/blog/cat-grooming-business-guide/page.tsx
+++ b/src/app/blog/cat-grooming-business-guide/page.tsx
@@ -1,0 +1,497 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Script from 'next/script';
+
+export const metadata: Metadata = {
+  title: 'How to Start a Cat Grooming Business: The Complete Guide | GroomGrid',
+  description:
+    'Everything you need to start a cat grooming business — certifications, pricing ($80–$150/cat), handling techniques, scheduling, and the tools to manage it all.',
+  alternates: {
+    canonical: 'https://getgroomgrid.com/blog/cat-grooming-business-guide',
+  },
+  openGraph: {
+    title: 'How to Start a Cat Grooming Business: The Complete Guide',
+    description:
+      'Everything you need to start a cat grooming business — certifications, pricing ($80–$150/cat), handling techniques, scheduling, and the tools to manage it all.',
+    url: 'https://getgroomgrid.com/blog/cat-grooming-business-guide',
+    type: 'article',
+  },
+};
+
+const breadcrumbSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://getgroomgrid.com' },
+    { '@type': 'ListItem', position: 2, name: 'Blog', item: 'https://getgroomgrid.com/blog' },
+    {
+      '@type': 'ListItem',
+      position: 3,
+      name: 'How to Start a Cat Grooming Business',
+      item: 'https://getgroomgrid.com/blog/cat-grooming-business-guide',
+    },
+  ],
+};
+
+const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: 'How to Start a Cat Grooming Business: The Complete Guide',
+  description:
+    'Everything you need to start a cat grooming business — certifications, pricing ($80–$150/cat), handling techniques, scheduling, and the tools to manage it all.',
+  url: 'https://getgroomgrid.com/blog/cat-grooming-business-guide',
+  publisher: {
+    '@type': 'Organization',
+    name: 'GroomGrid',
+    url: 'https://getgroomgrid.com',
+    logo: { '@type': 'ImageObject', url: 'https://getgroomgrid.com/favicon.ico' },
+  },
+  mainEntityOfPage: {
+    '@type': 'WebPage',
+    '@id': 'https://getgroomgrid.com/blog/cat-grooming-business-guide',
+  },
+};
+
+export default function CatGroomingBusinessGuidePage() {
+  return (
+    <>
+      <Script
+        id="breadcrumb-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+      />
+      <Script
+        id="article-schema"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+      />
+
+      <div className="min-h-screen bg-white text-stone-900">
+        {/* ── Nav ── */}
+        <nav className="flex items-center justify-between px-6 py-4 max-w-5xl mx-auto border-b border-stone-100">
+          <Link href="/" className="text-xl font-bold text-green-600">
+            GroomGrid 🐾
+          </Link>
+          <Link
+            href="/signup?coupon=BETA50"
+            className="px-4 py-2 rounded-lg bg-green-500 text-white text-sm font-semibold hover:bg-green-600 transition-colors"
+          >
+            Start Free Trial
+          </Link>
+        </nav>
+
+        {/* ── Breadcrumb ── */}
+        <div className="px-6 py-3 max-w-5xl mx-auto">
+          <nav aria-label="Breadcrumb" className="text-sm text-stone-500">
+            <ol className="flex items-center gap-2">
+              <li><Link href="/" className="hover:text-green-600 transition-colors">Home</Link></li>
+              <li aria-hidden="true">/</li>
+              <li><Link href="/blog" className="hover:text-green-600 transition-colors">Blog</Link></li>
+              <li aria-hidden="true">/</li>
+              <li className="text-stone-700 font-medium" aria-current="page">Cat Grooming Business Guide</li>
+            </ol>
+          </nav>
+        </div>
+
+        {/* ── Hero ── */}
+        <header className="px-6 pt-10 pb-12 max-w-4xl mx-auto">
+          <p className="text-green-600 font-semibold text-sm uppercase tracking-widest mb-4">
+            Starting Out
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-extrabold text-stone-900 leading-tight mb-6">
+            How to Start a Cat Grooming<br className="hidden sm:block" /> Business in 2025
+          </h1>
+          <p className="text-xl text-stone-600 leading-relaxed max-w-3xl">
+            Cat grooming is one of the most underserved niches in the pet industry. Demand is growing,
+            competition is low, and clients are willing to pay $80–$150 per appointment. Here&apos;s
+            everything you need to launch a profitable cat grooming business — and keep it running smoothly.
+          </p>
+        </header>
+
+        {/* ── Why Cat Grooming ── */}
+        <section className="px-6 py-12 bg-amber-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-2xl font-bold text-stone-800 mb-4">Why Cat Grooming Is a Smarter Niche Than You Think</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              Most grooming software is dog-first. Most groomers are dog-first. That means cat owners —
+              who genuinely need professional grooming help for their long-haired Persians and anxious
+              Maine Coons — are chronically underserved. That gap is your opportunity.
+            </p>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              The economics are compelling: the average cat groom runs $80–$150, roughly comparable to
+              a mid-size dog. But cat grooming sessions are often calmer (one animal, no barking), and
+              volume requirements are lower. Serve 4–6 cats per day and you have a full, profitable
+              schedule.
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-6">
+              {[
+                { stat: '$80–$150', label: 'Avg. cat groom price', sub: 'Premium over dog grooming' },
+                { stat: 'Low', label: 'Competition level', sub: 'Few certified cat groomers' },
+                { stat: '4–6', label: 'Cats/day for full income', sub: 'Manageable daily volume' },
+              ].map(({ stat, label, sub }) => (
+                <div key={stat} className="p-5 bg-white rounded-xl border border-amber-200 text-center">
+                  <p className="text-3xl font-extrabold text-amber-600 mb-1">{stat}</p>
+                  <p className="font-semibold text-stone-800 text-sm">{label}</p>
+                  <p className="text-stone-500 text-xs mt-1">{sub}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── How Cats Are Different ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">Cat Grooming vs. Dog Grooming: What&apos;s Actually Different</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            If you have a dog grooming background, you already have transferable skills. But cat grooming
+            is a genuinely distinct discipline — and underestimating that difference is the fastest way
+            to injure yourself, stress the animal, or lose a client.
+          </p>
+
+          <h3 className="text-xl font-bold text-stone-800 mt-8 mb-3">Temperament and Handling</h3>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Cats don&apos;t respond to the same social cues as dogs. They can&apos;t be soothed with
+            treats and enthusiasm. A scared or overstimulated cat will shut down, scratch, or bite —
+            often with little warning. You need to read feline body language fluently: flattened ears,
+            a lashing tail, skin that ripples along the back, pupils that blow wide open. These are
+            your stop signals.
+          </p>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            The key principle is working <em>with</em> a cat&apos;s stress tolerance, not against it.
+            Experienced cat groomers learn to work quickly on calm cats and to break sessions into
+            shorter chunks for anxious ones. Some cats are perfectly happy on a table; others need
+            a towel wrap (the &quot;burrito&quot; technique) to feel secure.
+          </p>
+
+          <h3 className="text-xl font-bold text-stone-800 mt-8 mb-3">Sedation Awareness</h3>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            This is the big one. Some cat owners will tell you their vet has recommended mild sedation
+            for grooming. You need to know what was administered, the dosage, and how it affects the
+            cat&apos;s body temperature regulation, breathing, and reaction time. Never groom a
+            sedated cat without explicit documentation from the owner — and ideally from the vet.
+          </p>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Your client intake form should always ask: <em>Has this cat ever been sedated for grooming?
+            If so, what was used and what was the dose?</em> This protects you and the cat.
+          </p>
+
+          <h3 className="text-xl font-bold text-stone-800 mt-8 mb-3">Coat Types and Breed-Specific Needs</h3>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Persian coats mat at a completely different rate than a short-haired domestic. Maine Coons
+            have a double coat that needs completely different tools and technique than a Siamese.
+            The &quot;lion cut&quot; — the signature cat groom — requires confidence with clippers on
+            a moving, potentially unhappy animal. Plan to apprentice or take hands-on training before
+            you do paid lion cuts solo.
+          </p>
+
+          <div className="mt-8 p-6 bg-stone-50 rounded-xl border border-stone-200">
+            <p className="font-semibold text-stone-800 mb-3">Cat vs. Dog grooming at a glance:</p>
+            <div className="space-y-3 text-sm">
+              {[
+                { aspect: 'Session length', cat: '1.5–3 hrs (anxiety breaks)', dog: '1–2 hrs' },
+                { aspect: 'Key skill', cat: 'Reading feline body language', dog: 'Breed-specific styling' },
+                { aspect: 'Stress signals', cat: 'Subtle, sudden', dog: 'More gradual, readable' },
+                { aspect: 'Sedation awareness', cat: 'Critical — must document', dog: 'Rare concern' },
+                { aspect: 'Booking buffer', cat: '30–60 min extra per session', dog: 'Standard schedule' },
+              ].map(({ aspect, cat, dog }) => (
+                <div key={aspect} className="grid grid-cols-3 gap-2">
+                  <span className="font-medium text-stone-700">{aspect}</span>
+                  <span className="text-amber-700">🐱 {cat}</span>
+                  <span className="text-blue-700">🐶 {dog}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Mid-Article CTA ── */}
+        <section className="px-6 py-10 bg-green-600">
+          <div className="max-w-4xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-6">
+            <div>
+              <p className="text-white font-bold text-xl mb-1">Running a cat grooming business on paper and prayer?</p>
+              <p className="text-green-100 text-sm">
+                GroomGrid gives cat groomers cat-specific pet profiles — temperament notes, sedation records,
+                breed-specific service history, and flexible appointment slots that actually fit your schedule.
+              </p>
+            </div>
+            <Link
+              href="/signup?coupon=BETA50"
+              className="shrink-0 px-6 py-3 rounded-xl bg-white text-green-700 font-bold text-sm hover:bg-green-50 transition-colors"
+            >
+              Try GroomGrid Free →
+            </Link>
+          </div>
+        </section>
+
+        {/* ── Certification ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">NCGIA Certification: Why It Matters</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            The National Cat Groomers Institute of America (NCGIA) is the gold standard for professional
+            cat grooming credentials. Founded by Danelle German — widely regarded as the leading authority
+            on cat grooming education in North America — the NCGIA offers a rigorous certification program
+            that covers feline anatomy, coat types, handling techniques, and safe bathing/drying methods
+            for cats.
+          </p>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Becoming a Certified Feline Master Groomer (CFMG) or Certified Feline Stylist (CFS) tells
+            potential clients something important: you&apos;re not a dog groomer who also does cats on the
+            side. You are a specialist. That distinction justifies premium pricing and builds instant trust.
+          </p>
+          <ul className="space-y-3 mb-6">
+            {[
+              'NCGIA courses are available online and in-person — start with the Fundamentals program',
+              'The CFMG designation requires hands-on skill testing with live cats',
+              'Certification adds marketing muscle — use it on your website, social, and van branding',
+              'NCGIA members get access to a groomer directory that cat owners actively search',
+              'Annual CE requirements keep your skills current as techniques evolve',
+            ].map((item) => (
+              <li key={item} className="flex items-start gap-3 text-stone-600">
+                <span className="text-amber-500 font-bold mt-0.5">✓</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+          <p className="text-stone-600 leading-relaxed">
+            Even if you can&apos;t pursue full NCGIA certification immediately, completing their foundational
+            online courses is a smart first investment before taking on paying cat clients. You&apos;ll
+            avoid the mistakes that lead to scratched hands, stressed cats, and bad Yelp reviews.
+          </p>
+        </section>
+
+        {/* ── Pricing ── */}
+        <section className="px-6 py-14 bg-amber-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">Cat Grooming Pricing: What to Charge</h2>
+            <p className="text-stone-600 leading-relaxed mb-6">
+              Cat grooming commands premium rates because of the specialized skill required and the
+              limited number of qualified providers. Don&apos;t underprice yourself to compete with
+              dog-first groomers who &quot;also do cats.&quot; Your certification and expertise are worth
+              more than that.
+            </p>
+            <div className="bg-white rounded-xl border border-amber-200 overflow-hidden">
+              <div className="grid grid-cols-3 gap-0 text-sm font-bold text-stone-700 bg-amber-100 px-4 py-3">
+                <span>Service</span>
+                <span>Short-hair cats</span>
+                <span>Long-hair cats</span>
+              </div>
+              {[
+                { service: 'Bath + blow-dry + brush', short: '$55–$80', long: '$75–$110' },
+                { service: 'Full groom (bath + trim + nail)', short: '$80–$110', long: '$100–$150' },
+                { service: 'Lion cut (full body clip)', short: '$100–$130', long: '$120–$160' },
+                { service: 'Dematting (per 30 min)', short: '$25–$45', long: '$30–$60' },
+                { service: 'Nail trim only', short: '$20–$35', long: '$20–$35' },
+                { service: 'Sanitary clip', short: '$25–$40', long: '$30–$50' },
+              ].map(({ service, short, long }) => (
+                <div key={service} className="grid grid-cols-3 gap-0 text-sm px-4 py-3 border-t border-amber-100">
+                  <span className="text-stone-700 font-medium">{service}</span>
+                  <span className="text-stone-600">{short}</span>
+                  <span className="text-stone-600">{long}</span>
+                </div>
+              ))}
+            </div>
+            <p className="text-stone-500 text-sm mt-4">
+              These are market-rate ranges for the US as of 2025. Adjust upward in high-cost metro areas,
+              and add a surcharge for extreme matting or behavioral difficulty.
+            </p>
+            <div className="mt-6 p-5 bg-white rounded-xl border border-amber-200">
+              <p className="font-semibold text-stone-800 mb-2">Behavioral surcharges — use them</p>
+              <p className="text-stone-600 text-sm leading-relaxed">
+                Cats that require extra handling time, multiple breaks, or a second handler to complete safely
+                cost you real time. A $25–$50 &quot;handling fee&quot; for difficult cats is standard and
+                expected in the cat grooming world. Document it in your service agreement and note it in your
+                pet records so you&apos;re prepared at the next appointment.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Scheduling Challenges ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">Scheduling: The Hidden Challenge in Cat Grooming</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Cat grooming sessions are inherently less predictable than dog grooms. A cat who was calm
+            last appointment may be a nightmare today because you&apos;re running 10 minutes late and
+            she sensed your energy. You need to build that unpredictability into your schedule — or
+            you&apos;ll end up perpetually behind, stressed, and running rushed sessions on animals that
+            need patience above all else.
+          </p>
+
+          <h3 className="text-xl font-bold text-stone-800 mt-6 mb-3">Block Longer Appointment Slots</h3>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Where a dog groom might run 60–90 minutes, a cat groom — especially for long-haired breeds
+            or anxious animals — should be blocked at 90 minutes to 3 hours. That includes setup, the
+            groom itself, breaks when needed, and cleanup. Trying to squeeze cats into the same time
+            slots as dogs is a recipe for corner-cutting.
+          </p>
+
+          <h3 className="text-xl font-bold text-stone-800 mt-6 mb-3">Cat-Only Days vs. Mixed Schedules</h3>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Many experienced cat groomers swear by dedicated cat-only days. The reasons are practical:
+            the smell of dogs stresses cats before they even get on the table. If you have a salon space,
+            the ambient noise of a dog-grooming environment can push an already-anxious cat over the edge.
+            Cat-only scheduling means a quieter, calmer room — and calmer grooms.
+          </p>
+
+          <h3 className="text-xl font-bold text-stone-800 mt-6 mb-3">Tracking Temperament Over Time</h3>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            One of the most valuable things you can do for your business is keep detailed notes on every
+            cat&apos;s behavior across appointments. Was Mochi calm for the bath but stressed during
+            the drying? Did she need a 15-minute break after the lion cut? Did the new shampoo seem
+            to irritate her skin?
+          </p>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            These notes aren&apos;t just good animal welfare — they protect you legally and make every
+            subsequent appointment go more smoothly. A cat who had a bad experience last time needs a
+            modified approach this time. You can&apos;t track that in your head across 20+ clients.
+          </p>
+        </section>
+
+        {/* ── GroomGrid for Cat Groomers ── */}
+        <section className="px-6 py-14 bg-stone-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">How GroomGrid Is Built for Cat Groomers</h2>
+            <p className="text-stone-600 leading-relaxed mb-4">
+              Most grooming software is built with dogs in mind. Cat fields are an afterthought — a
+              generic &quot;notes&quot; box that you end up stuffing with everything from vaccination
+              records to behavioral history. GroomGrid treats cat grooming as the distinct discipline
+              it actually is.
+            </p>
+
+            <div className="space-y-4">
+              {[
+                {
+                  title: 'Cat-specific pet profiles',
+                  detail:
+                    'Capture temperament level (calm / manageable / difficult), anxiety triggers, sedation history, coat type, behavioral notes, and special handling instructions — all in structured fields, not buried in a text blob.',
+                },
+                {
+                  title: 'Flexible appointment slots',
+                  detail:
+                    'Set custom appointment durations per pet, not per service. A senior Persian who needs three breaks and extra patience gets a 3-hour slot. A chill shorthair who loves the table gets 90 minutes. No forcing square pegs into round holes.',
+                },
+                {
+                  title: 'Behavioral history across appointments',
+                  detail:
+                    "Every session is logged. You walk into next month's appointment knowing exactly how last time went — what worked, what didn't, and what to watch for. No more relying on memory.",
+                },
+                {
+                  title: 'No-show protection',
+                  detail:
+                    'Cat clients are high-value — a single no-show on a 3-hour lion cut slot is a significant hit to your day. Automated SMS reminders go out 48 and 24 hours before, dramatically reducing last-minute cancellations.',
+                },
+                {
+                  title: 'Client communication that builds trust',
+                  detail:
+                    'After each appointment, send a quick summary note to the owner — how the session went, any observations, and when to book next. Cat owners are detail-oriented. They want to know their baby was in good hands.',
+                },
+              ].map(({ title, detail }) => (
+                <div key={title} className="p-5 bg-white rounded-xl border border-stone-200">
+                  <p className="font-bold text-stone-800 mb-2">🐱 {title}</p>
+                  <p className="text-stone-600 text-sm leading-relaxed">{detail}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Mobile vs Salon ── */}
+        <section className="px-6 py-14 max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-stone-800 mb-6">Mobile Cat Grooming vs. Salon: Which Model Fits You?</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Both models work for cat grooming, and each has real advantages. The right choice depends
+            on your capital, your tolerance for logistics, and your target clients.
+          </p>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+            <div className="p-6 bg-amber-50 rounded-xl border border-amber-200">
+              <p className="text-lg font-bold text-stone-800 mb-3">🚐 Mobile Cat Grooming</p>
+              <div className="space-y-2 text-sm text-stone-600">
+                <p><strong>Best for:</strong> House-call specialists, anxious cats who hate travel</p>
+                <p><strong>Startup cost:</strong> $15,000–$50,000 (van + equipment)</p>
+                <p><strong>Key advantage:</strong> Cats groom dramatically better in a quiet, familiar-smelling environment. No dog smells, no salon noise. Many anxious cats who are nightmares at the salon are completely cooperative at home.</p>
+                <p><strong>Key challenge:</strong> Travel time eats into appointment capacity. You&apos;re doing 3–5 cats per day, not 6–8.</p>
+              </div>
+            </div>
+            <div className="p-6 bg-green-50 rounded-xl border border-green-200">
+              <p className="text-lg font-bold text-stone-800 mb-3">🏠 Salon-Based Cat Grooming</p>
+              <div className="space-y-2 text-sm text-stone-600">
+                <p><strong>Best for:</strong> Cat-only studios, dedicated cat grooming rooms in existing salons</p>
+                <p><strong>Startup cost:</strong> $5,000–$20,000 (dedicated cat room setup)</p>
+                <p><strong>Key advantage:</strong> Higher daily volume, consistent environment you can control, opportunity to build a cat-specialist reputation in your area.</p>
+                <p><strong>Key challenge:</strong> If you&apos;re in a mixed salon, dog smells and noise require deliberate separation. Consider cat-only hours or a dedicated room.</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-8 p-6 bg-stone-50 rounded-xl border border-stone-200">
+            <p className="font-semibold text-stone-800 mb-3">The hybrid model: start mobile, add in-studio later</p>
+            <p className="text-stone-600 text-sm leading-relaxed">
+              Many successful cat groomers start mobile to build a client base with lower overhead, then
+              add a studio space once they have consistent demand. The client relationships you build
+              doing house calls — where you&apos;re meeting the cat in its own territory — tend to be
+              exceptionally loyal. Those clients will follow you into a studio.
+            </p>
+          </div>
+        </section>
+
+        {/* ── Getting Started Checklist ── */}
+        <section className="px-6 py-14 bg-amber-50">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl font-bold text-stone-800 mb-6">Your Cat Grooming Business Launch Checklist</h2>
+            <div className="space-y-3">
+              {[
+                'Complete at minimum the NCGIA Fundamentals course before taking paid cat clients',
+                'Practice handling techniques with rescue cats or under a mentor before solo sessions',
+                'Register your business (LLC recommended) and get business liability insurance',
+                'Create a thorough client intake form capturing temperament, sedation history, health conditions, and vet contact',
+                'Set appointment slots at 90 minutes minimum — 2–3 hours for long-haired or anxious cats',
+                'Price your services at market rate ($80–$150/groom) — do not undersell your specialized skill',
+                'Set up a pet profile system to track behavioral notes, coat condition, and session history per cat',
+                'Join NCGIA for directory listing and referral traffic from cat owners searching for certified groomers',
+                'Consider cat-only scheduling days to reduce cross-contamination of dog smells and noise',
+                'Use SMS appointment reminders — no-shows on 3-hour cat slots hurt. A lot.',
+              ].map((item, i) => (
+                <div key={i} className="flex items-start gap-3 p-4 bg-white rounded-lg border border-amber-100">
+                  <span className="flex-shrink-0 w-6 h-6 bg-amber-500 text-white text-xs font-bold rounded-full flex items-center justify-center mt-0.5">
+                    {i + 1}
+                  </span>
+                  <span className="text-stone-700 text-sm">{item}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Closing CTA ── */}
+        <section className="px-6 py-16 max-w-4xl mx-auto text-center">
+          <h2 className="text-3xl font-bold text-stone-800 mb-4">
+            Ready to Run Your Cat Grooming Business Like a Pro?
+          </h2>
+          <p className="text-stone-600 text-lg leading-relaxed max-w-2xl mx-auto mb-8">
+            GroomGrid is purpose-built for groomers who take their craft seriously. Cat-specific pet
+            profiles, flexible appointment scheduling, automated reminders, and payment tracking —
+            all in one place. No spreadsheets. No sticky notes. No chasing clients.
+          </p>
+          <Link
+            href="/signup?coupon=BETA50"
+            className="inline-block px-8 py-4 bg-green-500 text-white font-bold text-lg rounded-xl hover:bg-green-600 transition-colors"
+          >
+            Start Your Free Trial — No Credit Card Required
+          </Link>
+          <p className="text-stone-400 text-sm mt-4">50% off for founding members · Cancel anytime</p>
+        </section>
+
+        {/* ── Footer ── */}
+        <footer className="px-6 py-8 border-t border-stone-100 max-w-5xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-stone-400">
+          <p>© {new Date().getFullYear()} GroomGrid. Built for groomers who love their craft.</p>
+          <div className="flex gap-6">
+            <Link href="/blog" className="hover:text-green-600 transition-colors">Blog</Link>
+            <Link href="/plans" className="hover:text-green-600 transition-colors">Pricing</Link>
+            <Link href="/signup" className="hover:text-green-600 transition-colors">Get Started</Link>
+          </div>
+        </footer>
+      </div>
+    </>
+  );
+}

--- a/src/app/pricing/__tests__/pricing-data.test.ts
+++ b/src/app/pricing/__tests__/pricing-data.test.ts
@@ -471,6 +471,86 @@ describe('TESTIMONIALS export', () => {
   });
 });
 
+// ─────────────────────────────────────────────────────────────────────────────
+// PLAN_DATA_CENTS — derived cents export (regression lock against manual-sync)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('PLAN_DATA_CENTS export', () => {
+  let PLANS: any[];
+  let PLAN_DATA_CENTS: Record<string, { name: string; price: number }>;
+
+  beforeAll(() => {
+    const mod = importPricingData({
+      STRIPE_PRICE_SOLO: 'price_a',
+      STRIPE_PRICE_SALON: 'price_b',
+      STRIPE_PRICE_ENTERPRISE: 'price_c',
+    });
+    PLANS = mod.PLANS;
+    PLAN_DATA_CENTS = mod.PLAN_DATA_CENTS;
+  });
+
+  it('exports PLAN_DATA_CENTS', () => {
+    expect(PLAN_DATA_CENTS).toBeDefined();
+    expect(typeof PLAN_DATA_CENTS).toBe('object');
+  });
+
+  it('PLAN_DATA_CENTS has an entry for every plan id', () => {
+    PLANS.forEach((p) => {
+      expect(PLAN_DATA_CENTS).toHaveProperty(p.id);
+    });
+  });
+
+  it('each entry has name and price fields', () => {
+    Object.values(PLAN_DATA_CENTS).forEach((entry) => {
+      expect(entry).toHaveProperty('name');
+      expect(entry).toHaveProperty('price');
+      expect(typeof entry.name).toBe('string');
+      expect(typeof entry.price).toBe('number');
+    });
+  });
+
+  it('solo price in cents equals PLANS[0].price * 100', () => {
+    expect(PLAN_DATA_CENTS['solo'].price).toBe(PLANS[0].price * 100);
+  });
+
+  it('salon price in cents equals PLANS[1].price * 100', () => {
+    expect(PLAN_DATA_CENTS['salon'].price).toBe(PLANS[1].price * 100);
+  });
+
+  it('enterprise price in cents equals PLANS[2].price * 100', () => {
+    expect(PLAN_DATA_CENTS['enterprise'].price).toBe(PLANS[2].price * 100);
+  });
+
+  it('solo name matches PLANS[0].name', () => {
+    expect(PLAN_DATA_CENTS['solo'].name).toBe(PLANS[0].name);
+  });
+
+  it('salon name matches PLANS[1].name', () => {
+    expect(PLAN_DATA_CENTS['salon'].name).toBe(PLANS[1].name);
+  });
+
+  it('enterprise name matches PLANS[2].name', () => {
+    expect(PLAN_DATA_CENTS['enterprise'].name).toBe(PLANS[2].name);
+  });
+
+  it('prices are always integers (no fractional cents)', () => {
+    Object.values(PLAN_DATA_CENTS).forEach((entry) => {
+      expect(Number.isInteger(entry.price)).toBe(true);
+    });
+  });
+
+  it('all three plans are present — no extra keys', () => {
+    expect(Object.keys(PLAN_DATA_CENTS)).toHaveLength(3);
+  });
+
+  // Regression lock: changing a price in PLANS must automatically update cents
+  it('full regression lock — all entries match PLANS[n].price * 100 and name', () => {
+    PLANS.forEach((p) => {
+      expect(PLAN_DATA_CENTS[p.id].price).toBe(p.price * 100);
+      expect(PLAN_DATA_CENTS[p.id].name).toBe(p.name);
+    });
+  });
+});
+
 describe('FAQ_ITEMS export', () => {
   let FAQ_ITEMS: any[];
 

--- a/src/app/pricing/pricing-data.ts
+++ b/src/app/pricing/pricing-data.ts
@@ -6,13 +6,12 @@ import { Plan } from '@/types';
  * Used by:
  *   - /plans page (PlanCard, Schema.org markup)
  *   - /signup page (plan selection)
- *   - API checkout route (plan validation)
+ *   - API checkout routes (plan validation + metadata)
  *   - Any other component that needs plan data
  *
- * IMPORTANT: When adding or changing plans, also update:
+ * When adding or changing plans, also update:
  *   - Schema.org SoftwareApplication markup in src/app/layout.tsx
  *   - Stripe price IDs in .env (STRIPE_PRICE_SOLO, STRIPE_PRICE_SALON, STRIPE_PRICE_ENTERPRISE)
- *   - PLAN_DATA in src/app/api/checkout/route.ts
  */
 export const PLANS: Plan[] = [
   {
@@ -68,6 +67,11 @@ export const PLANS: Plan[] = [
     popular: false,
   },
 ];
+
+// Prices in cents, derived from PLANS — no manual sync needed.
+// Import this in API routes instead of hardcoding local PLAN_DATA objects.
+export const PLAN_DATA_CENTS: Record<string, { name: string; price: number }> =
+  Object.fromEntries(PLANS.map(p => [p.id, { name: p.name, price: p.price * 100 }]));
 
 export interface Testimonial {
   name: string;

--- a/src/tests/stripe/checkout-session-route.unit.test.ts
+++ b/src/tests/stripe/checkout-session-route.unit.test.ts
@@ -6,70 +6,225 @@
  * This route creates a Stripe Checkout session with BETA50 pre-applied and
  * redirects (307) to the Stripe-hosted checkout URL.
  *
+ * Mocking strategy: mock @/lib/stripe (createCheckoutSession) directly to avoid
+ * loading the Stripe SDK native bindings which cause SIGTRAP in jest-worker.
+ * Missing mocks for next-auth, next/headers, next-auth-options, and prisma were
+ * the original cause of this test file being excluded — all four are now provided.
+ *
  * Coverage:
- *  - Valid plan param creates checkout session and redirects
- *  - BETA50 coupon is always pre-applied (discounts param)
- *  - allow_promotion_codes is omitted (Stripe mutual exclusivity with discounts)
+ *  - Valid plan param creates checkout session and redirects (307)
+ *  - BETA50 coupon is always pre-applied (couponCode forwarded to createCheckoutSession)
  *  - Invalid plan param → 400
  *  - Missing plan param → 400
+ *  - Unauthenticated request → 302 redirect to /login
+ *  - Profile not found → 404
  *  - Stripe error → 500
  *  - Session without URL → 500
  *  - All three valid plans (solo/salon/enterprise)
+ *  - PLAN_DATA_CENTS values reach createCheckoutSession (regression lock against manual sync)
  */
 
 // ── Mocks (hoisted above imports) ─────────────────────────────────────────────
 
-jest.mock('stripe', () => {
-  const mockCreate = jest.fn();
-  const MockStripe = jest.fn().mockImplementation(() => ({
-    checkout: {
-      sessions: {
-        create: mockCreate,
-      },
-    },
-  }));
-  (MockStripe as any).__mockCreate = mockCreate;
-  return { __esModule: true, default: MockStripe };
-});
+// Mock @/lib/stripe directly — avoids loading Stripe SDK native bindings
+jest.mock('@/lib/stripe', () => ({
+  __esModule: true,
+  createCheckoutSession: jest.fn(),
+}));
 
 jest.mock('@/lib/validation', () => ({
   __esModule: true,
-  requireEnvVar: jest.fn((name: string) => {
-    const vars: Record<string, string> = {
-      STRIPE_SECRET_KEY: 'sk_test_mock_key',
-      STRIPE_PRICE_SOLO: 'price_mock_solo',
-      STRIPE_PRICE_SALON: 'price_mock_salon',
-      STRIPE_PRICE_ENTERPRISE: 'price_mock_enterprise',
-    };
-    return vars[name] ?? `mock_${name}`;
-  }),
+  ensureEnv: jest.fn(), // no-op — env vars are set in jest.setup.js
+  requireEnvVar: jest.fn((name: string) => `mock_${name}`),
 }));
 
-// ── Imports ────────────────────────────────────────────────────────────────────
+// Prevent next/headers from throwing "headers() called outside request scope"
+jest.mock('next/headers', () => ({
+  headers: jest.fn(() => new Headers()),
+  cookies: jest.fn(() => ({ get: jest.fn(), getAll: jest.fn(() => []) })),
+}));
+
+// Mock getServerSession — returns authenticated user by default
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(() =>
+    Promise.resolve({ user: { id: 'user-sess-123', email: 'session@example.com' } })
+  ),
+}));
+
+// Prevent loading @/lib/next-auth-options which pulls in Prisma (native bindings)
+jest.mock('@/lib/next-auth-options', () => ({
+  authOptions: {},
+}));
+
+// Mock Prisma — prevents loading native bindings that crash jest-worker
+jest.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    profile: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+// ── Imports (after mocks) ──────────────────────────────────────────────────────
 
 import { NextRequest } from 'next/server';
 import { GET } from '@/app/api/checkout/session/route';
-import Stripe from 'stripe';
+import { createCheckoutSession } from '@/lib/stripe';
+import { getServerSession } from 'next-auth';
+import prisma from '@/lib/prisma';
 
-// Access the mock create function via the mock
-function getMockCreate(): jest.MockedFunction<any> {
-  const MockStripe = Stripe as unknown as jest.MockedClass<any>;
-  return MockStripe.__mockCreate;
-}
+// Typed mock helpers
+const mockCreateCheckoutSession = createCheckoutSession as jest.MockedFunction<typeof createCheckoutSession>;
+const mockGetServerSession = getServerSession as jest.MockedFunction<any>;
+const mockFindUniqueProfile = prisma.profile.findUnique as jest.MockedFunction<typeof prisma.profile.findUnique>;
+
+const MOCK_CHECKOUT_URL = 'https://checkout.stripe.com/c/pay/cs_test_session_mock';
 
 function makeRequest(url: string): NextRequest {
   return new NextRequest(url);
 }
 
-const MOCK_CHECKOUT_URL = 'https://checkout.stripe.com/c/pay/cs_test_mock_abc';
+// ─────────────────────────────────────────────────────────────────────────────
+// Test helpers / shared setup
+// ─────────────────────────────────────────────────────────────────────────────
+
+function setupAuthenticatedProfile() {
+  mockGetServerSession.mockResolvedValue({
+    user: { id: 'user-sess-123', email: 'session@example.com' },
+  });
+  mockFindUniqueProfile.mockResolvedValue({
+    id: 'profile-sess-1',
+    userId: 'user-sess-123',
+    businessName: 'Sudsy Paws Salon',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as any);
+  mockCreateCheckoutSession.mockResolvedValue({
+    id: 'cs_test_session_mock',
+    url: MOCK_CHECKOUT_URL,
+  } as any);
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Valid plan → redirect
+// Authentication guard
 // ─────────────────────────────────────────────────────────────────────────────
-describe('GET /api/checkout/session — valid plans', () => {
+describe('GET /api/checkout/session — authentication guard', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('redirects (302) to /login when user is unauthenticated', async () => {
+    mockGetServerSession.mockResolvedValueOnce(null);
+
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    const res = await GET(req);
+
+    expect(res.status).toBe(302);
+  });
+
+  it('redirect URL contains /login for unauthenticated user', async () => {
+    mockGetServerSession.mockResolvedValueOnce(null);
+
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    const res = await GET(req);
+
+    expect(res.headers.get('location')).toContain('/login');
+  });
+
+  it('sets next=/plans query param in login redirect', async () => {
+    mockGetServerSession.mockResolvedValueOnce(null);
+
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    const res = await GET(req);
+
+    const location = decodeURIComponent(res.headers.get('location') ?? '');
+    expect(location).toContain('next=');
+    expect(location).toContain('/plans');
+  });
+
+  it('does not call createCheckoutSession when unauthenticated', async () => {
+    mockGetServerSession.mockResolvedValueOnce(null);
+
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    await GET(req);
+
+    expect(mockCreateCheckoutSession).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plan parameter validation
+// ─────────────────────────────────────────────────────────────────────────────
+describe('GET /api/checkout/session — plan validation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    getMockCreate().mockResolvedValue({ id: 'cs_test_mock_abc', url: MOCK_CHECKOUT_URL });
+    setupAuthenticatedProfile();
+  });
+
+  it('returns 400 when plan param is missing', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session');
+    const res = await GET(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('error body mentions missing plan', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session');
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(body.error).toMatch(/missing plan/i);
+  });
+
+  it('returns 400 for invalid plan "premium"', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=premium');
+    const res = await GET(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for uppercase plan "SOLO" (case-sensitive)', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=SOLO');
+    const res = await GET(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for empty plan string', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=');
+    const res = await GET(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for plan "free"', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=free');
+    const res = await GET(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('does not call createCheckoutSession for invalid plan', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=bogus');
+    await GET(req);
+
+    expect(mockCreateCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it.each(['solo', 'salon', 'enterprise'])('accepts valid plan "%s" — returns 307', async (plan) => {
+    const req = makeRequest(`http://localhost:3000/api/checkout/session?plan=${plan}`);
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Happy path — valid plan → 307 redirect
+// ─────────────────────────────────────────────────────────────────────────────
+describe('GET /api/checkout/session — valid plan creates session', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupAuthenticatedProfile();
   });
 
   it('redirects (307) to Stripe checkout URL for solo plan', async () => {
@@ -96,159 +251,143 @@ describe('GET /api/checkout/session — valid plans', () => {
     expect(res.headers.get('location')).toBe(MOCK_CHECKOUT_URL);
   });
 
-  it('calls stripe.checkout.sessions.create once per request', async () => {
+  it('calls createCheckoutSession exactly once per request', async () => {
     const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
     await GET(req);
 
-    expect(getMockCreate()).toHaveBeenCalledTimes(1);
+    expect(mockCreateCheckoutSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards the authenticated userId to createCheckoutSession', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    await GET(req);
+
+    const [args] = mockCreateCheckoutSession.mock.calls[0];
+    expect(args.userId).toBe('user-sess-123');
+  });
+
+  it('forwards business name from profile to createCheckoutSession', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    await GET(req);
+
+    const [args] = mockCreateCheckoutSession.mock.calls[0];
+    expect(args.businessName).toBe('Sudsy Paws Salon');
   });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// BETA50 coupon pre-applied
+// BETA50 coupon — always pre-applied
 // ─────────────────────────────────────────────────────────────────────────────
-describe('GET /api/checkout/session — BETA50 coupon', () => {
+describe('GET /api/checkout/session — BETA50 coupon pre-applied', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    getMockCreate().mockResolvedValue({ id: 'cs_test_mock_abc', url: MOCK_CHECKOUT_URL });
+    setupAuthenticatedProfile();
   });
 
-  it('passes BETA50 as a discount coupon in the Stripe session params', async () => {
+  it('passes BETA50 as couponCode to createCheckoutSession for solo', async () => {
     const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
     await GET(req);
 
-    const [params] = getMockCreate().mock.calls[0];
-    expect(params.discounts).toEqual([{ coupon: 'BETA50' }]);
+    const [args] = mockCreateCheckoutSession.mock.calls[0];
+    expect(args.couponCode).toBe('BETA50');
   });
 
-  it('does not set allow_promotion_codes when coupon is pre-applied (Stripe mutual exclusivity)', async () => {
-    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
-    await GET(req);
-
-    const [params] = getMockCreate().mock.calls[0];
-    // Stripe requires discounts and allow_promotion_codes to be mutually exclusive.
-    // When discounts is specified, allow_promotion_codes must be omitted entirely.
-    expect(params.allow_promotion_codes).toBeUndefined();
-  });
-
-  it('uses subscription mode', async () => {
-    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
-    await GET(req);
-
-    const [params] = getMockCreate().mock.calls[0];
-    expect(params.mode).toBe('subscription');
-  });
-
-  it('includes correct price ID for solo plan', async () => {
-    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
-    await GET(req);
-
-    const [params] = getMockCreate().mock.calls[0];
-    expect(params.line_items[0].price).toBe('price_mock_solo');
-    expect(params.line_items[0].quantity).toBe(1);
-  });
-
-  it('includes correct price ID for salon plan', async () => {
+  it('passes BETA50 as couponCode to createCheckoutSession for salon', async () => {
     const req = makeRequest('http://localhost:3000/api/checkout/session?plan=salon');
     await GET(req);
 
-    const [params] = getMockCreate().mock.calls[0];
-    expect(params.line_items[0].price).toBe('price_mock_salon');
+    const [args] = mockCreateCheckoutSession.mock.calls[0];
+    expect(args.couponCode).toBe('BETA50');
   });
 
-  it('includes correct price ID for enterprise plan', async () => {
+  it('passes BETA50 as couponCode to createCheckoutSession for enterprise', async () => {
     const req = makeRequest('http://localhost:3000/api/checkout/session?plan=enterprise');
     await GET(req);
 
-    const [params] = getMockCreate().mock.calls[0];
-    expect(params.line_items[0].price).toBe('price_mock_enterprise');
-  });
-
-  it('sets success_url with CHECKOUT_SESSION_ID placeholder', async () => {
-    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
-    await GET(req);
-
-    const [params] = getMockCreate().mock.calls[0];
-    expect(params.success_url).toContain('{CHECKOUT_SESSION_ID}');
-    expect(params.success_url).toContain('/checkout/success');
-  });
-
-  it('sets cancel_url to /plans', async () => {
-    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
-    await GET(req);
-
-    const [params] = getMockCreate().mock.calls[0];
-    expect(params.cancel_url).toContain('/plans');
+    const [args] = mockCreateCheckoutSession.mock.calls[0];
+    expect(args.couponCode).toBe('BETA50');
   });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Validation — missing or invalid plan param
+// PLAN_DATA_CENTS regression lock — prices must match pricing-data.ts
 // ─────────────────────────────────────────────────────────────────────────────
-describe('GET /api/checkout/session — validation', () => {
+describe('GET /api/checkout/session — PLAN_DATA_CENTS regression lock', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    getMockCreate().mockResolvedValue({ id: 'cs_test_mock', url: MOCK_CHECKOUT_URL });
+    setupAuthenticatedProfile();
   });
 
-  it('returns 400 when plan param is missing', async () => {
-    const req = makeRequest('http://localhost:3000/api/checkout/session');
-    const res = await GET(req);
-
-    expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.error).toMatch(/missing plan/i);
-  });
-
-  it('does NOT call Stripe when plan param is missing', async () => {
-    const req = makeRequest('http://localhost:3000/api/checkout/session');
+  it('passes correct planData for solo ($29 = 2900 cents)', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
     await GET(req);
 
-    expect(getMockCreate()).not.toHaveBeenCalled();
+    const [args] = mockCreateCheckoutSession.mock.calls[0];
+    expect(args.planData).toEqual({ name: 'Solo', price: 2900 });
   });
 
-  it('returns 400 for invalid plan "premium"', async () => {
-    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=premium');
-    const res = await GET(req);
-
-    expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.error).toMatch(/invalid plan/i);
-  });
-
-  it('returns 400 for invalid plan "free"', async () => {
-    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=free');
-    const res = await GET(req);
-
-    expect(res.status).toBe(400);
-  });
-
-  it('returns 400 for uppercase plan (case-sensitive)', async () => {
-    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=SOLO');
-    const res = await GET(req);
-
-    expect(res.status).toBe(400);
-  });
-
-  it('returns 400 for empty plan param', async () => {
-    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=');
-    const res = await GET(req);
-
-    expect(res.status).toBe(400);
-  });
-
-  it('does NOT call Stripe for invalid plan', async () => {
-    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=bogus');
+  it('passes correct planData for salon ($79 = 7900 cents)', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=salon');
     await GET(req);
 
-    expect(getMockCreate()).not.toHaveBeenCalled();
+    const [args] = mockCreateCheckoutSession.mock.calls[0];
+    expect(args.planData).toEqual({ name: 'Salon', price: 7900 });
   });
 
-  it.each(['solo', 'salon', 'enterprise'])('accepts valid plan "%s" without error', async (plan) => {
-    const req = makeRequest(`http://localhost:3000/api/checkout/session?plan=${plan}`);
+  it('passes correct planData for enterprise ($149 = 14900 cents)', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=enterprise');
+    await GET(req);
+
+    const [args] = mockCreateCheckoutSession.mock.calls[0];
+    expect(args.planData).toEqual({ name: 'Enterprise', price: 14900 });
+  });
+
+  it('planData is sourced from PLAN_DATA_CENTS — same shape as checkout POST route', async () => {
+    // This test locks that both checkout routes use the same pricing source.
+    // If pricing-data.ts prices change, both routes update automatically.
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    await GET(req);
+
+    const [args] = mockCreateCheckoutSession.mock.calls[0];
+    expect(args.planData).toHaveProperty('name');
+    expect(args.planData).toHaveProperty('price');
+    expect(typeof args.planData!.price).toBe('number');
+    expect(Number.isInteger(args.planData!.price)).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Profile not found
+// ─────────────────────────────────────────────────────────────────────────────
+describe('GET /api/checkout/session — profile not found', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue({
+      user: { id: 'user-sess-123', email: 'session@example.com' },
+    });
+    mockFindUniqueProfile.mockResolvedValue(null);
+  });
+
+  it('returns 404 when profile does not exist', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
     const res = await GET(req);
 
-    expect(res.status).toBe(307);
+    expect(res.status).toBe(404);
+  });
+
+  it('error body mentions profile not found', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(body.error).toMatch(/profile not found/i);
+  });
+
+  it('does not call createCheckoutSession when profile is missing', async () => {
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    await GET(req);
+
+    expect(mockCreateCheckoutSession).not.toHaveBeenCalled();
   });
 });
 
@@ -258,21 +397,20 @@ describe('GET /api/checkout/session — validation', () => {
 describe('GET /api/checkout/session — error handling', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue({
+      user: { id: 'user-sess-123', email: 'session@example.com' },
+    });
+    mockFindUniqueProfile.mockResolvedValue({
+      id: 'profile-1',
+      userId: 'user-sess-123',
+      businessName: 'Test Salon',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as any);
   });
 
-  it('returns 500 when Stripe throws an error', async () => {
-    getMockCreate().mockRejectedValueOnce(new Error('Stripe network error'));
-
-    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
-    const res = await GET(req);
-
-    expect(res.status).toBe(500);
-    const body = await res.json();
-    expect(body.error).toBeDefined();
-  });
-
-  it('returns 500 when Stripe session has no URL', async () => {
-    getMockCreate().mockResolvedValueOnce({ id: 'cs_no_url', url: null });
+  it('returns 500 when createCheckoutSession throws', async () => {
+    mockCreateCheckoutSession.mockRejectedValueOnce(new Error('Stripe network error'));
 
     const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
     const res = await GET(req);
@@ -281,12 +419,82 @@ describe('GET /api/checkout/session — error handling', () => {
   });
 
   it('returns JSON error body on Stripe failure', async () => {
-    getMockCreate().mockRejectedValueOnce(new Error('Connection timeout'));
+    mockCreateCheckoutSession.mockRejectedValueOnce(new Error('Connection timeout'));
 
     const req = makeRequest('http://localhost:3000/api/checkout/session?plan=salon');
     const res = await GET(req);
     const body = await res.json();
 
     expect(body).toHaveProperty('error');
+  });
+
+  it('returns 500 when checkout session has no URL', async () => {
+    mockCreateCheckoutSession.mockResolvedValueOnce({
+      id: 'cs_no_url',
+      url: null,
+    } as any);
+
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    const res = await GET(req);
+
+    expect(res.status).toBe(500);
+  });
+
+  it('error body is defined when session has no URL', async () => {
+    mockCreateCheckoutSession.mockResolvedValueOnce({
+      id: 'cs_no_url',
+      url: null,
+    } as any);
+
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(body.error).toBeDefined();
+    expect(typeof body.error).toBe('string');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plan type forwarding
+// ─────────────────────────────────────────────────────────────────────────────
+describe('GET /api/checkout/session — planType forwarding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupAuthenticatedProfile();
+  });
+
+  it.each(['solo', 'salon', 'enterprise'] as const)(
+    'forwards planType "%s" to createCheckoutSession',
+    async (plan) => {
+      const req = makeRequest(`http://localhost:3000/api/checkout/session?plan=${plan}`);
+      await GET(req);
+
+      const [args] = mockCreateCheckoutSession.mock.calls[0];
+      expect(args.planType).toBe(plan);
+    }
+  );
+
+  it('falls back to userId@groomgrid.app when session email is absent', async () => {
+    mockGetServerSession.mockResolvedValueOnce({
+      user: { id: 'user-sess-123' }, // no email
+    });
+    mockFindUniqueProfile.mockResolvedValueOnce({
+      id: 'profile-1',
+      userId: 'user-sess-123',
+      businessName: 'No Email Salon',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as any);
+    mockCreateCheckoutSession.mockResolvedValueOnce({
+      id: 'cs_test_fallback',
+      url: MOCK_CHECKOUT_URL,
+    } as any);
+
+    const req = makeRequest('http://localhost:3000/api/checkout/session?plan=solo');
+    await GET(req);
+
+    const [args] = mockCreateCheckoutSession.mock.calls[0];
+    expect(args.customerEmail).toBe('user-sess-123@groomgrid.app');
   });
 });


### PR DESCRIPTION
## Summary

- **Add `PLAN_DATA_CENTS`** to `pricing-data.ts` derived from `PLANS` (price × 100) — now a single source of truth for plan name + price-in-cents
- **Remove all three local `PLAN_DATA` duplicates** in `checkout/route.ts`, `checkout/session/route.ts`, and `stripe/route.ts` — import the shared export instead
- **Remove dead `/api/stripe` POST handler** — the frontend exclusively calls `/api/checkout` (confirmed in `plans/page.tsx:144`). Replaced with 405 + `Location: /api/checkout` header so accidental hits are documented, not silently routed
- **Remove the `IMPORTANT: also update PLAN_DATA in checkout/route.ts` warning comment** from `pricing-data.ts` — the comment that didn't even mention `checkout/session/route.ts`

## Test Results

**1195/1196 tests passing** (+38 new tests written for this change)

| File | Tests | Status |
|------|-------|--------|
| `pricing-data.test.ts` | 63 | ✅ All pass — PLAN_DATA_CENTS regression lock |
| `checkout.unit.test.ts` | 53 | ✅ All pass — validatePlan + POST handler |
| `stripe/route.unit.test.ts` | 12 | ✅ All pass — 405 deprecated handler |
| `checkout-session-route.unit.test.ts` | **38** | ✅ **Fixed + re-enabled** (was excluded) |

**Pre-existing failure (not introduced by this branch):**
- `pipeline/page.unit.test.tsx:260` — stale `"3h ago"` time-relative assertion, confirmed failing on `main` before this change.

### checkout-session-route.unit.test.ts — fix note
This test was in `testPathIgnorePatterns` with the comment "Loads Stripe SDK natively + next/headers; causes SIGTRAP/OOM in jest-worker CI". Root cause was the wrong mocking strategy: it mocked the `stripe` npm package directly while missing mocks for `next-auth`, `next/headers`, `@/lib/next-auth-options`, and `@/lib/prisma`. Fixed by mocking `@/lib/stripe` (createCheckoutSession function) directly and adding all four missing mocks. Test now covers auth guard, plan validation (PLAN_DATA_CENTS), BETA50 coupon forwarding, profile lookup, and error paths.

## Test plan

- [x] Run `npm test` — 1195/1196 pass
- [x] `pricing-data.test.ts` regression lock: `PLAN_DATA_CENTS[id].price === PLANS[n].price * 100`
- [x] `checkout.unit.test.ts`: `validatePlan` now delegates to `PLAN_DATA_CENTS`; plan amounts spot-checked (solo=2900, salon=7900, enterprise=14900)
- [x] `stripe/route.unit.test.ts`: 405 returns correct status, Location header, error body
- [x] `checkout-session-route.unit.test.ts`: auth guard, plan validation, 307 redirect, BETA50 coupon, PLAN_DATA_CENTS values, profile 404, Stripe 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)