### PR TITLE
fix: wrap dashboard useSearchParams in Suspense boundary

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -32,6 +32,21 @@ interface DashboardError {
 const FETCH_TIMEOUT = 15000; // 15 seconds
 
 export default function DashboardPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen bg-gradient-to-br from-green-50 to-stone-50 flex items-center justify-center">
+        <div className="text-center">
+          <LoadingSpinner size="lg" />
+          <p className="mt-4 text-stone-600">Loading your dashboard...</p>
+        </div>
+      </div>
+    }>
+      <DashboardContent />
+    </Suspense>
+  );
+}
+
+function DashboardContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { data: session, status } = useSession();


### PR DESCRIPTION
## Summary
Production build fails because `useSearchParams()` in the dashboard page requires a Suspense boundary for static generation (Next.js requirement).

Splits `DashboardPage` into a wrapper component with Suspense fallback + `DashboardContent` component that uses `useSearchParams`.

## Why
This was introduced by the trial plan_selected feature (PR #201) which added `useSearchParams` to read `plan_selected` from the URL. Without a Suspense boundary, Next.js can't prerender the page.

## Test plan
- [x] Dashboard test passes (useSearchParams mock still works)
- [ ] Production build succeeds (was failing with prerender error)
- [ ] Dashboard loads correctly with and without `?plan_selected=solo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)