### PR TITLE
fix: update PM2 ecosystem config for production stability

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,28 +1,44 @@
 module.exports = {
   apps: [
     {
-      name: 'groomgrid-app',
+      name: 'groomgrid-prod',
       script: 'node_modules/.bin/next',
-      args: 'start -p 3003',
-      cwd: '/home/deployer/cortex/groomgrid-app',
-      // Secrets are loaded from .env.local on the droplet (never committed to git).
-      // Required entries in /home/deployer/cortex/groomgrid-app/.env.local:
-      //   DATABASE_URL, NEXTAUTH_SECRET, STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET
-      //   MAILGUN_API_KEY, MAILGUN_DOMAIN, SENTRY_DSN, NEXT_PUBLIC_SENTRY_DSN
-      //   NEXT_PUBLIC_GA4_MEASUREMENT_ID  — from GA4 Admin → Data Streams → Measurement ID
-      //   GA4_API_SECRET                  — from GA4 Admin → Data Streams → Measurement Protocol API Secrets
-      //   STRIPE_PRICE_SOLO               — Stripe price ID for $29/mo Solo plan
-      //   STRIPE_PRICE_SALON              — Stripe price ID for $79/mo Salon plan
-      //   STRIPE_PRICE_ENTERPRISE         — Stripe price ID for $149/mo Enterprise plan
+      args: 'start -p 3002',
+      cwd: '/var/www/groomgrid/prod',
+      // Secrets loaded from .env.local on the droplet (never committed to git).
+      // Required: DATABASE_URL, NEXTAUTH_SECRET, STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET,
+      //   MAILGUN_API_KEY, MAILGUN_DOMAIN, SENTRY_DSN, NEXT_PUBLIC_SENTRY_DSN,
+      //   NEXT_PUBLIC_GA4_MEASUREMENT_ID, GA4_API_SECRET,
+      //   STRIPE_PRICE_SOLO, STRIPE_PRICE_SALON, STRIPE_PRICE_ENTERPRISE,
+      //   NEXT_PUBLIC_APP_URL, NEXTAUTH_URL
       //   Run scripts/set-stripe-prices.sh on the droplet to set these automatically.
-      env_file: '/home/deployer/cortex/groomgrid-app/.env.local',
+      env_file: '/var/www/groomgrid/prod/.env.local',
       instances: 1,
       autorestart: true,
       watch: false,
       max_memory_restart: '512M',
+      max_restarts: 10,
+      restart_delay: 5000,
       env: {
         NODE_ENV: 'production',
-        PORT: 3003,
+        PORT: 3002,
+      },
+    },
+    {
+      name: 'groomgrid-staging',
+      script: 'node_modules/.bin/next',
+      args: 'start -p 3001',
+      cwd: '/var/www/groomgrid/staging',
+      env_file: '/var/www/groomgrid/staging/.env.local',
+      instances: 1,
+      autorestart: true,
+      watch: false,
+      max_memory_restart: '384M',
+      max_restarts: 10,
+      restart_delay: 5000,
+      env: {
+        NODE_ENV: 'production',
+        PORT: 3001,
       },
     },
   ],

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -49,7 +49,7 @@ if [ "$LOCAL_BUILD" = true ]; then
 
   # 5. Restart
   echo "[5/5] Restarting app..."
-  ssh -i "$DEPLOY_KEY" root@${DEPLOY_HOST} "pm2 restart ${PM2_NAME} || pm2 start 'node_modules/.bin/next start -p 3002' --name ${PM2_NAME}; pm2 save"
+  ssh -i "$DEPLOY_KEY" root@${DEPLOY_HOST} "pm2 restart ${PM2_NAME} || pm2 start ecosystem.config.js --only ${PM2_NAME}; pm2 save"
 
 else
   # === SERVER BUILD MODE (legacy — use --local-build for 1GB droplets) ===
@@ -68,10 +68,10 @@ else
   npx prisma migrate deploy
 
   echo "[5/6] Building..."
-  NODE_ENV=production node_modules/.bin/next build
+  NODE_ENV=production npx next build
 
   echo "[6/6] Starting app..."
-  pm2 restart "$PM2_NAME" || pm2 start "$PM2_NAME"
+  pm2 restart "$PM2_NAME" || pm2 start ecosystem.config.js --only "$PM2_NAME"
   pm2 save
 fi
 


### PR DESCRIPTION
## Summary
- Fixes the 475+ restart crash loop on production PM2
- Updates `ecosystem.config.js` with correct paths (`/var/www/groomgrid/prod`), ports (3002), and env_file locations
- Adds `max_restarts: 10` and `restart_delay: 5000` to prevent infinite crash loops
- Adds staging app config alongside prod (port 3001)
- Updates deploy script to use ecosystem.config.js instead of ad-hoc PM2 start commands
- Uses `npx next build` instead of `node_modules/.bin/next build`

## Root cause
PM2 was started with `bash -c node_modules/.bin/next start -p 3002` as an ad-hoc command. When node_modules was temporarily unavailable (during deploys or OOM situations), PM2 would crash-loop infinitely. The ecosystem.config.js provides proper process management with restart limits.

## Test plan
- [x] Deployed to production, PM2 restart count stays at 0
- [x] Health endpoint returns 200 OK
- [x] All pages respond correctly (/, /plans, /signup)
- [x] App stable for 60+ seconds with no crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)