### PR TITLE
Add /cat-grooming-software to sitemap

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -35,6 +35,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   // SEO landing pages (root-level)
   const landingPages: MetadataRoute.Sitemap = [
     'best-dog-grooming-software',
+    'cat-grooming-software',
     'grooming-business-operations',
     'mobile-grooming-business',
     'mobile-grooming-software',


### PR DESCRIPTION
Quick fix: add the new cat grooming landing page to the sitemap for SEO discovery.