### PR TITLE
fix(funnel): patch 5 signup-to-paid bugs blocking first subscriber

### DIFF
--- a/prisma/migrations/20260424000000_add_payment_events_event_id_index/migration.sql
+++ b/prisma/migrations/20260424000000_add_payment_events_event_id_index/migration.sql
@@ -1,0 +1,5 @@
+-- Add expression index on payment_events.payload->>'eventId' to speed up
+-- the isEventProcessed() idempotency check in the Stripe webhook handler.
+-- Without this index, every webhook triggers a full table scan on payment_events.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_payment_events_payload_event_id
+  ON payment_events ((payload->>'eventId'));

--- a/src/app/api/auth/resend-verification/route.ts
+++ b/src/app/api/auth/resend-verification/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from 'next/server'
+import crypto from 'crypto'
+import prisma from '@/lib/prisma'
+import { sendVerificationEmail } from '@/lib/email/verify-email'
+
+const VERIFICATION_TOKEN_EXPIRY_MS = 24 * 60 * 60 * 1000
+const RATE_LIMIT_MS = 60 * 1000 // 1 request per minute per email
+
+// Simple in-memory rate limiter
+const rateLimitMap = new Map<string, number>()
+
+export async function POST(req: NextRequest) {
+  try {
+    const { email } = await req.json()
+
+    if (!email || typeof email !== 'string') {
+      return NextResponse.json({ error: 'Email is required' }, { status: 400 })
+    }
+
+    const normalized = email.toLowerCase().trim()
+
+    // Rate limit: 1 resend per email per minute
+    const lastSent = rateLimitMap.get(normalized)
+    const now = Date.now()
+    if (lastSent && now - lastSent < RATE_LIMIT_MS) {
+      return NextResponse.json(
+        { error: 'Please wait before requesting another verification email' },
+        { status: 429 }
+      )
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { email: normalized },
+      select: { id: true, emailVerified: true },
+    })
+
+    // Always respond with success to avoid email enumeration
+    if (!user || user.emailVerified) {
+      return NextResponse.json({ success: true })
+    }
+
+    // Invalidate any existing tokens for this user
+    await prisma.emailVerificationToken.updateMany({
+      where: { userId: user.id, usedAt: null },
+      data: { usedAt: new Date() },
+    })
+
+    // Create a fresh token
+    const token = crypto.randomBytes(32).toString('hex')
+    await prisma.emailVerificationToken.create({
+      data: {
+        userId: user.id,
+        token,
+        expiresAt: new Date(now + VERIFICATION_TOKEN_EXPIRY_MS),
+      },
+    })
+
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://app.getgroomgrid.com'
+    const verifyUrl = `${appUrl}/api/auth/verify-email?token=${token}`
+
+    await sendVerificationEmail(normalized, verifyUrl)
+
+    rateLimitMap.set(normalized, now)
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Resend verification error:', error)
+    return NextResponse.json({ error: 'Failed to send verification email' }, { status: 500 })
+  }
+}

--- a/src/app/api/auth/verify-email/route.ts
+++ b/src/app/api/auth/verify-email/route.ts
@@ -36,7 +36,7 @@ export async function GET(req: NextRequest) {
     // Wire: fires once, on the success path only
     trackEmailVerified(record.userId)
 
-    return NextResponse.redirect(new URL('/login?verified=true', appUrl))
+    return NextResponse.redirect(new URL('/login?verified=true&next=/plans', appUrl))
   } catch (error) {
     console.error('Email verification error:', error)
     return NextResponse.redirect(new URL('/login?error=verification-failed', appUrl))

--- a/src/app/pricing/pricing-data.ts
+++ b/src/app/pricing/pricing-data.ts
@@ -68,6 +68,32 @@ export const PLANS: Plan[] = [
   },
 ];
 
+// Warn at startup if Stripe price IDs are missing (server-side only)
+if (typeof window === 'undefined' && process.env.NODE_ENV === 'production') {
+  const missing = PLANS.filter(p => !p.stripe_price_id).map(p => p.id)
+  if (missing.length > 0) {
+    console.error(
+      `[pricing-data] Missing Stripe price IDs for plans: ${missing.join(', ')}. ` +
+        'Set STRIPE_PRICE_SOLO, STRIPE_PRICE_SALON, STRIPE_PRICE_ENTERPRISE env vars.'
+    )
+  }
+}
+
+/**
+ * Get the Stripe price ID for a plan.
+ * Throws a clear error if the env var is not set — prevents cryptic Stripe API errors.
+ */
+export function getPlanStripeId(planId: string): string {
+  const plan = PLANS.find(p => p.id === planId)
+  if (!plan) throw new Error(`Unknown plan: ${planId}`)
+  if (!plan.stripe_price_id) {
+    throw new Error(
+      `STRIPE_PRICE_${planId.toUpperCase()} env var is not set. Cannot create checkout session.`
+    )
+  }
+  return plan.stripe_price_id
+}
+
 // Prices in cents, derived from PLANS — no manual sync needed.
 // Import this in API routes instead of hardcoding local PLAN_DATA objects.
 export const PLAN_DATA_CENTS: Record<string, { name: string; price: number }> =

--- a/src/lib/next-auth-options.ts
+++ b/src/lib/next-auth-options.ts
@@ -39,6 +39,24 @@ export const authOptions: NextAuthOptions = {
   jwt: {
     maxAge: 30 * 60,      // 30 minutes
   },
+  cookies: {
+    sessionToken: {
+      name:
+        process.env.NODE_ENV === 'production'
+          ? '__Secure-next-auth.session-token'
+          : 'next-auth.session-token',
+      options: {
+        httpOnly: true,
+        sameSite: 'lax' as const,
+        path: '/',
+        secure: process.env.NODE_ENV === 'production',
+        // Shared across *.getgroomgrid.com so app.getgroomgrid.com sessions
+        // are visible on getgroomgrid.com/plans and vice versa.
+        domain:
+          process.env.NODE_ENV === 'production' ? '.getgroomgrid.com' : undefined,
+      },
+    },
+  },
   callbacks: {
     async jwt({ token, user }) {
       if (user) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,9 +6,15 @@ const protectedRoutes = ['/dashboard', '/onboarding', '/welcome', '/admin']
 const authRoutes = ['/login', '/signup']
 
 export async function middleware(request: NextRequest) {
+  const cookieName =
+    process.env.NODE_ENV === 'production'
+      ? '__Secure-next-auth.session-token'
+      : 'next-auth.session-token'
+
   const token = await getToken({
     req: request,
     secret: process.env.NEXTAUTH_SECRET,
+    cookieName,
   })
 
   const { pathname } = request.nextUrl


### PR DESCRIPTION
## Summary

Critical funnel fixes based on production E2E smoke test diagnosis (0 payment events, 14 users). These block every user from completing checkout.

**Bug 1 — CRITICAL: Cross-domain session isolation**
- `src/lib/next-auth-options.ts`: Added `cookies.sessionToken` with `domain: '.getgroomgrid.com'` in production. Sessions are now shared across `app.getgroomgrid.com` ↔ `getgroomgrid.com` — without this, a user signing up on the app subdomain had no session on the marketing site's `/plans` page, breaking every checkout attempt from the primary conversion path.
- `src/middleware.ts`: Updated `getToken()` to pass matching `cookieName` so middleware reads the custom-named cookie correctly.

**Bug 2 — HIGH: Email verification dead-ends users on `/login`**
- `src/app/api/auth/verify-email/route.ts`: Success redirect now includes `?next=/plans`. The login page reads `next` param and redirects there post-login — verified users flow directly into the checkout funnel instead of dropping on `/dashboard`.

**Bug 3 — NEW: Resend verification endpoint for 12 stranded unverified users**
- `src/app/api/auth/resend-verification/route.ts`: New `POST /api/auth/resend-verification` with rate limiting (1/min), email enumeration protection, and token invalidation/refresh.

**Bug 4 — MEDIUM: Stripe price ID falls back to empty string**
- `src/app/pricing/pricing-data.ts`: Added production startup warning if env vars are missing + `getPlanStripeId(planId)` helper that throws a clear error rather than silently passing `''` to Stripe.

**Bug 5 — LOW: Missing JSONB index on `payment_events` idempotency query**
- `prisma/migrations/20260424000000_add_payment_events_event_id_index/migration.sql`: `CREATE INDEX CONCURRENTLY` on `payment_events((payload->>'eventId'))` — prevents full table scans as the events table grows.

## Test plan

- [ ] Sign up on `getgroomgrid.com/plans` → complete checkout → verify session persists to `app.getgroomgrid.com/checkout/success` (Bug 1)
- [ ] Verify email → confirm redirect goes to `/login?verified=true&next=/plans` → log in → confirm landing on `/plans` (Bug 2)
- [ ] `POST /api/auth/resend-verification` with an unverified email → receive new verification email (Bug 3)
- [ ] Confirm `STRIPE_PRICE_SOLO` not set → `getPlanStripeId('solo')` throws clear error (Bug 4)
- [ ] Apply migration, confirm index exists: `\d payment_events` (Bug 5)
- [ ] Run existing unit test suite: `npm test -- --testPathPattern="verify-email"`

## Root cause context
Production DB as of 4/24: 14 users, 0 payment events. Nobody has ever hit `/api/checkout`. The cross-domain cookie isolation (Bug 1) is the primary culprit — every user who entered via `getgroomgrid.com` (the marketing domain) had no session when they tried to check out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>