### PR TITLE
fix: health endpoint returns 200 for degraded status (GA4 missing)

### DIFF
--- a/src/app/api/__tests__/health.test.ts
+++ b/src/app/api/__tests__/health.test.ts
@@ -163,6 +163,53 @@ describe('health-check utilities', () => {
       expect(check!.message).toContain('MAILGUN_DOMAIN');
     });
 
+    it('returns degraded for missing GA4_API_SECRET (not fail)', () => {
+      process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+      process.env.NEXTAUTH_URL = 'http://localhost:3000';
+      process.env.NEXTAUTH_SECRET = 'test-secret';
+      process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+      process.env.MAILGUN_API_KEY = 'key-test123';
+      process.env.MAILGUN_DOMAIN = 'sandbox.mailgun.org';
+      process.env.STRIPE_SECRET_KEY = 'sk_test_123';
+      process.env.STRIPE_PRICE_SOLO = 'price_test_solo';
+      process.env.STRIPE_PRICE_SALON = 'price_test_salon';
+      process.env.STRIPE_PRICE_ENTERPRISE = 'price_test_enterprise';
+      process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID = 'G-TEST123';
+      delete process.env.GA4_API_SECRET;
+
+      const results = checkEnvironmentVars();
+      const ga4Check = results.find((r) => r.name === 'env:GA4_API_SECRET');
+
+      expect(ga4Check).toBeDefined();
+      expect(ga4Check!.status).toBe('degraded');
+      expect(ga4Check!.message).toContain('GA4_API_SECRET');
+
+      // Core vars should still pass — no critical failures
+      const coreFailures = results.filter((r) => r.status === 'fail');
+      expect(coreFailures).toHaveLength(0);
+    });
+
+    it('returns degraded for missing NEXT_PUBLIC_GA4_MEASUREMENT_ID', () => {
+      process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+      process.env.NEXTAUTH_URL = 'http://localhost:3000';
+      process.env.NEXTAUTH_SECRET = 'test-secret';
+      process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+      process.env.MAILGUN_API_KEY = 'key-test123';
+      process.env.MAILGUN_DOMAIN = 'sandbox.mailgun.org';
+      process.env.STRIPE_SECRET_KEY = 'sk_test_123';
+      process.env.STRIPE_PRICE_SOLO = 'price_test_solo';
+      process.env.STRIPE_PRICE_SALON = 'price_test_salon';
+      process.env.STRIPE_PRICE_ENTERPRISE = 'price_test_enterprise';
+      delete process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID;
+      process.env.GA4_API_SECRET = 'test_api_secret';
+
+      const results = checkEnvironmentVars();
+      const ga4IdCheck = results.find((r) => r.name === 'env:NEXT_PUBLIC_GA4_MEASUREMENT_ID');
+
+      expect(ga4IdCheck).toBeDefined();
+      expect(ga4IdCheck!.status).toBe('degraded');
+    });
+
     it('does NOT fail when MAILGUN_FROM_EMAIL is absent (it is optional)', () => {
       process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
       process.env.NEXTAUTH_URL = 'http://localhost:3000';
@@ -208,6 +255,24 @@ describe('health-check utilities', () => {
       const checks: HealthCheckResult[] = [
         { name: 'database', status: 'fail', message: 'down' },
         { name: 'env:DATABASE_URL', status: 'fail', message: 'missing' },
+      ];
+
+      expect(computeStatus(checks)).toBe('critical');
+    });
+
+    it('returns degraded when only degraded checks (no fails)', () => {
+      const checks: HealthCheckResult[] = [
+        { name: 'database', status: 'pass', message: 'ok' },
+        { name: 'env:GA4_API_SECRET', status: 'degraded', message: 'not set' },
+      ];
+
+      expect(computeStatus(checks)).toBe('degraded');
+    });
+
+    it('returns critical when both fail and degraded checks exist (fail takes precedence)', () => {
+      const checks: HealthCheckResult[] = [
+        { name: 'database', status: 'fail', message: 'down' },
+        { name: 'env:GA4_API_SECRET', status: 'degraded', message: 'not set' },
       ];
 
       expect(computeStatus(checks)).toBe('critical');
@@ -311,11 +376,45 @@ describe('health-check utilities', () => {
       process.env.MAILGUN_DOMAIN = 'sandbox.mailgun.org';
       process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID = 'G-TEST123';
       process.env.GA4_API_SECRET = 'test_api_secret';
+      process.env.STRIPE_SECRET_KEY = 'sk_test_123';
+      process.env.STRIPE_PRICE_SOLO = 'price_test_solo';
+      process.env.STRIPE_PRICE_SALON = 'price_test_salon';
+      process.env.STRIPE_PRICE_ENTERPRISE = 'price_test_enterprise';
 
       const report = await buildHealthReport();
 
       expect(report.status).toBe('healthy');
       for (const check of report.checks) {
+        expect(check.status).toBe('pass');
+      }
+    });
+
+    it('reports degraded (not critical) when GA4 vars are missing', async () => {
+      mockQueryRaw.mockResolvedValueOnce([{ '?column?': 1 }]);
+      process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+      process.env.NEXTAUTH_URL = 'http://localhost:3000';
+      process.env.NEXTAUTH_SECRET = 'test-secret';
+      process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+      process.env.MAILGUN_API_KEY = 'key-test123';
+      process.env.MAILGUN_DOMAIN = 'sandbox.mailgun.org';
+      process.env.STRIPE_SECRET_KEY = 'sk_test_123';
+      process.env.STRIPE_PRICE_SOLO = 'price_test_solo';
+      process.env.STRIPE_PRICE_SALON = 'price_test_salon';
+      process.env.STRIPE_PRICE_ENTERPRISE = 'price_test_enterprise';
+      delete process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID;
+      delete process.env.GA4_API_SECRET;
+
+      const report = await buildHealthReport();
+
+      // Should be degraded, NOT critical — the app still works without analytics
+      expect(report.status).toBe('degraded');
+      const ga4Checks = report.checks.filter((c) => c.name.startsWith('env:GA4') || c.name.startsWith('env:NEXT_PUBLIC_GA4'));
+      for (const check of ga4Checks) {
+        expect(check.status).toBe('degraded');
+      }
+      // Core checks should all pass
+      const coreChecks = report.checks.filter((c) => !c.name.startsWith('env:GA4') && !c.name.startsWith('env:NEXT_PUBLIC_GA4'));
+      for (const check of coreChecks) {
         expect(check.status).toBe('pass');
       }
     });

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -12,7 +12,7 @@ import { buildHealthReport, HealthReport } from '@/lib/health-check';
 export async function GET(): Promise<NextResponse<HealthReport>> {
   const report = await buildHealthReport();
 
-  // Return 503 when critical so load balancers / monitors detect the issue.
+  // Return 503 only when critical (core infra down). Degraded (analytics missing) returns 200.
   const httpStatus = report.status === 'critical' ? 503 : 200;
 
   return NextResponse.json(report, { status: httpStatus });

--- a/src/lib/health-check.ts
+++ b/src/lib/health-check.ts
@@ -9,7 +9,7 @@
 
 export interface HealthCheckResult {
   name: string;
-  status: 'pass' | 'fail';
+  status: 'pass' | 'fail' | 'degraded';
   message: string;
   latencyMs?: number;
   details?: Record<string, unknown>;
@@ -98,7 +98,8 @@ export function checkEnvironmentVars(): HealthCheckResult[] {
     }
   }
 
-  // GA4 analytics vars — required for server-side funnel tracking (checkout_completed, subscription events)
+  // GA4 analytics vars — NOT critical; app works without them, just analytics won't fire.
+  // We track them as "degraded" so health endpoint returns 200 not 503.
   const analyticsVars: Array<{ name: string; label: string }> = [
     { name: 'NEXT_PUBLIC_GA4_MEASUREMENT_ID', label: 'GA4 Measurement ID' },
     { name: 'GA4_API_SECRET', label: 'GA4 Measurement Protocol API secret' },
@@ -109,7 +110,7 @@ export function checkEnvironmentVars(): HealthCheckResult[] {
     if (!value) {
       checks.push({
         name: `env:${name}`,
-        status: 'fail',
+        status: 'degraded',
         message: `${label} (${name}) is not set — server-side GA4 events will not fire`,
       });
     } else {
@@ -145,11 +146,15 @@ export function checkEnvironmentVars(): HealthCheckResult[] {
 /**
  * Compute aggregate status from individual check results.
  * - All pass → healthy
- * - Any fail → critical (for MVP, degraded is unused but reserved)
+ * - Any fail (core infra like DB, auth, Stripe) → critical
+ * - Any degraded (optional like analytics) → degraded
+ * - Mixed fail + degraded → critical (fail takes precedence)
  */
 export function computeStatus(checks: HealthCheckResult[]): 'healthy' | 'degraded' | 'critical' {
   const failures = checks.filter((c) => c.status === 'fail').length;
+  const degraded = checks.filter((c) => c.status === 'degraded').length;
   if (failures > 0) return 'critical';
+  if (degraded > 0) return 'degraded';
   return 'healthy';
 }
 


### PR DESCRIPTION
## Summary
- Health endpoint was returning 503 "critical" when GA4_API_SECRET was missing, making uptime monitors think the app was down
- The app is fully functional without GA4 - only server-side analytics events are affected
- Added "degraded" status tier between "healthy" and "critical" for non-critical env var checks

## Changes
- Added `degraded` status to `HealthCheckResult` type
- GA4 env var checks now return `degraded` instead of `fail`
- `computeStatus`: critical > degraded > healthy ordering
- Health route returns HTTP 200 for "degraded" (only 503 for "critical")
- Added 5 new tests for degraded status behavior

## Test plan
- [x] All 24 health check tests pass
- [x] Deployed to production, verified `/api/health` returns 200 with `"status":"degraded"` 
- [ ] Verify uptime monitors now see 200 instead of 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)