### PR TITLE
fix: Escape apostrophes in JSX strings to fix Turbopack build

### DIFF
--- a/src/app/best-dog-grooming-software/page.tsx
+++ b/src/app/best-dog-grooming-software/page.tsx
@@ -442,7 +442,7 @@ export default function BestDogGroomingSoftwarePage() {
           links={[
           { href: '/signup?coupon=BETA50', category: 'Alternatives', title: 'MoeGo Alternatives: Best Pet Grooming Software for 2026' },
           { href: '/daysmart-alternatives', category: 'Alternatives', title: 'DaySmart Alternatives: Best Pet Grooming Software for 2026' },
-          { href: '/mobile-grooming-software', category: 'Mobile Groomers', title: 'Mobile Grooming Software: The Van Groomer's Complete Guide' }
+          { href: '/mobile-grooming-software', category: 'Mobile Groomers', title: 'Mobile Grooming Software: The Van Groomer\'s Complete Guide' }
           ]}
           columns={3}
         />

--- a/src/app/blog/best-pet-grooming-software/page.tsx
+++ b/src/app/blog/best-pet-grooming-software/page.tsx
@@ -286,7 +286,7 @@ export default function BestPetGroomingSoftwarePage() {
           heading="Start with the best-rated option for independent groomers"
           links={[
           { href: '/signup?coupon=BETA50', category: 'Comparison', title: 'GroomGrid vs MoeGo: An Honest Comparison' },
-          { href: '/blog/pet-grooming-software', category: 'Software Guide', title: 'Pet Grooming Software: The Complete Beginner's Guide' }
+          { href: '/blog/pet-grooming-software', category: 'Software Guide', title: 'Pet Grooming Software: The Complete Beginner\'s Guide' }
           ]}
           columns={3}
         />

--- a/src/app/blog/free-dog-grooming-software/page.tsx
+++ b/src/app/blog/free-dog-grooming-software/page.tsx
@@ -371,7 +371,7 @@ export default function FreeDogGroomingSoftwarePage() {
         <RelatedLinks
           heading="Skip the DIY hacks. Try the real thing free."
           links={[
-          { href: '/signup?coupon=BETA50', category: 'Software Guide', title: 'Dog Grooming Software: The 2026 Buyer's Guide' },
+          { href: '/signup?coupon=BETA50', category: 'Software Guide', title: 'Dog Grooming Software: The 2026 Buyer\'s Guide' },
           { href: '/blog/reduce-no-shows-dog-grooming', category: 'Operations', title: 'How to Reduce No-Shows in Your Dog Grooming Business' },
           { href: '/blog/is-dog-grooming-a-profitable-business', category: 'Business', title: 'Is Dog Grooming a Profitable Business? Real Numbers' }
           ]}

--- a/src/app/blog/groomgrid-vs-daysmart/page.tsx
+++ b/src/app/blog/groomgrid-vs-daysmart/page.tsx
@@ -446,7 +446,7 @@ export default function GroomGridVsDaySmartPage() {
           heading="Try GroomGrid free — 50% off your first month"
           links={[
           { href: '/signup?coupon=BETA50', category: 'Comparison', title: 'GroomGrid vs MoeGo: Which is Right for You?' },
-          { href: '/blog/dog-grooming-software', category: 'Software', title: 'Dog Grooming Software: The 2026 Buyer's Guide' }
+          { href: '/blog/dog-grooming-software', category: 'Software', title: 'Dog Grooming Software: The 2026 Buyer\'s Guide' }
           ]}
           columns={3}
         />

--- a/src/app/blog/groomgrid-vs-moego/page.tsx
+++ b/src/app/blog/groomgrid-vs-moego/page.tsx
@@ -354,7 +354,7 @@ export default function GroomGridVsMoeGoPage() {
         <RelatedLinks
           heading="Try GroomGrid free — 50% off your first month"
           links={[
-          { href: '/signup?coupon=BETA50', category: 'Software', title: 'Dog Grooming Software: The 2026 Buyer's Guide' },
+          { href: '/signup?coupon=BETA50', category: 'Software', title: 'Dog Grooming Software: The 2026 Buyer\'s Guide' },
           { href: '/blog/reduce-no-shows-dog-grooming', category: 'Operations', title: 'How to Reduce No-Shows in Your Dog Grooming Business' }
           ]}
           columns={3}

--- a/src/app/blog/pet-grooming-software/page.tsx
+++ b/src/app/blog/pet-grooming-software/page.tsx
@@ -253,7 +253,7 @@ export default function PetGroomingSoftwarePage() {
         <RelatedLinks
           heading="Ready to run your grooming business smarter?"
           links={[
-          { href: '/signup?coupon=BETA50', category: 'Software', title: 'Dog Grooming Software: The 2026 Buyer's Guide' },
+          { href: '/signup?coupon=BETA50', category: 'Software', title: 'Dog Grooming Software: The 2026 Buyer\'s Guide' },
           { href: '/blog/dog-grooming-business-management', category: 'Operations', title: 'Dog Grooming Business Management: The Complete Guide' }
           ]}
           columns={3}

--- a/src/app/cat-grooming-software/page.tsx
+++ b/src/app/cat-grooming-software/page.tsx
@@ -544,7 +544,7 @@ export default function CatGroomingSoftwarePage() {
           links={[
           { href: '/signup?coupon=BETA50', category: 'Mobile Groomers', title: 'Mobile Grooming Software for Van Groomers' },
           { href: '/blog/cat-grooming-business-guide', category: 'Business Guide', title: 'How to Start a Cat Grooming Business' },
-          { href: '/best-dog-grooming-software', category: 'Buyer's Guide', title: 'Best Dog Grooming Software for 2026' }
+          { href: '/best-dog-grooming-software', category: 'Buyer\'s Guide', title: 'Best Dog Grooming Software for 2026' }
           ]}
           columns={3}
         />

--- a/src/app/daysmart-alternatives/page.tsx
+++ b/src/app/daysmart-alternatives/page.tsx
@@ -333,7 +333,7 @@ export default function DaySmartAlternativesPage() {
           links={[
           { href: '/signup?coupon=BETA50', category: 'Comparison', title: 'GroomGrid vs MoeGo: Which Dog Grooming Software is Right for You?' },
           { href: '/pawfinity-alternatives', category: 'Alternatives', title: 'Pawfinity Alternatives: Best Pet Grooming Software for 2026' },
-          { href: '/blog/dog-grooming-software', category: 'Software Guide', title: 'Dog Grooming Software: The 2026 Buyer's Guide' }
+          { href: '/blog/dog-grooming-software', category: 'Software Guide', title: 'Dog Grooming Software: The 2026 Buyer\'s Guide' }
           ]}
           columns={3}
         />

--- a/src/app/mobile-grooming-software/page.tsx
+++ b/src/app/mobile-grooming-software/page.tsx
@@ -400,7 +400,7 @@ export default function MobileGroomingSoftwarePage() {
         <RelatedLinks
           heading="Mobile grooming software that works as hard as you do"
           links={[
-          { href: '/signup?coupon=BETA50', category: "Buyer's Guide", title: 'Best Dog Grooming Software for 2026: Full Comparison' },
+          { href: '/signup?coupon=BETA50', category: "Buyer\'s Guide", title: 'Best Dog Grooming Software for 2026: Full Comparison' },
           { href: '/blog/how-to-start-a-mobile-dog-grooming-business', category: 'Business Guide', title: 'How to Start a Mobile Dog Grooming Business' },
           { href: '/features/mobile-groomer', category: 'Feature Spotlight', title: 'See GroomGrid Mobile Groomer Tools in Action' },
           { href: '/blog/reduce-no-shows-dog-grooming', category: 'Operations', title: 'How to Reduce No-Shows in Your Dog Grooming Business' }

--- a/src/app/moego-alternatives/page.tsx
+++ b/src/app/moego-alternatives/page.tsx
@@ -380,8 +380,8 @@ export default function MoeGoAlternativesPage() {
           heading="The MoeGo alternative built for groomers who do not need enterprise pricing"
           links={[
           { href: '/signup?coupon=BETA50', category: 'Alternatives', title: 'DaySmart Alternatives: Best Pet Grooming Software for 2026' },
-          { href: '/best-dog-grooming-software', category: 'Buyer's Guide', title: 'Best Dog Grooming Software for 2026: Full Comparison' },
-          { href: '/mobile-grooming-software', category: 'Mobile Groomers', title: 'Mobile Grooming Software: The Van Groomer's Complete Guide' }
+          { href: '/best-dog-grooming-software', category: 'Buyer\'s Guide', title: 'Best Dog Grooming Software for 2026: Full Comparison' },
+          { href: '/mobile-grooming-software', category: 'Mobile Groomers', title: 'Mobile Grooming Software: The Van Groomer\'s Complete Guide' }
           ]}
           columns={3}
         />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -340,7 +340,7 @@ export default function HomePage() {
             { href: '/cat-grooming-software', category: 'Cat Groomers', title: 'Cat Grooming Software' },
             { href: '/mobile-grooming-software', category: 'Mobile Groomers', title: 'Mobile Grooming Software' },
             { href: '/plans', category: 'Pricing', title: 'See All Plans' },
-            { href: '/best-dog-grooming-software', category: "Buyer's Guide", title: 'Best Dog Grooming Software' },
+            { href: '/best-dog-grooming-software', category: "Buyer\'s Guide", title: 'Best Dog Grooming Software' },
             { href: '/moego-alternatives', category: 'Alternatives', title: 'MoeGo Alternatives' },
             { href: '/daysmart-alternatives', category: 'Alternatives', title: 'DaySmart Alternatives' },
             { href: '/pawfinity-alternatives', category: 'Alternatives', title: 'Pawfinity Alternatives' },

--- a/src/app/pawfinity-alternatives/page.tsx
+++ b/src/app/pawfinity-alternatives/page.tsx
@@ -334,7 +334,7 @@ export default function PawfinityAlternativesPage() {
           links={[
           { href: '/signup?coupon=BETA50', category: 'Alternatives', title: 'DaySmart Alternatives: Best Pet Grooming Software for 2026' },
           { href: '/blog/groomgrid-vs-moego', category: 'Comparison', title: 'GroomGrid vs MoeGo: Which Dog Grooming Software is Right for You?' },
-          { href: '/blog/dog-grooming-software', category: 'Software Guide', title: 'Dog Grooming Software: The 2026 Buyer's Guide' }
+          { href: '/blog/dog-grooming-software', category: 'Software Guide', title: 'Dog Grooming Software: The 2026 Buyer\'s Guide' }
           ]}
           columns={3}
         />


### PR DESCRIPTION
## Summary
Fix build-breaking apostrophe errors in single-quoted JSX title attributes. Words like `Groomer's`, `Buyer's`, and `Beginner's` inside single-quoted strings were prematurely terminating the string in Turbopack's parser.

## Problem
After merging PR #210 (marketing components + middleware fix), the production build fails with 10 "Expected '</', got 'ident'" errors because apostrophes in title values like `'Groomer's Complete Guide'` end the string early.

## Fix
Escape apostrophes in single-quoted JSX strings: `Groomer's` → `Groomer\'s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)