### PR TITLE
fix: email verification redirects to localhost:3002 instead of app.getgroomgrid.com

### DIFF
--- a/src/app/api/auth/verify-email/route.ts
+++ b/src/app/api/auth/verify-email/route.ts
@@ -2,11 +2,15 @@ import { NextRequest, NextResponse } from 'next/server'
 import prisma from '@/lib/prisma'
 import { trackEmailVerified } from '@/lib/ga4'
 
+// Use the public app URL as redirect base — req.url resolves to localhost:3002
+// behind nginx, which produces unreachable redirects in production.
+const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://app.getgroomgrid.com'
+
 export async function GET(req: NextRequest) {
   const token = req.nextUrl.searchParams.get('token')
 
   if (!token) {
-    return NextResponse.redirect(new URL('/login?error=missing-token', req.url))
+    return NextResponse.redirect(new URL('/login?error=missing-token', appUrl))
   }
 
   try {
@@ -15,7 +19,7 @@ export async function GET(req: NextRequest) {
     })
 
     if (!record || record.expiresAt < new Date() || record.usedAt) {
-      return NextResponse.redirect(new URL('/login?error=invalid-token', req.url))
+      return NextResponse.redirect(new URL('/login?error=invalid-token', appUrl))
     }
 
     await prisma.$transaction([
@@ -32,9 +36,9 @@ export async function GET(req: NextRequest) {
     // Wire: fires once, on the success path only
     trackEmailVerified(record.userId)
 
-    return NextResponse.redirect(new URL('/login?verified=true', req.url))
+    return NextResponse.redirect(new URL('/login?verified=true', appUrl))
   } catch (error) {
     console.error('Email verification error:', error)
-    return NextResponse.redirect(new URL('/login?error=verification-failed', req.url))
+    return NextResponse.redirect(new URL('/login?error=verification-failed', appUrl))
   }
 }


### PR DESCRIPTION
## Summary
- **Bug**: All 4 `NextResponse.redirect` calls in `verify-email/route.ts` used `req.url` as the base URL, which resolves to `http://localhost:3002/...` when nginx proxies the request internally. Users clicking the verification link received a `302 Location: http://localhost:3002/login?...` — unreachable from their browser.
- **Fix**: Replace `req.url` with `process.env.NEXT_PUBLIC_APP_URL || 'https://app.getgroomgrid.com'` as the redirect base — identical to the pattern already used in `signup/route.ts` for building the verification email link.
- **Scope**: 1 file, 4 lines changed. Zero blast radius outside the email verification flow.

## Files Changed
- `src/app/api/auth/verify-email/route.ts` — added `appUrl` constant at module level, replaced `req.url` on lines 9, 18, 35, 38

## Test Results
- All 7 existing unit tests pass (`src/app/api/auth/__tests__/verify-email.test.ts`)
- Tests cover: missing token, expired token, used token, DB error, successful verification, transaction failure

## Verify After Deploy
```
curl -I "https://app.getgroomgrid.com/api/auth/verify-email?token=badtoken"
# Expect: Location: https://app.getgroomgrid.com/login?error=invalid-token
# Before fix: Location: http://localhost:3002/login?error=invalid-token
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)