### PR TITLE
fix: post-merge audit consolidation — PLAN_DATA dedup + webhook safety

### DIFF
--- a/src/app/api/stripe/webhook/__tests__/handler.unit.test.ts
+++ b/src/app/api/stripe/webhook/__tests__/handler.unit.test.ts
@@ -143,6 +143,7 @@ jest.mock('@/lib/prisma', () => ({
   prisma: {
     paymentEvent: {
       create: jest.fn().mockResolvedValue({}),
+      upsert: jest.fn().mockResolvedValue({}),
       findFirst: jest.fn().mockResolvedValue(null),
       findUnique: jest.fn().mockResolvedValue(null),
     },

--- a/src/app/api/stripe/webhook/_handler.ts
+++ b/src/app/api/stripe/webhook/_handler.ts
@@ -10,11 +10,16 @@ import { updatePaymentLockoutStatus } from '@/lib/payment-lockout';
 import type Stripe from 'stripe';
 
 /**
- * Check if event has already been processed for idempotency
+ * Check if event has already been processed for idempotency.
+ * Filters by normalized event type so PAYMENT_CONFIRMED records
+ * (which store webhookEventId, not eventId) don't cause false positives
+ * during the window between transaction commit and completion handler success.
  */
 async function isEventProcessed(eventId: string, eventType: string): Promise<boolean> {
+  const normalizedType = eventType.toUpperCase().replace(/\./g, '_');
   const existing = await prisma.paymentEvent.findFirst({
     where: {
+      eventType: normalizedType,
       payload: {
         path: ['eventId'],
         equals: eventId,
@@ -72,30 +77,24 @@ export const handleStripeEvent = async (event: Stripe.Event) => {
       if (userId && userId !== 'anonymous') {
         // Wrap related operations in a transaction for consistency
         await prisma.$transaction(async (tx) => {
-          // Create PAYMENT_CONFIRMED event to signal webhook received
-          await tx.paymentEvent.create({
-            data: {
+          // Upsert PAYMENT_CONFIRMED — idempotent on Stripe retries (unique constraint:
+          // paymentId+eventType). Uses webhookEventId (not eventId) in payload so that
+          // isEventProcessed() — which queries payload.eventId — cannot match this record
+          // before the CHECKOUT_SESSION_COMPLETED idempotency marker is written below.
+          await tx.paymentEvent.upsert({
+            where: {
+              paymentId_eventType: { paymentId, eventType: 'PAYMENT_CONFIRMED' },
+            },
+            create: {
               paymentId,
               eventType: 'PAYMENT_CONFIRMED',
               payload: {
                 userId,
                 sessionId: session.id,
-                eventId: event.id,
+                webhookEventId: event.id, // renamed from eventId — no collision with idempotency check
               },
             },
-          });
-
-          // Record event processing for idempotency
-          await tx.paymentEvent.create({
-            data: {
-              paymentId: event.id,
-              eventType: 'EVENT_PROCESSED',
-              payload: {
-                eventId: event.id,
-                originalPaymentId: paymentId,
-                processedAt: new Date().toISOString(),
-              },
-            },
+            update: {}, // no-op if already committed on a previous attempt
           });
 
           // Update payment lockout status if exists
@@ -111,11 +110,17 @@ export const handleStripeEvent = async (event: Stripe.Event) => {
           }
         });
 
-        // Trigger payment completion handler (outside transaction - it has its own)
+        // Trigger payment completion handler (outside transaction - it has its own idempotency)
         await triggerPaymentCompletionHandler({
           ...session,
           metadata: session.metadata ?? undefined,
         });
+
+        // Write idempotency marker AFTER completion handler succeeds.
+        // Placing this last closes the race window: if triggerPaymentCompletionHandler
+        // throws, Stripe retries will find no CHECKOUT_SESSION_COMPLETED record and
+        // correctly re-run the completion handler instead of silently skipping it.
+        await recordEventProcessed(event.id, event.type, paymentId);
       } else if (userId === 'anonymous') {
         console.warn(`[Webhook] checkout.session.completed with userId='anonymous' — session ${session.id} cannot be linked to a real user. This session was likely created by the legacy unauthenticated checkout endpoint.`);
       }

--- a/src/app/settings/billing/page.tsx
+++ b/src/app/settings/billing/page.tsx
@@ -8,52 +8,23 @@ import {
   ArrowLeft, CreditCard, Check, AlertCircle, ExternalLink, RefreshCw, Mail,
 } from 'lucide-react';
 import { trackPageView } from '@/lib/ga4';
+import { PLANS as PRICING_PLANS } from '@/app/pricing/pricing-data';
 
-const PLANS = [
-  {
-    id: 'solo',
-    name: 'Solo',
-    price: '$29',
-    period: '/month',
-    description: 'Perfect for independent mobile groomers',
-    features: [
-      'Unlimited appointments',
-      'Client & pet profiles',
-      'Automated reminders',
-      'Payment tracking',
-      'Invoice generation',
-    ],
-  },
-  {
-    id: 'salon',
-    name: 'Salon',
-    price: '$79',
-    period: '/month',
-    description: 'Ideal for salons with 2–5 groomers',
-    popular: true,
-    features: [
-      'Everything in Solo',
-      'Staff scheduling',
-      'Multi-groomer calendar',
-      'Revenue analytics',
-      'Priority support',
-    ],
-  },
-  {
-    id: 'enterprise',
-    name: 'Enterprise',
-    price: '$149',
-    period: '/month',
-    description: 'For large operations',
-    features: [
-      'Everything in Salon',
-      'Unlimited staff',
-      'Custom integrations',
-      'Dedicated account manager',
-      'SLA support',
-    ],
-  },
-];
+const PLAN_DESCRIPTIONS: Record<string, string> = {
+  solo: 'Perfect for independent mobile groomers',
+  salon: 'Ideal for salons with 2–5 groomers',
+  enterprise: 'For large operations',
+};
+
+const PLANS = PRICING_PLANS.map((plan) => ({
+  id: plan.id,
+  name: plan.name,
+  price: `$${plan.price}`,
+  period: '/month',
+  description: PLAN_DESCRIPTIONS[plan.id] ?? '',
+  popular: plan.popular,
+  features: plan.features,
+}));
 
 const PLAN_DISPLAY: Record<string, { label: string; color: string }> = {
   trial: { label: 'Free Trial', color: 'bg-green-100 text-green-700' },


### PR DESCRIPTION
## Summary

- **Webhook idempotency race fix** (`_handler.ts`): Three coordinated fixes close the race window where a Stripe retry could silently skip `triggerPaymentCompletionHandler` after a transient failure:
  1. `isEventProcessed()` now filters by normalized `eventType` (e.g. `CHECKOUT_SESSION_COMPLETED`) so `PAYMENT_CONFIRMED` records — which store `webhookEventId` not `eventId` — can't cause false early-exits
  2. `PAYMENT_CONFIRMED` payload field renamed `eventId` → `webhookEventId` as second-layer defence against collision
  3. `create()` replaced with `upsert()` (no-op `update: {}` on retry); `EVENT_PROCESSED` write removed from transaction; `recordEventProcessed()` now called **after** `triggerPaymentCompletionHandler` succeeds

- **PLAN_DATA deduplication** (`billing/page.tsx`): Replaces hardcoded `PLANS` array (with stale string prices `'$29'`, `'$79'`, `'$149'`) with a derived mapping from `@/app/pricing/pricing-data`. Single source of truth — price changes now propagate automatically.

- **Test fixture** (`handler.unit.test.ts`): Adds `upsert: jest.fn()` to the `paymentEvent` mock so existing tests exercise the new upsert path (12/12 passing).

## Test plan

- [x] `npm test` — 1220 tests pass across 48 suites (0 failures)
- [x] Webhook handler unit tests — 12/12 pass including idempotency skip test
- [x] Pricing data import verified — `PLANS` exported from `pricing-data.ts`, `Plan` type has `id`, `name`, `price` (number), `features`, `popular` fields
- [x] Prisma schema confirms `@@unique([paymentId, eventType])` constraint backing the `paymentId_eventType` upsert key

🤖 Generated with [Claude Code](https://claude.com/claude-code)