### PR TITLE
perf: add missing DB indexes on drip_email_queue, clients, pets, analytics_events

### DIFF
--- a/prisma/migrations/20260424000001_add_missing_indexes/migration.sql
+++ b/prisma/migrations/20260424000001_add_missing_indexes/migration.sql
@@ -1,0 +1,24 @@
+-- Performance: Add missing indexes identified by QA audit (catastrophic seq_scan ratios)
+-- Uses CONCURRENTLY to avoid locking tables during production apply
+-- Uses IF NOT EXISTS to make idempotent
+
+-- drip_email_queue: worker polls WHERE status='pending' AND scheduled_at <= now(), grouped by user_id
+-- 1,006 seq_scans vs 5 idx_scans — CRITICAL
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "drip_email_queue_user_id_status_scheduled_at_idx"
+  ON "drip_email_queue" ("user_id", "status", "scheduled_at");
+
+-- clients: every client list page queries WHERE user_id = ?
+-- 73 seq_scans vs 7 idx_scans — HIGH
+-- Note: @@unique([userId, email]) exists but PostgreSQL may not use it for single-col user_id scans
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "clients_user_id_idx"
+  ON "clients" ("user_id");
+
+-- pets: every pet profile fetch queries WHERE client_id = ?
+-- 33 seq_scans vs 0 idx_scans — MEDIUM
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "pets_client_id_idx"
+  ON "pets" ("client_id");
+
+-- analytics_events: funnel queries filter by user_id + event_name (+ date range on created_at)
+-- 144 seq_scans vs 0 idx_scans — HIGH
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "analytics_events_user_id_event_name_created_at_idx"
+  ON "analytics_events" ("user_id", "event_name", "created_at");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,7 @@ model Client {
   appointments Appointment[]
 
   @@unique([userId, email])
+  @@index([userId])
   @@map("clients")
 }
 
@@ -86,6 +87,7 @@ model Pet {
   client       Client       @relation(fields: [clientId], references: [id], onDelete: Cascade)
   appointments Appointment[]
 
+  @@index([clientId])
   @@map("pets")
 }
 
@@ -149,6 +151,7 @@ model DripEmailQueue {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
+  @@index([userId, status, scheduledAt])
   @@map("drip_email_queue")
 }
 
@@ -179,6 +182,7 @@ model AnalyticsEvent {
   // are stored without a user session. If a user is deleted, their events are nulled.
   user User? @relation(fields: [userId], references: [id], onDelete: SetNull)
 
+  @@index([userId, eventName, createdAt])
   @@map("analytics_events")
 }
 


### PR DESCRIPTION
## Summary
- **drip_email_queue**: Added compound index `(user_id, status, scheduled_at)` — drip worker polls `WHERE status='pending' AND scheduled_at <= now()`. Was 1,006 seq_scans vs 5 idx_scans (CRITICAL).
- **clients**: Added index `(user_id)` — every client list page queries `WHERE user_id = ?`. Was 73 seq_scans vs 7 idx_scans (HIGH).
- **pets**: Added index `(client_id)` — every pet fetch queries `WHERE client_id = ?`. Was 33 seq_scans vs 0 idx_scans (MEDIUM).
- **analytics_events**: Added compound index `(user_id, event_name, created_at)` — funnel analytics filters by user + event type + date range. Was 144 seq_scans vs 0 idx_scans (HIGH).
- **appointments**: Already has `@@index([userId, startTime])` — no change needed.

## Implementation
- `@@index` directives added to `prisma/schema.prisma` (schema source of truth)
- Migration SQL at `prisma/migrations/20260424000001_add_missing_indexes/migration.sql`
- All indexes use `CREATE INDEX CONCURRENTLY IF NOT EXISTS` — zero table locks, idempotent apply
- No application logic touched — pure schema migration

## Test plan
- [ ] Verify migration applies cleanly on staging: `psql -c "\d drip_email_queue"` shows new index
- [ ] EXPLAIN ANALYZE on `SELECT * FROM drip_email_queue WHERE user_id=? AND status='pending' AND scheduled_at <= now()` → should show Index Scan, not Seq Scan
- [ ] EXPLAIN ANALYZE on `SELECT * FROM clients WHERE user_id=?` → Index Scan
- [ ] EXPLAIN ANALYZE on `SELECT * FROM pets WHERE client_id=?` → Index Scan
- [ ] EXPLAIN ANALYZE on `SELECT * FROM analytics_events WHERE user_id=? AND event_name=?` → Index Scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)