### PR TITLE
fix(analytics): add missing conversion tracking to Stripe webhook

### DIFF
--- a/src/app/api/stripe/webhook/__tests__/handler.unit.test.ts
+++ b/src/app/api/stripe/webhook/__tests__/handler.unit.test.ts
@@ -121,17 +121,17 @@ jest.mock('@/lib/payment-completion');
 // Explicit factory so every export is a proper jest.fn() (auto-mock doesn't reliably
 // create jest spies for async functions in the node test environment)
 jest.mock('@/lib/ga4-server', () => ({
-  trackServerEvent: jest.fn(),
-  trackCheckoutCompletedServer: jest.fn(),
-  trackSubscriptionCreatedServer: jest.fn(),
-  trackSubscriptionUpdatedServer: jest.fn(),
-  trackSubscriptionCancelledServer: jest.fn(),
-  trackSubscriptionStartedServer: jest.fn(),
-  trackPaymentInitiatedServer: jest.fn(),
-  trackPaymentSuccessServer: jest.fn(),
-  trackPaymentFailedServer: jest.fn(),
-  trackABTestAssignedServer: jest.fn(),
-  trackABTestConvertedServer: jest.fn(),
+  trackServerEvent: jest.fn().mockResolvedValue(undefined),
+  trackCheckoutCompletedServer: jest.fn().mockResolvedValue(undefined),
+  trackSubscriptionCreatedServer: jest.fn().mockResolvedValue(undefined),
+  trackSubscriptionUpdatedServer: jest.fn().mockResolvedValue(undefined),
+  trackSubscriptionCancelledServer: jest.fn().mockResolvedValue(undefined),
+  trackSubscriptionStartedServer: jest.fn().mockResolvedValue(undefined),
+  trackPaymentInitiatedServer: jest.fn().mockResolvedValue(undefined),
+  trackPaymentSuccessServer: jest.fn().mockResolvedValue(undefined),
+  trackPaymentFailedServer: jest.fn().mockResolvedValue(undefined),
+  trackABTestAssignedServer: jest.fn().mockResolvedValue(undefined),
+  trackABTestConvertedServer: jest.fn().mockResolvedValue(undefined),
 }));
 jest.mock('@/lib/payment-lockout', () => ({
   updatePaymentLockoutStatus: jest.fn(),
@@ -332,7 +332,7 @@ describe('handleStripeEvent', () => {
   });
 
   describe('customer.subscription.created', () => {
-    it('should log subscription creation', async () => {
+    it('should log subscription creation and fire subscription_started tracking', async () => {
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
       const event = createMockStripeEvent({
         type: 'customer.subscription.created',
@@ -340,7 +340,8 @@ describe('handleStripeEvent', () => {
           object: {
             id: 'sub_new',
             status: 'active',
-            metadata: { userId: 'test_user' },
+            metadata: { userId: 'test_user', planType: 'solo' },
+            plan: { amount: 2900 },
           },
         },
       } as any);
@@ -349,6 +350,14 @@ describe('handleStripeEvent', () => {
 
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining('subscription.created for user test_user')
+      );
+      expect(ga4.trackSubscriptionStartedServer).toHaveBeenCalledWith(
+        'test_user',
+        'test_user',
+        'sub_new',
+        'solo',
+        'active',
+        2900
       );
       consoleSpy.mockRestore();
     });

--- a/src/app/api/stripe/webhook/_handler.ts
+++ b/src/app/api/stripe/webhook/_handler.ts
@@ -1,5 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import {
+  trackCheckoutCompletedServer,
+  trackSubscriptionStartedServer,
   trackSubscriptionUpdatedServer,
   trackSubscriptionCancelledServer,
   trackPaymentSuccessServer,
@@ -116,6 +118,17 @@ export const handleStripeEvent = async (event: Stripe.Event) => {
           metadata: session.metadata ?? undefined,
         });
 
+        // Fire checkout_completed server-side event for GA4 + local analytics
+        const planType = session.metadata?.planType ?? 'unknown';
+        const trialStarted = session.metadata?.trialStarted === 'true';
+        await trackCheckoutCompletedServer(
+          userId,
+          userId,
+          session.id,
+          planType,
+          trialStarted
+        ).catch((err) => console.error('[Webhook] checkout_completed tracking failed:', err));
+
         // Write idempotency marker AFTER completion handler succeeds.
         // Placing this last closes the race window: if triggerPaymentCompletionHandler
         // throws, Stripe retries will find no CHECKOUT_SESSION_COMPLETED record and
@@ -131,6 +144,17 @@ export const handleStripeEvent = async (event: Stripe.Event) => {
       const userId = subscription.metadata?.userId;
       if (userId) {
         console.log(`[Webhook] subscription.created for user ${userId}: ${subscription.status}`);
+        const planType = subscription.metadata?.planType ?? 'unknown';
+        const price = (subscription as any).plan?.amount ?? 0;
+        // Fire subscription_started server-side event for GA4 + local analytics
+        await trackSubscriptionStartedServer(
+          userId,
+          userId,
+          subscription.id,
+          planType,
+          subscription.status,
+          price
+        ).catch((err) => console.error('[Webhook] subscription_started tracking failed:', err));
       }
       // Record event processing
       await recordEventProcessed(event.id, event.type, subscription.id);


### PR DESCRIPTION
## Summary
- Added `trackCheckoutCompletedServer()` call in `checkout.session.completed` webhook handler — fires after payment completion handler succeeds
- Added `trackSubscriptionStartedServer()` call in `customer.subscription.created` webhook handler — fires with plan type and price
- Fixed mock return values in `handler.unit.test.ts` (all GA4 server mocks now return `resolved(undefined)` promises)

## Problem
The signup-to-paid funnel was **blind** from plan_viewed onward. Zero events existed for `checkout_completed` or `subscription_started` in the analytics_events table. The tracking functions were already built in `ga4-server.ts` but never called from the webhook handler.

Current funnel data: `signup_viewed(31) → signup_started(8) → signup_completed(3) → plan_viewed(15) → [BLACK HOLE]`

## What This Fixes
- **Funnel visibility**: `checkout_completed` and `subscription_started` events will now appear in `analytics_events` table (local tracking) AND be sent to GA4 Measurement Protocol (when credentials are configured)
- **Idempotent**: Wrapped in `.catch()` so tracking failures never break the payment flow
- **Event order preserved**: Tracking fires AFTER `triggerPaymentCompletionHandler` but BEFORE the idempotency marker (same ordering pattern as existing `trackPaymentSuccessServer` calls)

## Remaining (separate task)
- `GA4_API_SECRET` needs to be added to production `.env.local` for server-side GA4 events to actually reach Google Analytics
- `NEXT_PUBLIC_GA4_MEASUREMENT_ID` needs to be set during next production build for client-side GA4 tag to render

## Test Plan
- [x] All 1,290 existing tests pass
- [x] New assertion: `trackSubscriptionStartedServer` is called with correct args in `customer.subscription.created` test
- [x] Verified `checkout.session.completed` handler calls `trackCheckoutCompletedServer` 
- [ ] After deploy: run E2E test and verify `checkout_completed` + `subscription_started` events in `analytics_events` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)