### PR TITLE
feat: add DB tracking for plan/checkout funnel events

### DIFF
--- a/src/lib/__tests__/ga4-server.test.ts
+++ b/src/lib/__tests__/ga4-server.test.ts
@@ -6,7 +6,19 @@
  * - Edge cases: missing env vars, network failures
  * - Single vs array events
  * - All 9 server functions tested
+ * - DB writes: prisma.analyticsEvent.create called fire-and-forget for checkout_completed and subscription_started
  */
+
+jest.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  default: {
+    analyticsEvent: {
+      create: jest.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+import prisma from '@/lib/prisma';
 import {
   trackServerEvent,
   trackCheckoutCompletedServer,
@@ -19,6 +31,8 @@ import {
   trackPaymentFailedServer,
   trackPurchaseCompletedServer,
 } from '../ga4-server';
+
+const mockAnalyticsEventCreate = prisma.analyticsEvent.create as jest.MockedFunction<typeof prisma.analyticsEvent.create>;
 
 describe('ga4-server.ts', () => {
   const originalEnv = {
@@ -241,6 +255,26 @@ describe('ga4-server.ts', () => {
       const fetchBody = JSON.parse((fetch as jest.Mock).mock.calls[0][1].body);
       expect(fetchBody.events[0].params.session_id).toBeNull();
     });
+
+    it('should write checkout_completed to analytics_events DB', async () => {
+      (global as any).fetch = jest.fn().mockResolvedValue({ ok: true });
+      mockAnalyticsEventCreate.mockResolvedValue({} as any);
+
+      await trackCheckoutCompletedServer('user_123', 'user_123', 'sess_456', 'solo', true);
+
+      expect(mockAnalyticsEventCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          userId: 'user_123',
+          eventName: 'checkout_completed',
+          properties: expect.objectContaining({
+            plan_type: 'solo',
+            session_id: 'sess_456',
+            trial_started: true,
+          }),
+          sessionId: null,
+        }),
+      });
+    });
   });
 
   describe('trackSubscriptionCreatedServer', () => {
@@ -304,6 +338,25 @@ describe('ga4-server.ts', () => {
 
       const fetchBody = JSON.parse((fetch as jest.Mock).mock.calls[0][1].body);
       expect(fetchBody.events[0].params.price).toBe(149.99);
+    });
+
+    it('should write subscription_started to analytics_events DB', async () => {
+      (global as any).fetch = jest.fn().mockResolvedValue({ ok: true });
+      mockAnalyticsEventCreate.mockResolvedValue({} as any);
+
+      await trackSubscriptionStartedServer('user_123', 'user_123', 'sub_456', 'solo', 'active', 29);
+
+      expect(mockAnalyticsEventCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          userId: 'user_123',
+          eventName: 'subscription_started',
+          properties: expect.objectContaining({
+            plan_type: 'solo',
+            user_id: 'user_123',
+          }),
+          sessionId: null,
+        }),
+      });
     });
   });
 

--- a/src/lib/__tests__/ga4.test.ts
+++ b/src/lib/__tests__/ga4.test.ts
@@ -404,6 +404,19 @@ describe('ga4.ts', () => {
 
       expect(window.gtag).not.toHaveBeenCalled();
     });
+
+    it('should call postToLocalTrack with plan_selected', () => {
+      trackPlanSelected('solo', 29);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/analytics/track',
+        expect.objectContaining({ method: 'POST' })
+      );
+      const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+      expect(body.eventName).toBe('plan_selected');
+      expect(body.properties.plan_type).toBe('solo');
+      expect(body.properties.plan_price).toBe(29);
+    });
   });
 
   describe('trackCheckoutCompleted', () => {
@@ -1365,6 +1378,18 @@ describe('ga4.ts', () => {
 
       expect(window.gtag).not.toHaveBeenCalled();
     });
+
+    it('should call postToLocalTrack with signup_completed', () => {
+      trackSignupCompleted('user_12345');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/analytics/track',
+        expect.objectContaining({ method: 'POST' })
+      );
+      const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+      expect(body.eventName).toBe('signup_completed');
+      expect(body.properties.user_id).toBe('user_12345');
+    });
   });
 
   // ─── trackPlanViewed ────────────────────────────────────────────────────────
@@ -1385,6 +1410,17 @@ describe('ga4.ts', () => {
       trackPlanViewed();
 
       expect(window.gtag).not.toHaveBeenCalled();
+    });
+
+    it('should call postToLocalTrack with plan_viewed', () => {
+      trackPlanViewed();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/analytics/track',
+        expect.objectContaining({ method: 'POST' })
+      );
+      const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+      expect(body.eventName).toBe('plan_viewed');
     });
   });
 
@@ -1427,6 +1463,19 @@ describe('ga4.ts', () => {
       trackCheckoutStarted('Solo', 29);
 
       expect(window.gtag).not.toHaveBeenCalled();
+    });
+
+    it('should call postToLocalTrack with checkout_started', () => {
+      trackCheckoutStarted('Solo', 29);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/analytics/track',
+        expect.objectContaining({ method: 'POST' })
+      );
+      const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+      expect(body.eventName).toBe('checkout_started');
+      expect(body.properties.plan_name).toBe('Solo');
+      expect(body.properties.plan_price).toBe(29);
     });
   });
 });

--- a/src/lib/ga4-server.ts
+++ b/src/lib/ga4-server.ts
@@ -12,6 +12,8 @@
  * If GA4_API_SECRET is not set, events are logged to console (no-op in prod).
  */
 
+import prisma from '@/lib/prisma';
+
 // Read env vars dynamically so per-test overrides take effect at call time
 const MP_ENDPOINT = 'https://www.google-analytics.com/mp/collect';
 
@@ -107,6 +109,15 @@ export async function trackCheckoutCompletedServer(
     },
     userId
   );
+  // Write to local DB for funnel analysis — fire-and-forget, never blocks the response
+  prisma.analyticsEvent.create({
+    data: {
+      userId,
+      eventName: 'checkout_completed',
+      properties: { plan_type: planType, session_id: sessionId, trial_started: trialStarted },
+      sessionId: null,
+    },
+  }).catch(() => {});
 }
 
 export async function trackSubscriptionCreatedServer(
@@ -185,6 +196,15 @@ export async function trackSubscriptionStartedServer(
     },
     userId
   );
+  // Write to local DB for funnel analysis — fire-and-forget, never blocks the response
+  prisma.analyticsEvent.create({
+    data: {
+      userId,
+      eventName: 'subscription_started',
+      properties: { plan_type: planType, user_id: userId },
+      sessionId: null,
+    },
+  }).catch(() => {});
 }
 
 export async function trackPaymentInitiatedServer(

--- a/src/lib/ga4.ts
+++ b/src/lib/ga4.ts
@@ -70,11 +70,13 @@ export function trackSignupCompleted(userId: string, attribution?: Record<string
   if (attribution?.utm_campaign) params.utm_campaign = attribution.utm_campaign;
   if (attribution?.utm_medium) params.utm_medium = attribution.utm_medium;
   trackEvent('signup_completed', params);
+  postToLocalTrack('signup_completed', { user_id: userId, ...attribution });
 }
 
 // Fires when user lands on /plans page (once per mount)
 export function trackPlanViewed() {
   trackEvent('plan_viewed');
+  postToLocalTrack('plan_viewed');
 }
 
 // Fires when user clicks a paid plan CTA
@@ -83,6 +85,7 @@ export function trackCheckoutStarted(planName: string, planPrice: number) {
     plan_name: planName,
     plan_price: planPrice,
   });
+  postToLocalTrack('checkout_started', { plan_name: planName, plan_price: planPrice });
 }
 
 export function trackSignupStarted(businessName: string) {
@@ -106,6 +109,7 @@ export function trackPlanSelected(planType: string, planPrice: number) {
     plan_price: planPrice,
     timestamp: new Date().toISOString(),
   });
+  postToLocalTrack('plan_selected', { plan_type: planType, plan_price: planPrice });
 }
 
 export function trackCheckoutCompleted(


### PR DESCRIPTION
## Summary

- **ga4.ts**: Added `postToLocalTrack()` calls inside `trackSignupCompleted`, `trackPlanViewed`, `trackCheckoutStarted`, and `trackPlanSelected` — these fire-and-forget to `/api/analytics/track` alongside existing gtag calls
- **ga4-server.ts**: Added `import prisma from '@/lib/prisma'` + fire-and-forget `prisma.analyticsEvent.create()` calls inside `trackCheckoutCompletedServer` and `trackSubscriptionStartedServer`
- **ga4.test.ts**: Added `postToLocalTrack` fetch assertions for all 4 client-side functions
- **ga4-server.test.ts**: Added prisma mock + DB write assertions for both server functions

## What this fixes

The `analytics_events` table had only 1 row (`signup_viewed`). We were completely blind on plan_viewed → plan_selected → checkout_started → checkout_completed → subscription_started. All 6 events now write to the DB.

## Test plan

- [x] 170 tests pass across ga4.test.ts and ga4-server.test.ts
- [x] No signature changes — additive only
- [x] All DB writes are fire-and-forget (`.catch(() => {})`) — never blocks UX
- [x] GA4 gtag calls unchanged
- [x] TypeScript compiles cleanly (ts-jest warnOnly mode, no new errors introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)