### PR TITLE
fix: checkout session localhost redirect — revenue-blocking hotfix

### DIFF
--- a/src/app/api/checkout/session/route.ts
+++ b/src/app/api/checkout/session/route.ts
@@ -5,6 +5,10 @@ import { createCheckoutSession } from '@/lib/stripe';
 import prisma from '@/lib/prisma';
 import { ensureEnv } from '@/lib/validation';
 
+// Use the public app URL as redirect base — req.url resolves to localhost:3002
+// behind nginx, which produces unreachable redirects in production.
+const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://app.getgroomgrid.com';
+
 const VALID_PLANS = ['solo', 'salon', 'enterprise'] as const;
 type PlanType = typeof VALID_PLANS[number];
 
@@ -26,7 +30,7 @@ export async function GET(req: NextRequest) {
   // ── Authentication check ──────────────────────────────────────────
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
-    const loginUrl = new URL('/login', req.url);
+    const loginUrl = new URL('/login', appUrl);
     loginUrl.searchParams.set('next', '/plans');
     return NextResponse.redirect(loginUrl, 302);
   }


### PR DESCRIPTION
## Summary
- **CRITICAL BUG FIX**: Checkout session route (`/api/checkout/session`) used `new URL('/login', req.url)` which resolves to `http://localhost:3002/login` behind nginx in production
- Unauthenticated users trying to start checkout got redirected to a dead localhost URL — **blocking ALL revenue**
- Fix: Use `process.env.NEXT_PUBLIC_APP_URL` with fallback to `https://app.getgroomgrid.com`, matching the exact same pattern already deployed in the email verification route (`/api/auth/verify-email`)

## Changes
**`src/app/api/checkout/session/route.ts`** (1 file, +5 lines, -1 line)
- Added `appUrl` constant using `NEXT_PUBLIC_APP_URL` env var with safe fallback
- Changed `new URL('/login', req.url)` → `new URL('/login', appUrl)` on the redirect line

## Audit: Other API Routes Scanned
All `new URL(req.url)` usages across API routes were audited:
- ✅ `checkout/session/route.ts:29` — **FIXED** (was redirect bug)
- ✅ `auth/verify-email/route.ts` — Already fixed (uses `appUrl` pattern)
- ✅ All other uses are `new URL(req.url)` for **searchParams parsing only** — safe, not used for redirects

## Acceptance Criteria
1. ✅ Checkout session redirect uses `NEXT_PUBLIC_APP_URL` or fallback `https://app.getgroomgrid.com`
2. ✅ No API route creates redirect URLs from `req.url`
3. ⏳ Deployed to production — needs merge + deploy

## Test Plan
- [ ] Verify unauthenticated user hitting `/api/checkout/session?plan=solo` redirects to `https://app.getgroomgrid.com/login?next=%2Fplans` (not localhost)
- [ ] Verify authenticated user still gets redirected to Stripe checkout normally
- [ ] Verify `NEXT_PUBLIC_APP_URL` env var is set in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)