### PR TITLE
fix: deployment version detection + cache headers to prevent stale Server Action errors

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import SessionExpirationDetector from '@/components/session-expiration/SessionEx
 import { NetworkStatusProvider } from '@/context/NetworkStatusContext';
 import { RequestQueueProvider } from '@/context/RequestQueueContext';
 import { OfflineBanner } from '@/components/network';
+import DeploymentVersionCheck from '@/components/deployment/DeploymentVersionCheck';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -127,6 +128,7 @@ export default function RootLayout({
                 <OfflineBanner position="top" className="fixed inset-x-0 top-0" />
                 {children}
                 <SessionExpirationDetector />
+                <DeploymentVersionCheck />
               </RequestQueueProvider>
             </NetworkStatusProvider>
           </ABTestProvider>

--- a/src/components/deployment/DeploymentVersionCheck.tsx
+++ b/src/components/deployment/DeploymentVersionCheck.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useEffect, useState, useRef } from 'react';
+
+/**
+ * DeploymentVersionCheck — detects new deployments and prompts users to reload.
+ *
+ * Prevents "Failed to find Server Action" errors that occur when a user's
+ * cached page has stale action IDs from a previous build.
+ *
+ * Polls /api/health every 60 seconds. If the buildId changes, shows a
+ * non-intrusive banner at the bottom of the screen.
+ */
+export default function DeploymentVersionCheck() {
+  const [newVersionAvailable, setNewVersionAvailable] = useState(false);
+  const initialBuildId = useRef<string | null>(null);
+
+  useEffect(() => {
+    // Capture the initial build ID from the health endpoint
+    fetch('/api/health')
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.buildId) {
+          initialBuildId.current = data.buildId;
+        }
+      })
+      .catch(() => {
+        // Health check failed — ignore
+      });
+
+    // Poll for build ID changes every 60 seconds
+    const interval = setInterval(() => {
+      if (!initialBuildId.current) return;
+      fetch('/api/health')
+        .then((res) => res.json())
+        .then((data) => {
+          if (data.buildId && data.buildId !== initialBuildId.current) {
+            setNewVersionAvailable(true);
+          }
+        })
+        .catch(() => {
+          // Network error — ignore
+        });
+    }, 60_000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  if (!newVersionAvailable) return null;
+
+  return (
+    <div className="fixed bottom-0 inset-x-0 z-50 bg-green-600 text-white px-4 py-3 text-center text-sm font-medium shadow-lg">
+      A new version of GroomGrid is available.{' '}
+      <button
+        onClick={() => window.location.reload()}
+        className="underline font-bold hover:text-green-100"
+      >
+        Reload now
+      </button>
+    </div>
+  );
+}

--- a/src/lib/health-check.ts
+++ b/src/lib/health-check.ts
@@ -19,6 +19,7 @@ export interface HealthReport {
   status: 'healthy' | 'degraded' | 'critical';
   timestamp: string;
   version: string;
+  buildId: string;
   environment: string;
   uptimeSeconds: number;
   checks: HealthCheckResult[];
@@ -115,10 +116,22 @@ export async function buildHealthReport(): Promise<HealthReport> {
   // Environment variable checks (sync)
   checks.push(...checkEnvironmentVars());
 
+  // Read the Next.js build ID for version change detection
+  let buildId = 'unknown';
+  try {
+    const fs = await import('fs');
+    const path = await import('path');
+    const buildIdPath = path.join(process.cwd(), '.next', 'BUILD_ID');
+    buildId = fs.readFileSync(buildIdPath, 'utf-8').trim();
+  } catch {
+    // BUILD_ID not available (dev mode or missing file)
+  }
+
   return {
     status: computeStatus(checks),
     timestamp: new Date().toISOString(),
     version: process.env.APP_VERSION || 'unknown',
+    buildId,
     environment: process.env.NODE_ENV || 'unknown',
     uptimeSeconds: Math.floor(process.uptime()),
     checks,


### PR DESCRIPTION
## Summary
- Adds `buildId` to `/api/health` endpoint for client-side version change detection
- Adds `DeploymentVersionCheck` component that polls health endpoint every 60s and shows a reload banner when a new deployment is detected
- Adds `Cache-Control: no-cache, no-store, must-revalidate` header via nginx to prevent browsers from serving stale HTML
- Prevents "Failed to find Server Action" errors that occur when users have cached pages from a previous build

## Problem
Production error logs are flooded with "Failed to find Server Action" errors after deployments. These occur when a user's browser serves a cached HTML page with stale action IDs from a previous Next.js build. The user then tries to interact with the page and the server can't find the action.

## Solution
1. **Health endpoint** now includes the Next.js build ID (`buildId` field)
2. **Client component** compares current buildId with the server's buildId every 60s
3. **Nginx headers** prevent stale HTML caching (already deployed to production)
4. When a mismatch is detected, a non-intrusive green banner appears asking the user to reload

## Test plan
- [ ] Deploy and verify health endpoint returns `buildId` field
- [ ] Verify `Cache-Control: no-cache` header is present on HTML responses
- [ ] Verify DeploymentVersionCheck component renders correctly
- [ ] Verify that after a new deployment, the banner appears for users with old cached pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)