### PR TITLE
fix(test): update sitemap test for new blog posts

### DIFF
--- a/src/__tests__/sitemap.test.ts
+++ b/src/__tests__/sitemap.test.ts
@@ -36,6 +36,8 @@ describe('Sitemap Generation', () => {
     expect(urls).toContain('https://getgroomgrid.com/blog/how-to-open-a-pet-grooming-business');
     expect(urls).toContain('https://getgroomgrid.com/blog/how-to-build-mobile-grooming-trailer');
     expect(urls).toContain('https://getgroomgrid.com/blog/free-dog-grooming-software');
+    expect(urls).toContain('https://getgroomgrid.com/blog/groomgrid-vs-daysmart');
+    expect(urls).toContain('https://getgroomgrid.com/blog/groomgrid-vs-pawfinity');
   });
 
   it('should include SEO landing pages', () => {
@@ -129,7 +131,7 @@ describe('Sitemap Generation', () => {
   it('should have total entries matching all pages', () => {
     const result = sitemap();
 
-    // 4 static pages + 7 landing pages + 21 blog posts = 32 total
-    expect(result.length).toBe(32);
+    // 4 static pages + 7 landing pages + 23 blog posts = 34 total
+    expect(result.length).toBe(34);
   });
 });


### PR DESCRIPTION
## Summary
Fixes the broken sitemap test caused by PR #188 adding two new blog posts (`groomgrid-vs-daysmart`, `groomgrid-vs-pawfinity`) without updating the sitemap test's total entry count assertion.

## Changes
- Updated total sitemap entry count from 32 → 34 (4 static + 7 landing + 23 blog posts)
- Added assertions for `groomgrid-vs-daysmart` and `groomgrid-vs-pawfinity` blog URLs

## QA Gate Items Addressed
1. ✅ **PR #189 (E2E Selector Fix)**: Already merged — verified selectors are correct:
   - `e2e/helpers/selectors.ts`: `submitButton: /Start Free Trial/i` ✅
   - `tests/helpers/selectors.ts`: `submitButton: 'button:has-text("Start Free Trial")'` ✅
   - `src/app/signup/page.tsx`: `data-testid="signup-submit"` ✅
2. ✅ **Sitemap Test Fix**: Updated count and assertions for new blog posts

## Testing
- `npx jest src/__tests__/sitemap.test.ts` → 11/11 passed
- `npx jest` (full suite) → 49 suites, 1276 tests, all passed
- No regressions

## Risk
- **Blast radius**: Test-only change, no production code
- **Regression risk**: None — only updates test expectations to match actual content

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>