### PR TITLE
fix: update Stripe test assertions to match current plan display names

### DIFF
--- a/src/tests/stripe/checkout-session-route.unit.test.ts
+++ b/src/tests/stripe/checkout-session-route.unit.test.ts
@@ -323,7 +323,7 @@ describe('GET /api/checkout/session — PLAN_DATA_CENTS regression lock', () => 
     await GET(req);
 
     const [args] = mockCreateCheckoutSession.mock.calls[0];
-    expect(args.planData).toEqual({ name: 'Solo', price: 2900 });
+    expect(args.planData).toEqual({ name: 'Solo Groomer', price: 2900 });
   });
 
   it('passes correct planData for salon ($79 = 7900 cents)', async () => {
@@ -331,7 +331,7 @@ describe('GET /api/checkout/session — PLAN_DATA_CENTS regression lock', () => 
     await GET(req);
 
     const [args] = mockCreateCheckoutSession.mock.calls[0];
-    expect(args.planData).toEqual({ name: 'Salon', price: 7900 });
+    expect(args.planData).toEqual({ name: 'Salon Team', price: 7900 });
   });
 
   it('passes correct planData for enterprise ($149 = 14900 cents)', async () => {
@@ -339,7 +339,7 @@ describe('GET /api/checkout/session — PLAN_DATA_CENTS regression lock', () => 
     await GET(req);
 
     const [args] = mockCreateCheckoutSession.mock.calls[0];
-    expect(args.planData).toEqual({ name: 'Enterprise', price: 14900 });
+    expect(args.planData).toEqual({ name: 'Multi-Location', price: 14900 });
   });
 
   it('planData is sourced from PLAN_DATA_CENTS — same shape as checkout POST route', async () => {

--- a/src/tests/stripe/getPriceIds-route.unit.test.ts
+++ b/src/tests/stripe/getPriceIds-route.unit.test.ts
@@ -20,9 +20,9 @@
  * acts as a regression guard for that alignment.
  *
  * Coverage targets:
- *  - solo plan → planType:'solo', planData:{name:'Solo', price:2900}
- *  - salon plan → planType:'salon', planData:{name:'Salon', price:7900}
- *  - enterprise plan → planType:'enterprise', planData:{name:'Enterprise', price:14900}
+ *  - solo plan → planType:'solo', planData:{name:'Solo Groomer', price:2900}
+ *  - salon plan → planType:'salon', planData:{name:'Salon Team', price:7900}
+ *  - enterprise plan → planType:'enterprise', planData:{name:'Multi-Location', price:14900}
  *  - planType is forwarded as-is (no transformation)
  *  - createCheckoutSession is called exactly once per request
  */
@@ -124,9 +124,9 @@ describe('getPriceIds() route integration — planType routes to correct STRIPE_
 
   // Regression: planData prices must align with pricing-data.ts PLANS array
   it.each([
-    ['solo',       { name: 'Solo',       price: 2900  }],
-    ['salon',      { name: 'Salon',      price: 7900  }],
-    ['enterprise', { name: 'Enterprise', price: 14900 }],
+    ['solo',       { name: 'Solo Groomer',   price: 2900  }],
+    ['salon',      { name: 'Salon Team',     price: 7900  }],
+    ['enterprise', { name: 'Multi-Location', price: 14900 }],
   ] as const)('%s plan forwards correct planData to createCheckoutSession', async (planType, expectedPlanData) => {
     await POST(makeReq({ userId: 'user-123', planType }));
     const [args] = mockCreate.mock.calls[0];
@@ -151,22 +151,22 @@ describe('getPriceIds() route integration — planType routes to correct STRIPE_
     expect(args.planData?.price).toBe(14900);
   });
 
-  it('solo planData name is "Solo"', async () => {
+  it('solo planData name is "Solo Groomer"', async () => {
     await POST(makeReq({ userId: 'user-123', planType: 'solo' }));
     const [args] = mockCreate.mock.calls[0];
-    expect(args.planData?.name).toBe('Solo');
+    expect(args.planData?.name).toBe('Solo Groomer');
   });
 
-  it('salon planData name is "Salon"', async () => {
+  it('salon planData name is "Salon Team"', async () => {
     await POST(makeReq({ userId: 'user-123', planType: 'salon' }));
     const [args] = mockCreate.mock.calls[0];
-    expect(args.planData?.name).toBe('Salon');
+    expect(args.planData?.name).toBe('Salon Team');
   });
 
-  it('enterprise planData name is "Enterprise"', async () => {
+  it('enterprise planData name is "Multi-Location"', async () => {
     await POST(makeReq({ userId: 'user-123', planType: 'enterprise' }));
     const [args] = mockCreate.mock.calls[0];
-    expect(args.planData?.name).toBe('Enterprise');
+    expect(args.planData?.name).toBe('Multi-Location');
   });
 
   it('createCheckoutSession is called exactly once per request', async () => {


### PR DESCRIPTION
## Summary
- Updates 9 test assertions across 2 test files to match current plan display names from `pricing-data.ts`
- Old names (`Solo`, `Salon`, `Enterprise`) → current names (`Solo Groomer`, `Salon Team`, `Multi-Location`)
- No production code changes — test-only fix

## Root Cause
`pricing-data.ts` was updated with new display names but two test suites (`checkout-session-route.unit.test.ts` and `getPriceIds-route.unit.test.ts`) still asserted the old names, causing 9 test failures.

## Test Results
- Stripe suite: 179/179 pass (was 170/179 with 9 failures)
- Full suite: 72 failures on branch vs 81 on main — net improvement of exactly 9, matching scope
- All remaining failures are pre-existing and unrelated

## Pipeline
- ✅ build — confirmed updated names in source
- ✅ buildVerifier — no forbidden files, no secrets, valid schema  
- ✅ qa — passed (1 loop, no issues)
- ✅ test — confirmed all Stripe tests pass
- ✅ regression — no regressions introduced

Reviewed and approved by Priya Kapoor (Architecture) via senior review pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)