### PR TITLE
fix: update blog index tests for new SEO footer

### DIFF
--- a/src/__tests__/app/blog/page.test.tsx
+++ b/src/__tests__/app/blog/page.test.tsx
@@ -102,7 +102,8 @@ describe('Blog Index Page', () => {
       const blogPostLinks = Array.from(postLinks).filter(
         (link) => link.getAttribute('href') !== '/'
       );
-      expect(blogPostLinks.length).toBe(5);
+      // 5 blog post cards + footer internal links that also match /blog/*
+      expect(blogPostLinks.length).toBeGreaterThanOrEqual(5);
     });
 
     it('each blog post link has correct href pattern', () => {
@@ -195,10 +196,12 @@ describe('Blog Index Page', () => {
       expect(footer?.textContent).toMatch(/© 2026 GroomGrid/);
     });
 
-    it('renders contact email link', () => {
+    it('renders legal links (Privacy & Terms)', () => {
       render(<BlogIndexPage />);
-      const emailLink = screen.getByRole('link', { name: /hello@getgroomgrid\.com/i });
-      expect(emailLink).toHaveAttribute('href', 'mailto:hello@getgroomgrid.com');
+      const privacyLink = screen.getByRole('link', { name: /privacy/i });
+      expect(privacyLink).toHaveAttribute('href', '/privacy');
+      const termsLink = screen.getByRole('link', { name: /terms/i });
+      expect(termsLink).toHaveAttribute('href', '/terms');
     });
   });
 


### PR DESCRIPTION
## Summary
- Updates blog index page tests to match the new 4-column SEO footer
- Replaces stale `hello@getgroomgrid.com` link test with legal links (Privacy/Terms) test
- Updates blog post link count assertion from `toBe(5)` to `toBeGreaterThanOrEqual(5)` since footer now includes additional `/blog/*` internal links

## Test plan
- [x] All 26 blog tests pass
- [x] Full suite: 1970/1970 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)