### PR TITLE
fix: add missing drip_email_queue migration + run migrations in deploy

### DIFF
--- a/prisma/migrations/20260429000001_add_drip_email_queue_and_missing_schema/migration.sql
+++ b/prisma/migrations/20260429000001_add_drip_email_queue_and_missing_schema/migration.sql
@@ -1,0 +1,80 @@
+-- Hotfix: Create drip_email_queue table and ensure unsubscribe infrastructure exists.
+-- All statements are idempotent (IF NOT EXISTS) so this is safe to re-run.
+
+-- 1. Create drip_email_queue table (MISSING — no migration ever created this table)
+CREATE TABLE IF NOT EXISTS "drip_email_queue" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "sequence_step" INTEGER NOT NULL,
+    "scheduled_at" TIMESTAMP(3) NOT NULL,
+    "sent_at" TIMESTAMP(3),
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "error_message" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "drip_email_queue_pkey" PRIMARY KEY ("id")
+);
+
+-- Foreign key: drip_email_queue.user_id -> users.id
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'drip_email_queue_user_id_fkey'
+    ) THEN
+        ALTER TABLE "drip_email_queue"
+            ADD CONSTRAINT "drip_email_queue_user_id_fkey"
+            FOREIGN KEY ("user_id")
+            REFERENCES "users"("id")
+            ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+-- Index for drip worker poll query (user_id, status, scheduled_at)
+CREATE INDEX IF NOT EXISTS "drip_email_queue_user_id_status_scheduled_at_idx"
+    ON "drip_email_queue"("user_id", "status", "scheduled_at");
+
+-- 2. Add email_unsubscribed column to profiles (idempotent)
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'profiles' AND column_name = 'email_unsubscribed'
+    ) THEN
+        ALTER TABLE "profiles" ADD COLUMN "email_unsubscribed" BOOLEAN NOT NULL DEFAULT false;
+    END IF;
+END $$;
+
+-- 3. Create unsubscribe_tokens table (idempotent — in case 20260429000000 wasn't applied)
+CREATE TABLE IF NOT EXISTS "unsubscribe_tokens" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "unsubscribe_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- Unique constraint on token
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'unsubscribe_tokens_token_key'
+    ) THEN
+        ALTER TABLE "unsubscribe_tokens" ADD CONSTRAINT "unsubscribe_tokens_token_key" UNIQUE ("token");
+    END IF;
+END $$;
+
+-- Foreign key: unsubscribe_tokens.user_id -> users.id
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'unsubscribe_tokens_user_id_fkey'
+    ) THEN
+        ALTER TABLE "unsubscribe_tokens"
+            ADD CONSTRAINT "unsubscribe_tokens_user_id_fkey"
+            FOREIGN KEY ("user_id")
+            REFERENCES "users"("id")
+            ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+-- Index on user_id for token lookups
+CREATE INDEX IF NOT EXISTS "unsubscribe_tokens_user_id_idx"
+    ON "unsubscribe_tokens"("user_id");

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -12,25 +12,31 @@ echo "=== GroomGrid Deploy: ${ENV} ==="
 echo ""
 
 # 1. Pull latest code
-echo "[1/5] Pulling latest code..."
+echo "[1/6] Pulling latest code..."
 cd "$APP_DIR"
 git pull origin main
 
 # 2. Stop app BEFORE npm install to free memory
 # On a 1GB droplet, npm install while the app is running causes OOM kills.
-echo "[2/5] Stopping app to free memory for install..."
+echo "[2/6] Stopping app to free memory for install..."
 pm2 stop "$PM2_NAME" 2>/dev/null || true
 
 # 3. Install deps (with app stopped, full RAM available for npm)
-echo "[3/5] Installing dependencies..."
+echo "[3/6] Installing dependencies..."
 npm ci --production=false  # devDeps required: Tailwind/PostCSS/autoprefixer needed for next build
 
-# 4. Build
-echo "[4/5] Building..."
+# 4. Run pending database migrations
+# Source DATABASE_URL from .env.local so prisma can connect
+echo "[4/6] Running database migrations..."
+set -a; source .env.local; set +a
+npx prisma migrate deploy
+
+# 5. Build
+echo "[5/6] Building..."
 NODE_ENV=production node_modules/.bin/next build
 
-# 5. Restart app
-echo "[5/5] Starting app..."
+# 6. Restart app
+echo "[6/6] Starting app..."
 pm2 restart "$PM2_NAME" || pm2 start "$PM2_NAME"
 pm2 save
 


### PR DESCRIPTION
## Summary

**CRITICAL HOTFIX** — Production groomgrid-prod is in a crash loop (71 PM2 restarts, 3s uptime).

### Root Cause
The Prisma schema references `drip_email_queue` table, `profiles.email_unsubscribed` column, and `unsubscribe_tokens` table — none of which exist in the production database:

1. **`drip_email_queue` table**: Never had a migration created. Was likely created via `prisma db push` in development but no migration file was ever generated for it.
2. **`unsubscribe_tokens` table + `profiles.email_unsubscribed`**: Migration exists (`20260429000000`) but the deploy script never ran `prisma migrate deploy`.
3. Signup route calls `enrollUserInDrip()` which queries both tables → crash.

### Changes
- **New migration** `20260429000001_add_drip_email_queue_and_missing_schema`:
  - Creates `drip_email_queue` table with all columns, FK, and composite index
  - Creates `unsubscribe_tokens` table (catches up if prior migration wasn't applied)
  - Adds `email_unsubscribed` column to `profiles`
  - **Fully idempotent** — all statements use `IF NOT EXISTS` / `DO $$ ... IF NOT EXISTS` guards
- **Updated `scripts/deploy.sh`**: Added step 4 to run `prisma migrate deploy` before build (sources `.env.local` for DATABASE_URL)

### Verification
- Migration SQL column names/types verified against Prisma schema (exact match)
- Foreign keys, indexes, and constraints match schema definitions
- Deploy script tested for correct step numbering

### Post-Deploy Verification Steps
1. SSH to prod: `ssh -i ~/.ssh/groomgrid_deploy root@68.183.151.222`
2. Run migration manually: `cd /var/www/groomgrid/prod && set -a; source .env.local; set +a; npx prisma migrate deploy`
3. Restart: `pm2 restart groomgrid-prod`
4. Verify: `pm2 status` shows stable uptime > 5 min
5. Test: `curl -s -o /dev/null -w "%{http_code}" https://getgroomgrid.com/signup` returns 200

### Acceptance Criteria
- [ ] PM2 stable (no crash loop)
- [ ] No `ColumnNotFound` or relation errors in logs
- [ ] `/signup` returns 200
- [ ] `drip_email_queue`, `unsubscribe_tokens` tables exist in prod DB
- [ ] `profiles.email_unsubscribed` column exists in prod DB

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>