### PR TITLE
Add Founding Groomer Beta Program plan for Week 2

### DIFF
--- a/docs/strategy/FOUNDING-BETA-PROGRAM.md
+++ b/docs/strategy/FOUNDING-BETA-PROGRAM.md
@@ -1,0 +1,253 @@
+# GroomGrid Founding Groomer Beta Program
+
+**Author:** Lucia Torres, Strategy & Planning  
+**Date:** April 28, 2026  
+**Status:** DRAFT — Ready for Review  
+**Supports Rock:** Build and execute pre-launch GTM playbook for first 100 subscribers  
+**Timeline:** May 8–14 (Week 2 of Revised Acquisition Plan)  
+**Target:** 10–15 beta testers (real groomers, not demo accounts)
+
+---
+
+## 0. Why a Beta Program
+
+The 6-Day Sprint produced 0 subscribers. The revised acquisition plan calls for a community-first, trust-building approach. The Founding Groomer Beta Program bridges Weeks 1–2 (community trust-building) and Week 3 (paid launch) by:
+
+1. **Getting real groomers into the product** — not as paying customers, but as feedback partners
+2. **Creating social proof** — testimonials, case studies, before/after stories from real users
+3. **Validating product-market fit** — do groomers actually use GroomGrid daily?
+4. **Identifying activation blockers** — what prevents an "aha moment"?
+5. **Building a warm list for founding pricing** — beta testers get first access to $14.50/mo deal
+
+**Key principle:** This is NOT a free trial. Beta testers get full Solo features for free for 30 days in exchange for structured feedback. This is a feedback program, not a giveaway.
+
+---
+
+## 1. Program Structure
+
+### Who: Target Beta Testers
+
+| Persona | Priority | Target Count | Recruitment Channel |
+|---------|----------|-------------|-------------------|
+| Independent Mobile Groomer (Core ICP) | P1 | 8–10 | Facebook Groups, Reddit DMs |
+| Salon Owner/Manager | P2 | 3–4 | LinkedIn, Facebook Groups |
+| Cat Grooming Specialist | P3 | 1–2 | NCGIA, Facebook cat grooming groups |
+| **Total** | | **12–16** | |
+
+### What They Get
+
+| Benefit | Details |
+|---------|---------|
+| Full Solo plan features | Unlimited clients, SMS/email reminders, online booking, payments, pet profiles, AI scheduling |
+| 30-day free access | No credit card required during beta |
+| Direct input | Feature requests prioritized. Bug reports fast-tracked. |
+| Founding Groomer status | "Founding Groomer" badge on their GroomGrid profile (future: public directory) |
+| Lock in founding price | $14.50/mo (50% off Solo) for 12 months after beta ends |
+| Cancel anytime | No obligation to convert. Export all data. |
+
+### What They Give
+
+| Commitment | Details |
+|------------|---------|
+| 30-minute onboarding call | Walk through setup, give initial impressions |
+| Weekly 5-minute pulse survey | 3 questions: What worked? What didn't? What's missing? |
+| Midpoint check-in (Day 15) | 15-minute call to discuss experience |
+| End-of-beta interview (Day 30) | 30-minute structured interview about value, willingness to pay, objections |
+| Optional: Testimonial | If they love it, a quote + permission to use their name/business type |
+| Optional: Before/after story | How GroomGrid changed their workflow |
+
+---
+
+## 2. Recruitment Plan
+
+### Week 1 (May 1–7): Community Value-Building (ALREADY IN PROGRESS)
+
+This is the Facebook engagement plan from `week1-facebook-log.md`. **No GroomGrid mentions in Week 1.** Goal: Build trust, become a recognized name in groups.
+
+### Week 2 (May 8–14): Beta Recruitment
+
+| Day | Action | Channel | Script Direction |
+|-----|--------|---------|-----------------|
+| Thu May 8 | Post: "I've been building a tool for groomers..." | Reddit /r/doggrooming (OC tag required) | Honest builder story. No sales language. |
+| Fri May 9 | DM 20 active group members with personal beta invite | Facebook Groups | Personal, 1:1. Reference specific posts they've made about scheduling pain. |
+| Sat May 10 | Post: "Looking for 10 groomers to test a new scheduling tool" | Facebook Groups (all 5) | Direct but low-pressure. Emphasize free access + feedback partnership. |
+| Mon May 12 | Share in local groomer networking groups | Facebook/LinkedIn | Focus on mobile groomers within 50-mile radius (in-person connection). |
+| Tue May 13 | Follow up on DMs. Send reminder to interested groomers. | DMs | Personal follow-up. Offer to answer questions. |
+| Wed May 14 | Close beta applications. Review and select 12–16 testers. | — | Prioritize diversity: mobile vs salon, dog vs cat, experienced vs newbie. |
+
+### Beta Application Form
+
+**Fields:**
+1. Name
+2. Email
+3. Business type: Mobile groomer / Salon owner / Home-based / Other
+4. Years in business
+5. Approximate number of clients/pets per week
+6. Current scheduling method (paper, Google Calendar, another app, etc.)
+7. Biggest business headache (1 sentence)
+8. Would you be willing to give 30 minutes of feedback per week for free access? (Yes/No)
+
+**Form tool:** Use existing GroomGrid signup form with a `?source=beta` parameter. Track in GA4.
+
+### DM Template (Facebook Groups)
+
+> Hey [Name]! I saw your post about [specific scheduling pain they mentioned]. I've been working on a scheduling tool specifically for mobile groomers and I'm looking for 10 people to test it out for free and tell me what they think.
+>
+> It handles scheduling, reminders, and client records — all the stuff that makes you want to throw your phone across the van 😅
+>
+> Would you be open to trying it for 30 days? No strings attached, no credit card, and I'd genuinely want your feedback on what works and what doesn't.
+>
+> Totally fine if not — just thought I'd ask since your post really resonated!
+
+---
+
+## 3. Onboarding Flow for Beta Testers
+
+### Step 1: Welcome Email (Automated)
+
+**Subject:** Welcome to the Founding Groomer Beta, [Name]! 🐾
+
+**Body:**
+- Thank them for joining
+- Link to create account (pre-configured with Solo features)
+- 3-minute setup guide: add first client → book first appointment → send first reminder
+- Link to book 30-minute onboarding call (Calendly or similar)
+- Slack/email channel for questions
+
+### Step 2: Onboarding Call (30 min)
+
+**Agenda:**
+1. Their business context (5 min)
+2. Walk through account setup (10 min)
+3. Add their first real client together (10 min)
+4. Questions, feedback, impressions (5 min)
+
+### Step 3: Week 1 Pulse Check (Day 7)
+
+**3-question survey:**
+1. What's one thing GroomGrid does well for you?
+2. What's one thing that confused you or didn't work?
+3. On a scale of 1–10, how likely are you to continue using it after the beta?
+
+### Step 4: Midpoint Check-in (Day 15)
+
+**15-minute call:**
+- Review their usage data (clients added, appointments booked)
+- Discuss what features they're using vs. ignoring
+- Ask about willingness to pay: "If this cost $29/mo, would you?"
+- Collect feature requests and bug reports
+
+### Step 5: End-of-Beta Interview (Day 30)
+
+**30-minute structured interview:**
+1. Overall experience rating (1–10)
+2. Top 3 features you'd miss most
+3. Top 3 things that frustrated you
+4. Would you pay $29/mo for this? (Yes / Maybe / No)
+5. Would you pay $14.50/mo founding price? (Yes / Maybe / No)
+6. Would you recommend this to another groomer? (NPS-style 0–10)
+7. What single feature would make this indispensable?
+8. Permission to use testimonial: Yes / No
+
+---
+
+## 4. Success Metrics
+
+| Metric | Minimum Viable | Target | Stretch |
+|--------|---------------|--------|---------|
+| Beta signups (applications) | 15 | 25 | 40 |
+| Beta activations (completed onboarding) | 10 | 15 | 20 |
+| Week 1 retention (still using Day 7) | 60% | 75% | 85% |
+| Week 2 retention (still using Day 14) | 50% | 65% | 80% |
+| Beta-to-paid conversion (Day 30) | 20% | 35% | 50% |
+| Testimonials collected | 3 | 5 | 8 |
+| Product bugs found | 5+ | 10+ | 15+ |
+| Feature requests (unique) | 10 | 15 | 20+ |
+| NPS score | >30 | >40 | >60 |
+
+---
+
+## 5. Conversion Path: Beta → Paid
+
+### At End of Beta (Day 30)
+
+| Scenario | Action |
+|----------|--------|
+| Tester loves it, wants to pay | Offer founding price ($14.50/mo, locked for 12 months). Make it 1-click. |
+| Tester likes it but unsure about price | Offer extended trial (30 more days) or reduced price ($9/mo for 3 months). |
+| Tester didn't use it much | Ask why. Offer to re-onboard. If still not using, let go gracefully. |
+| Tester used it but won't pay | Exit interview: "What would make this worth $29/mo?" Collect feedback. Don't push. |
+
+### Conversion Offer: Founding Groomer Pricing
+
+| Tier | Beta Tester Price | Standard Price | Savings |
+|------|-----------------|---------------|---------|
+| Solo | $14.50/mo (locked 12 months) | $29/mo | 50% |
+| Salon | $39.50/mo (locked 12 months) | $79/mo | 50% |
+
+**Urgency:** "Founding Groomer pricing is available to the first 50 beta testers who convert. After that, standard pricing applies."
+
+**Frictionless conversion:**
+1. Email on Day 28: "Your beta access ends in 2 days. Lock in founding pricing → [1-click button]"
+2. In-app banner on Day 29: "Keep all your data and upgrade to Solo at 50% off → [Upgrade Now]"
+3. In-app banner on Day 30 (last day): "Last chance: Founding price expires tonight at midnight → [Upgrade Now]"
+4. Day 31: Account downgrades to Starter (free tier, 10 clients). All data preserved. Can upgrade anytime.
+
+---
+
+## 6. Feedback Collection Infrastructure
+
+### What We Need to Build (or Use)
+
+| Tool | Purpose | Status |
+|------|---------|--------|
+| GA4 event tracking | Track beta user actions (client added, appointment booked, reminder sent) | ✅ Already in place |
+| Weekly pulse survey (3 questions) | Quick feedback | 🔴 Need: simple form or in-app survey |
+| Midpoint interview (15 min) | Qualitative feedback | 🟡 Manual (Sofia/Sienna conducts) |
+| End-of-beta interview (30 min) | Deep qualitative feedback | 🟡 Manual (Sofia/Sienna conducts) |
+| Beta feedback Slack channel | Real-time bug reports and feature requests | 🔴 Need: #beta-feedback channel |
+| In-app feedback widget | "Report bug" / "Request feature" button | 🔴 Need: simple modal or email link |
+
+### Minimal Viable Feedback Stack (Week 2)
+
+- **Pulse surveys:** Google Forms (3 questions, sent via email)
+- **Interviews:** Google Meet or Zoom (recorded, transcribed)
+- **Bug reports:** Dedicated email (beta@getgroomgrid.com) or Slack #beta-feedback
+- **Feature requests:** Same email/channel, tagged with "feature-request"
+
+---
+
+## 7. Risks & Mitigations
+
+| Risk | Probability | Impact | Mitigation |
+|------|------------|--------|-----------|
+| Not enough beta signups (<10) | Medium | Delays validation | Extend recruitment by 1 week. Offer $20 Amazon gift card for completing onboarding. |
+| Beta testers don't use the product | Medium | No feedback, no social proof | Onboarding call within 48 hours of signup. 3-minute setup guide. Daily email nudge for first week. |
+| Product too buggy for beta testers | Medium | Negative first impression | Only invite testers after MVP stability gate (Gate 1). Fix top 3 reported bugs within 24 hours. |
+| Beta testers expect permanent free access | Low | Awkward conversion | Set clear expectations: "30-day free access to Solo features" in signup. Remind at Day 14 and Day 21. |
+| Conversion rate <20% after beta | Medium | Revenue below target | Interview churners. Consider $9/mo Starter tier. Extend founding pricing window. |
+
+---
+
+## 8. Timeline
+
+| Date | Milestone |
+|------|-----------|
+| May 1–7 | Week 1: Community value-building (no product mentions) |
+| May 8 | Launch beta application form on GroomGrid website |
+| May 8 | Post beta announcement in Reddit and Facebook Groups |
+| May 9–10 | DM outreach to 20 active group members |
+| May 12 | Share beta in local groomer networks |
+| May 14 | Close beta applications. Select 12–16 testers. |
+| May 15 | Beta testers onboarded. Welcome emails sent. |
+| May 15–16 | Onboarding calls (30 min each, batch over 2 days) |
+| May 22 | Week 1 pulse survey sent |
+| May 29 | Midpoint check-in calls |
+| Jun 2 | Week 2 pulse survey sent |
+| Jun 5 | End-of-beta interviews begin |
+| Jun 12 | Beta period ends. Conversion offers sent. |
+| Jun 14 | Final conversion deadline. Accounts downgrade to Starter. |
+
+---
+
+*This program bridges community trust-building (Week 1) and paid launch (Week 3), creating the social proof and product validation needed for sustainable growth.*


### PR DESCRIPTION
Detailed plan for recruiting 10-15 real groomers as beta testers (May 8-14).

Includes: recruitment scripts for FB/Reddit DMs, onboarding flow, weekly pulse surveys, conversion path to paid ($14.50/mo founding price), feedback infrastructure, success metrics, and timeline.

Supports Rock: Build and execute pre-launch GTM playbook (63%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)