### PR TITLE
fix: update Stripe test assertions to match current plan display names

### DIFF
--- a/src/lib/__tests__/payment-completion.test.ts
+++ b/src/lib/__tests__/payment-completion.test.ts
@@ -407,7 +407,7 @@ describe('triggerPaymentCompletionHandler — purchase_completed event', () => {
       'ga4-client-id',
       'user-abc',
       'cs_test_abc',
-      'Solo',
+      'Solo Groomer',
       29
     );
   });
@@ -422,7 +422,7 @@ describe('triggerPaymentCompletionHandler — purchase_completed event', () => {
       'ga4-client-id',
       'user-abc',
       'cs_test_abc',
-      'Salon',
+      'Salon Team',
       79
     );
   });

--- a/src/tests/stripe/checkout-session-route.unit.test.ts
+++ b/src/tests/stripe/checkout-session-route.unit.test.ts
@@ -323,7 +323,7 @@ describe('GET /api/checkout/session — PLAN_DATA_CENTS regression lock', () => 
     await GET(req);
 
     const [args] = mockCreateCheckoutSession.mock.calls[0];
-    expect(args.planData).toEqual({ name: 'Solo', price: 2900 });
+    expect(args.planData).toEqual({ name: 'Solo Groomer', price: 2900 });
   });
 
   it('passes correct planData for salon ($79 = 7900 cents)', async () => {
@@ -331,7 +331,7 @@ describe('GET /api/checkout/session — PLAN_DATA_CENTS regression lock', () => 
     await GET(req);
 
     const [args] = mockCreateCheckoutSession.mock.calls[0];
-    expect(args.planData).toEqual({ name: 'Salon', price: 7900 });
+    expect(args.planData).toEqual({ name: 'Salon Team', price: 7900 });
   });
 
   it('passes correct planData for enterprise ($149 = 14900 cents)', async () => {
@@ -339,7 +339,7 @@ describe('GET /api/checkout/session — PLAN_DATA_CENTS regression lock', () => 
     await GET(req);
 
     const [args] = mockCreateCheckoutSession.mock.calls[0];
-    expect(args.planData).toEqual({ name: 'Enterprise', price: 14900 });
+    expect(args.planData).toEqual({ name: 'Multi-Location', price: 14900 });
   });
 
   it('planData is sourced from PLAN_DATA_CENTS — same shape as checkout POST route', async () => {

--- a/src/tests/stripe/getPriceIds-route.unit.test.ts
+++ b/src/tests/stripe/getPriceIds-route.unit.test.ts
@@ -20,9 +20,9 @@
  * acts as a regression guard for that alignment.
  *
  * Coverage targets:
- *  - solo plan → planType:'solo', planData:{name:'Solo', price:2900}
- *  - salon plan → planType:'salon', planData:{name:'Salon', price:7900}
- *  - enterprise plan → planType:'enterprise', planData:{name:'Enterprise', price:14900}
+ *  - solo plan → planType:'solo', planData:{name:'Solo Groomer', price:2900}
+ *  - salon plan → planType:'salon', planData:{name:'Salon Team', price:7900}
+ *  - enterprise plan → planType:'enterprise', planData:{name:'Multi-Location', price:14900}
  *  - planType is forwarded as-is (no transformation)
  *  - createCheckoutSession is called exactly once per request
  */
@@ -124,9 +124,9 @@ describe('getPriceIds() route integration — planType routes to correct STRIPE_
 
   // Regression: planData prices must align with pricing-data.ts PLANS array
   it.each([
-    ['solo',       { name: 'Solo',       price: 2900  }],
-    ['salon',      { name: 'Salon',      price: 7900  }],
-    ['enterprise', { name: 'Enterprise', price: 14900 }],
+    ['solo',       { name: 'Solo Groomer',   price: 2900  }],
+    ['salon',      { name: 'Salon Team',     price: 7900  }],
+    ['enterprise', { name: 'Multi-Location', price: 14900 }],
   ] as const)('%s plan forwards correct planData to createCheckoutSession', async (planType, expectedPlanData) => {
     await POST(makeReq({ userId: 'user-123', planType }));
     const [args] = mockCreate.mock.calls[0];
@@ -151,22 +151,22 @@ describe('getPriceIds() route integration — planType routes to correct STRIPE_
     expect(args.planData?.price).toBe(14900);
   });
 
-  it('solo planData name is "Solo"', async () => {
+  it('solo planData name is "Solo Groomer"', async () => {
     await POST(makeReq({ userId: 'user-123', planType: 'solo' }));
     const [args] = mockCreate.mock.calls[0];
-    expect(args.planData?.name).toBe('Solo');
+    expect(args.planData?.name).toBe('Solo Groomer');
   });
 
-  it('salon planData name is "Salon"', async () => {
+  it('salon planData name is "Salon Team"', async () => {
     await POST(makeReq({ userId: 'user-123', planType: 'salon' }));
     const [args] = mockCreate.mock.calls[0];
-    expect(args.planData?.name).toBe('Salon');
+    expect(args.planData?.name).toBe('Salon Team');
   });
 
-  it('enterprise planData name is "Enterprise"', async () => {
+  it('enterprise planData name is "Multi-Location"', async () => {
     await POST(makeReq({ userId: 'user-123', planType: 'enterprise' }));
     const [args] = mockCreate.mock.calls[0];
-    expect(args.planData?.name).toBe('Enterprise');
+    expect(args.planData?.name).toBe('Multi-Location');
   });
 
   it('createCheckoutSession is called exactly once per request', async () => {


### PR DESCRIPTION
## Summary
- Fixed 9 failing Stripe checkout tests caused by plan name mismatches between test assertions and pricing-data.ts
- Updated `checkout-session-route.unit.test.ts` (3 assertions) and `getPriceIds-route.unit.test.ts` (6 assertions)
- Plan names changed from: Solo → Solo Groomer, Salon → Salon Team, Enterprise → Multi-Location
- No production code changes — test-only fix

## Pipeline Results
| Stage | Status | Notes |
|-------|--------|-------|
| Plan | [pass] | 1 iteration — identified root cause: pricing-data.ts display names updated, tests not synced |
| Build | [pass] | No build errors — test files only |
| Test | [pass] | 52/52 Stripe tests passing — all 9 previously failing tests now pass |
| Simplify | [pass] | Minimal changes — only updated hardcoded name strings |
| Security | [pass] | No secrets or sensitive data in test files |
| Visual QA | [n/a] | No UI changes — backend test fix only |
| Regression | [pass] | Full suite passes — 0 new failures introduced |
| Docs | [pass] | Comment blocks updated to reflect current plan names |

## Test Plan
- [x] Run `npm test -- src/tests/stripe/checkout-session-route.unit.test.ts` — 3/3 pass
- [x] Run `npm test -- src/tests/stripe/getPriceIds-route.unit.test.ts` — 6/6 pass  
- [x] Run full Stripe test suite — 52/52 pass
- [x] Verify no production code modified — only test files changed

## Root Cause
`src/lib/pricing-data.ts` was updated with new plan display names:
- `Solo` → `Solo Groomer`
- `Salon` → `Salon Team`  
- `Enterprise` → `Multi-Location`

Test assertions still used old names, causing 9 failures.

🤖 Built by Cortex Dev Pipeline